### PR TITLE
Fix desktop icon dragging from images

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -491,6 +491,8 @@ iframe {
     width: 100%;
     height: 100%;
     object-fit: contain;
+    pointer-events: none;
+    -webkit-user-drag: none;
 }
 
 .desktop-icon .icon-label {


### PR DESCRIPTION
## Summary

- disable pointer handling and native image dragging in the existing `.game-icon-image` CSS rule
- let the parent desktop icon receive the existing drag interaction from both the image and label

## Root cause

The nested image could intercept pointer handling and start the browser's native image drag behavior instead of allowing the parent desktop icon's pointer-based drag handler to continue.

## Validation

- final diff contains one commit
- only `docs/css/main.css` changed
- no inline style, new file, JavaScript, or package change

Closes #14