### PR TITLE
feat: add port option to dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ A curated archive of Flash games
 ### Local testing
 
 ```bash
-python tools/dev_server.py
+python tools/dev_server.py --port 8000
 ```
+
+Use the `--port` flag to change the listening port (defaults to `8000`).
 
 ### Deployment
 

--- a/tools/dev_server.py
+++ b/tools/dev_server.py
@@ -1,22 +1,38 @@
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-import os
+from pathlib import Path
+import argparse
+
 
 class NoCacheHandler(SimpleHTTPRequestHandler):
+    """Serve files from the docs directory with no-cache headers."""
+
     def end_headers(self):
         # Add headers to prevent caching
-        self.send_header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
-        self.send_header('Pragma', 'no-cache')
-        self.send_header('Expires', '0')
+        self.send_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
         super().end_headers()
 
     def translate_path(self, path):
         # Serve from docs directory
-        path = super().translate_path(path)
-        rel_path = os.path.relpath(path, os.getcwd())
-        return os.path.join(os.getcwd(), 'docs', rel_path)
+        docs_dir = Path.cwd() / "docs"
+        full_path = Path(super().translate_path(path))
+        rel_path = full_path.relative_to(Path.cwd())
+        return str(docs_dir / rel_path)
 
-if __name__ == '__main__':
-    server_address = ('', 8000)
+
+def main():
+    parser = argparse.ArgumentParser(description="Local development server for docs/")
+    parser.add_argument(
+        "--port", type=int, default=8000, help="Port to serve on (default: 8000)"
+    )
+    args = parser.parse_args()
+
+    server_address = ("", args.port)
     httpd = HTTPServer(server_address, NoCacheHandler)
-    print("Server running on http://localhost:8000/")
-    httpd.serve_forever() 
+    print(f"Server running on http://localhost:{args.port}/")
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow specifying the port for the development server
- document port flag in README

## Testing
- `python -m py_compile tools/dev_server.py`
- `python tools/dev_server.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a922383964832eb597d6aaa6d67589