### PR TITLE
Add filesystem-backed Notepad and fix deployment versioning

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -551,6 +551,13 @@ html[data-xp-appearance="silver"] {
     height: 38px;
 }
 
+.desktop-icon .explorer-item-icon,
+.desktop-icon .explorer-item-icon img {
+    width: 38px;
+    height: 38px;
+    object-fit: contain;
+}
+
 .desktop-icon .icon-glyph.has-image:not(.system-icon)::after {
     content: "";
     position: absolute;
@@ -576,6 +583,42 @@ html[data-xp-appearance="silver"] {
     width: 100%;
     height: 100%;
     object-fit: contain;
+}
+
+.system-glyph-notepad {
+    position: relative;
+    width: 32px;
+    height: 32px;
+    border: 1px solid #334f72;
+    background:
+        repeating-linear-gradient(
+            to bottom,
+            transparent 0 5px,
+            #7999b8 5px 6px
+        ),
+        #f7f3dc;
+    box-shadow: inset 3px 0 #fff, 1px 1px 1px rgba(0, 0, 0, .35);
+}
+
+.system-glyph-notepad::before {
+    content: "";
+    position: absolute;
+    inset: -3px 3px auto;
+    height: 5px;
+    border: 1px solid #555;
+    background: repeating-linear-gradient(90deg, #777 0 2px, #ddd 2px 4px);
+}
+
+.title-icon.system-glyph-notepad,
+.task-icon.system-glyph-notepad {
+    width: 14px;
+    height: 14px;
+}
+
+.title-icon.system-glyph-notepad::before,
+.task-icon.system-glyph-notepad::before {
+    inset: -2px 1px auto;
+    height: 3px;
 }
 
 .desktop-icon .icon-label {
@@ -1016,6 +1059,142 @@ html[data-xp-appearance="silver"] {
     display: block;
     width: 100%;
     height: 100%;
+}
+
+.notepad-window {
+    min-width: min(300px, calc(100% - 8px));
+    min-height: min(220px, calc(100% - 8px));
+}
+
+.notepad-content {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--xp-beige);
+    color: #000;
+    overflow: hidden;
+}
+
+.notepad-menu-bar {
+    position: relative;
+    z-index: 4;
+    flex: none;
+    display: flex;
+    height: 22px;
+    padding: 0 2px;
+    border-bottom: 1px solid #aca899;
+    background: var(--xp-beige);
+    font: 11px Tahoma, "Segoe UI", sans-serif;
+}
+
+.notepad-menu-group {
+    position: relative;
+}
+
+.notepad-menu-button {
+    height: 21px;
+    padding: 1px 6px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: #000;
+    font: inherit;
+}
+
+.notepad-menu-button:hover,
+.notepad-menu-button:focus-visible,
+.notepad-menu-button[aria-expanded="true"] {
+    border-color: #0a246a;
+    background: #316ac5;
+    color: #fff;
+    outline: 0;
+}
+
+.notepad-menu {
+    position: absolute;
+    top: 20px;
+    left: 0;
+    z-index: 5;
+    min-width: 178px;
+    padding: 2px;
+    border: 1px solid #7f7f7f;
+    background: var(--xp-beige);
+    box-shadow: 2px 2px 3px rgba(0, 0, 0, .35), inset 1px 1px #fff;
+}
+
+.notepad-menu-item {
+    display: grid;
+    grid-template-columns: 18px 1fr auto;
+    align-items: center;
+    width: 100%;
+    min-height: 22px;
+    padding: 2px 5px 2px 2px;
+    border: 0;
+    background: transparent;
+    color: #000;
+    font: inherit;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.notepad-menu-item:hover,
+.notepad-menu-item:focus-visible {
+    background: #316ac5;
+    color: #fff;
+    outline: 0;
+}
+
+.notepad-menu-check {
+    color: transparent;
+    font-weight: 700;
+}
+
+.notepad-menu-item.checked .notepad-menu-check {
+    color: currentColor;
+}
+
+.notepad-menu-shortcut {
+    margin-left: 22px;
+}
+
+.notepad-menu-separator {
+    height: 1px;
+    margin: 3px 2px 3px 20px;
+    background: #aca899;
+    box-shadow: 0 1px #fff;
+}
+
+.notepad-editor {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    resize: none;
+    margin: 0;
+    padding: 2px;
+    border: 1px solid #7f9db9;
+    border-radius: 0;
+    outline: 0;
+    background: #fff;
+    color: #000;
+    font: 13px/1.25 "Lucida Console", "Courier New", monospace;
+    white-space: pre;
+    overflow: auto;
+}
+
+.notepad-editor.word-wrap {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
+.notepad-status {
+    flex: none;
+    height: 19px;
+    padding: 2px 8px;
+    border-top: 1px solid #fff;
+    background: var(--xp-beige);
+    box-shadow: inset 0 1px #aca899;
+    font: 11px Tahoma, "Segoe UI", sans-serif;
+    text-align: right;
 }
 
 .explorer-window {

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,8 +16,8 @@
         <script src="js/filesystem.js?v=750917fa"></script>
         <script src="js/file-operations.js?v=f2bf59d7"></script>
         <script src="js/dialogs.js?v=63482d98"></script>
-        <script src="js/main.js?v=14c67ba4"></script>
-        <link rel="stylesheet" href="css/main.css?v=c759e5af">
+        <script src="js/main.js?v=a4bb8490"></script>
+        <link rel="stylesheet" href="css/main.css?v=6194f8c9">
     </head>
 
     <body>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -88,6 +88,11 @@ const systemShortcuts = {
     icon: "assets/xp/icons/mycomputer.png",
     desktop: false,
   },
+  "__notepad": {
+    title: "Notepad",
+    glyph: "notepad",
+    desktop: false,
+  },
   __search: {
     title: "Search Results",
     icon: "assets/xp/icons/Search.png",
@@ -1103,11 +1108,22 @@ const toggleMaximize = (gameId) => {
   focusWindow(gameId);
 };
 
-const closeGameWindow = (gameId) => {
+const closeGameWindow = (gameId, { skipBeforeClose = false } = {}) => {
   const win = openWindows.get(gameId);
   if (!win) return;
 
-  win.beforeClose?.();
+  if (!skipBeforeClose && win.beforeClose) {
+    const result = win.beforeClose();
+    if (result && typeof result.then === "function") {
+      result.then((shouldClose) => {
+        if (shouldClose !== false) {
+          closeGameWindow(gameId, { skipBeforeClose: true });
+        }
+      });
+      return;
+    }
+    if (result === false) return;
+  }
   win.el.remove();
   openWindows.delete(gameId);
 
@@ -2514,6 +2530,12 @@ const SHELL_COMMANDS = [
     run: () => openHelpAndSupport(),
   },
   {
+    id: "notepad",
+    title: "Notepad",
+    aliases: ["notepad"],
+    run: () => openNotepad(),
+  },
+  {
     id: "search",
     title: "Search",
     aliases: ["search"],
@@ -3240,7 +3262,7 @@ const createExplorerIcon = (node) => {
   if (node.id === fs.MY_PICTURES) return addImage("MyPictures.png");
   if (node.id === fs.MY_COMPUTER) return addImage("MyComputer.png");
   if (node.type === "folder") {
-    return addImage("mydocuments.png");
+    return addImage("NewFolder.png");
   }
 
   const game = node.app ? gamesList[node.app] : null;
@@ -3507,6 +3529,371 @@ fs.registerFileType(".game", (file) => {
     openGameWindow(file.app);
   }
 });
+
+const NOTEPAD_ID = "__notepad";
+
+const openNotepad = (file = null) => {
+  const existing = openWindows.get(NOTEPAD_ID);
+  if (existing) {
+    const switchDocument = async () => {
+      if (!(await existing.confirmSaveChanges())) return;
+      existing.loadDocument(file);
+      restoreWindow(NOTEPAD_ID);
+      focusWindow(NOTEPAD_ID);
+    };
+    switchDocument();
+    return;
+  }
+
+  const { width: desktopWidth, height: desktopHeight } = getDesktopSize();
+  const el = createWindowElement(NOTEPAD_ID);
+  el.classList.add("notepad-window");
+  el.querySelectorAll(".game-menu-bar, .game-menu").forEach((node) =>
+    node.remove(),
+  );
+  const windowWidth = Math.min(600, desktopWidth - 16);
+  const windowHeight = Math.min(430, desktopHeight - 16);
+  el.style.width = `${windowWidth}px`;
+  el.style.height = `${windowHeight}px`;
+  el.style.left = `${Math.max(8, (desktopWidth - windowWidth) / 2)}px`;
+  el.style.top = `${Math.max(8, (desktopHeight - windowHeight) / 2)}px`;
+
+  const content = el.querySelector(".window-content");
+  content.className = "notepad-content";
+  content.replaceChildren();
+
+  const menuBar = document.createElement("div");
+  menuBar.className = "notepad-menu-bar";
+  menuBar.setAttribute("role", "menubar");
+  const editor = document.createElement("textarea");
+  editor.className = "notepad-editor";
+  editor.setAttribute("aria-label", "Notepad document");
+  editor.spellcheck = false;
+  editor.wrap = "off";
+  const status = document.createElement("div");
+  status.className = "notepad-status";
+  content.append(menuBar, editor, status);
+  document.getElementById("desktop").appendChild(el);
+
+  const win = {
+    gameId: NOTEPAD_ID,
+    el,
+    type: "system",
+    player: null,
+    minimized: false,
+    maximized: false,
+    prevRect: null,
+    zIndex: 0,
+    lastUsed: Date.now(),
+    nodeId: null,
+    dirty: false,
+    maximizeBtn: el.querySelector(".maximize-btn"),
+    favoriteBtn: null,
+    volumeBtn: null,
+  };
+  openWindows.set(NOTEPAD_ID, win);
+
+  const updateTitle = () => {
+    const node = win.nodeId && fs.getNode(win.nodeId);
+    const documentName = node?.name || "Untitled";
+    const title = `${documentName} - Notepad`;
+    systemShortcuts[NOTEPAD_ID].title = title;
+    el.querySelector(".title-text").textContent = title;
+    renderTaskButtons();
+    updateDocumentTitle();
+  };
+
+  const updateStatus = () => {
+    const beforeCaret = editor.value.slice(0, editor.selectionStart);
+    const lines = beforeCaret.split("\n");
+    status.textContent = `Ln ${lines.length}, Col ${lines.at(-1).length + 1}`;
+  };
+
+  const loadDocument = (node) => {
+    win.nodeId = node?.id || null;
+    editor.value = node ? fs.getContent(node.id) || "" : "";
+    win.dirty = false;
+    updateTitle();
+    updateStatus();
+    editor.focus();
+  };
+
+  const saveAs = async () => {
+    const current = win.nodeId && fs.getNode(win.nodeId);
+    const result = await XPDialogs.saveFile({
+      title: "Save As",
+      startFolder: current?.parent || fs.MY_DOCUMENTS,
+      defaultName: current?.name || "Untitled.txt",
+      filter: [".txt"],
+    });
+    if (!result) return false;
+    const name = result.name.toLowerCase().endsWith(".txt")
+      ? result.name
+      : `${result.name}.txt`;
+    try {
+      let target = result.existingId && fs.getNode(result.existingId);
+      if (target && target.type !== "file") {
+        throw new Error(`"${name}" is not a text file.`);
+      }
+      if (target && target.id !== win.nodeId) {
+        fs.destroy(target.id);
+        target = null;
+      }
+      if (!target) {
+        target = fileOps.createFile(result.parentId, name, {
+          content: editor.value,
+        });
+      } else {
+        if (target.name !== name) fileOps.rename(target.id, name);
+        fs.setContent(target.id, editor.value);
+      }
+      win.nodeId = target.id;
+      win.dirty = false;
+      updateTitle();
+      return true;
+    } catch (error) {
+      XPDialogs.alert(
+        error.message || "The file could not be saved.",
+        "Notepad",
+        "error",
+      );
+      return false;
+    }
+  };
+
+  const save = async () => {
+    const node = win.nodeId && fs.getNode(win.nodeId);
+    if (!node) return saveAs();
+    fs.setContent(node.id, editor.value);
+    win.dirty = false;
+    updateTitle();
+    return true;
+  };
+
+  const confirmSaveChanges = async () => {
+    if (!win.dirty) return true;
+    const node = win.nodeId && fs.getNode(win.nodeId);
+    const answer = await XPDialogs.message({
+      title: "Notepad",
+      text: `The text in the ${node?.name || "Untitled"} file has changed.\n\nDo you want to save the changes?`,
+      icon: "warning",
+      buttons: XPDialogs.BUTTON_SETS.yesNoCancel,
+      defaultButton: "yes",
+    });
+    if (answer === "cancel") return false;
+    if (answer === "no") return true;
+    return save();
+  };
+
+  Object.assign(win, { loadDocument, confirmSaveChanges });
+  win.beforeClose = confirmSaveChanges;
+
+  const insertText = (text) => {
+    editor.setRangeText(
+      text,
+      editor.selectionStart,
+      editor.selectionEnd,
+      "end",
+    );
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+  };
+
+  const commands = {
+    new: async () => {
+      if (await confirmSaveChanges()) loadDocument(null);
+    },
+    open: async () => {
+      if (!(await confirmSaveChanges())) return;
+      const chosen = await XPDialogs.openFile({
+        title: "Open",
+        startFolder: fs.MY_DOCUMENTS,
+        filter: [".txt"],
+      });
+      if (chosen) loadDocument(chosen);
+    },
+    save,
+    "save-as": saveAs,
+    exit: () => closeGameWindow(NOTEPAD_ID),
+    undo: () => {
+      editor.focus();
+      document.execCommand("undo");
+    },
+    cut: async () => {
+      const selected = editor.value.slice(
+        editor.selectionStart,
+        editor.selectionEnd,
+      );
+      if (selected) {
+        await navigator.clipboard?.writeText(selected);
+        insertText("");
+      }
+    },
+    copy: () =>
+      navigator.clipboard?.writeText(
+        editor.value.slice(editor.selectionStart, editor.selectionEnd),
+      ),
+    paste: async () => {
+      const text = await navigator.clipboard?.readText();
+      if (typeof text === "string") insertText(text);
+    },
+    delete: () => insertText(""),
+    "select-all": () => {
+      editor.focus();
+      editor.select();
+      updateStatus();
+    },
+    "time-date": () => insertText(new Date().toLocaleString()),
+    "word-wrap": (item) => {
+      const enabled = editor.wrap === "off";
+      editor.wrap = enabled ? "soft" : "off";
+      editor.classList.toggle("word-wrap", enabled);
+      item.classList.toggle("checked", enabled);
+      item.setAttribute("aria-checked", String(enabled));
+    },
+    "status-bar": (item) => {
+      status.hidden = !status.hidden;
+      item.classList.toggle("checked", !status.hidden);
+      item.setAttribute("aria-checked", String(!status.hidden));
+    },
+    about: () =>
+      XPDialogs.alert(
+        "Microsoft Windows XP\nNotepad",
+        "About Notepad",
+        "info",
+      ),
+  };
+
+  const menuDefinitions = [
+    [
+      "&File",
+      [
+        ["&New", "new", "Ctrl+N"],
+        ["&Open...", "open", "Ctrl+O"],
+        ["&Save", "save", "Ctrl+S"],
+        ["Save &As...", "save-as", ""],
+        ["-", "", ""],
+        ["E&xit", "exit", ""],
+      ],
+    ],
+    [
+      "&Edit",
+      [
+        ["&Undo", "undo", "Ctrl+Z"],
+        ["-", "", ""],
+        ["Cu&t", "cut", "Ctrl+X"],
+        ["&Copy", "copy", "Ctrl+C"],
+        ["&Paste", "paste", "Ctrl+V"],
+        ["De&lete", "delete", "Del"],
+        ["-", "", ""],
+        ["Select &All", "select-all", "Ctrl+A"],
+        ["Time/&Date", "time-date", "F5"],
+      ],
+    ],
+    ["F&ormat", [["&Word Wrap", "word-wrap", ""]]],
+    ["&View", [["&Status Bar", "status-bar", "", true]]],
+    ["&Help", [["&About Notepad", "about", ""]]],
+  ];
+
+  const closeMenus = () => {
+    menuBar.querySelectorAll(".notepad-menu").forEach((menu) => {
+      menu.hidden = true;
+    });
+    menuBar.querySelectorAll(".notepad-menu-button").forEach((button) => {
+      button.setAttribute("aria-expanded", "false");
+    });
+  };
+
+  menuDefinitions.forEach(([label, items]) => {
+    const group = document.createElement("div");
+    group.className = "notepad-menu-group";
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "notepad-menu-button";
+    button.setAttribute("role", "menuitem");
+    button.setAttribute("aria-haspopup", "menu");
+    button.setAttribute("aria-expanded", "false");
+    setAccessKeyText(button, label);
+    const menu = document.createElement("div");
+    menu.className = "notepad-menu";
+    menu.setAttribute("role", "menu");
+    menu.hidden = true;
+    items.forEach(([itemLabel, command, shortcut, checked]) => {
+      if (itemLabel === "-") {
+        const separator = document.createElement("div");
+        separator.className = "notepad-menu-separator";
+        menu.appendChild(separator);
+        return;
+      }
+      const item = document.createElement("button");
+      item.type = "button";
+      item.className = "notepad-menu-item";
+      item.dataset.command = command;
+      item.setAttribute(
+        "role",
+        checked ? "menuitemcheckbox" : "menuitem",
+      );
+      if (checked) {
+        item.classList.add("checked");
+        item.setAttribute("aria-checked", "true");
+      }
+      const check = document.createElement("span");
+      check.className = "notepad-menu-check";
+      check.textContent = "✓";
+      const text = document.createElement("span");
+      setAccessKeyText(text, itemLabel);
+      const key = document.createElement("span");
+      key.className = "notepad-menu-shortcut";
+      key.textContent = shortcut;
+      item.append(check, text, key);
+      item.addEventListener("click", () => {
+        closeMenus();
+        commands[command]?.(item);
+      });
+      menu.appendChild(item);
+    });
+    button.addEventListener("click", () => {
+      const shouldOpen = menu.hidden;
+      closeMenus();
+      menu.hidden = !shouldOpen;
+      button.setAttribute("aria-expanded", String(shouldOpen));
+      if (shouldOpen) menu.querySelector("button")?.focus();
+    });
+    group.append(button, menu);
+    menuBar.appendChild(group);
+  });
+
+  editor.addEventListener("input", () => {
+    win.dirty = true;
+    updateStatus();
+  });
+  ["click", "keyup", "select"].forEach((eventName) =>
+    editor.addEventListener(eventName, updateStatus),
+  );
+  el.addEventListener("pointerdown", (event) => {
+    if (!event.target.closest(".notepad-menu-group")) closeMenus();
+  });
+  el.addEventListener("keydown", (event) => {
+    if (event.ctrlKey && event.key.toLowerCase() === "s") {
+      event.preventDefault();
+      save();
+    } else if (event.ctrlKey && event.key.toLowerCase() === "o") {
+      event.preventDefault();
+      commands.open();
+    } else if (event.ctrlKey && event.key.toLowerCase() === "n") {
+      event.preventDefault();
+      commands.new();
+    } else if (event.key === "F5") {
+      event.preventDefault();
+      commands["time-date"]();
+    }
+  });
+
+  wireSystemWindowControls(win);
+  loadDocument(file);
+  focusWindow(NOTEPAD_ID);
+};
+
+fs.registerFileType(".txt", (file) => openNotepad(file));
 
 fs.registerFolderHandler((folder) => {
   openSystemWindow("__my-documents");

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -282,6 +282,75 @@ class DeployTests(unittest.TestCase):
         with mock.patch.object(deploy, "MAIN_JS_PATH", main_javascript):
             self.assertEqual(deploy.get_current_version(), "26.07.27-2")
 
+    def test_get_main_version_reads_committed_main_branch(self):
+        main_javascript = self.js_dir / "main.js"
+        main_javascript.write_text(
+            'const APP_VERSION = "99.12.31-99";\n',
+            encoding="utf-8",
+        )
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='const APP_VERSION = "26.07.28-3";\n',
+            stderr="",
+        )
+
+        with mock.patch.object(
+            deploy.subprocess,
+            "run",
+            return_value=completed,
+        ) as run:
+            self.assertEqual(deploy.get_main_version(), "26.07.28-3")
+
+        run.assert_called_once_with(
+            ["git", "show", "main:docs/js/main.js"],
+            cwd=self.project_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_get_main_version_fails_when_main_cannot_be_read(self):
+        with mock.patch.object(
+            deploy.subprocess,
+            "run",
+            side_effect=subprocess.CalledProcessError(128, ["git", "show"]),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                'Could not read APP_VERSION from the "main" branch',
+            ):
+                deploy.get_main_version()
+
+    def test_next_version_only_increments_version_from_main(self):
+        (self.js_dir / "main.js").write_text(
+            'const APP_VERSION = "26.07.28-99";\n',
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(
+            deploy,
+            "get_main_version",
+            return_value="26.07.28-3",
+        ):
+            self.assertEqual(deploy.get_next_version("26.07.28"), "26.07.28-4")
+
+    def test_next_version_uses_new_date_after_main(self):
+        with mock.patch.object(
+            deploy,
+            "get_main_version",
+            return_value="26.07.27-8",
+        ):
+            self.assertEqual(deploy.get_next_version("26.07.28"), "26.07.28")
+
+    def test_next_version_never_decreases_if_main_is_ahead(self):
+        with mock.patch.object(
+            deploy,
+            "get_main_version",
+            return_value="26.07.29-2",
+        ):
+            self.assertEqual(deploy.get_next_version("26.07.28"), "26.07.29-3")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -130,6 +130,26 @@ class ShellSourceTests(unittest.TestCase):
         # custom desktop icon drag, so images must opt out of it.
         self.assertIn("image.draggable = false", self.javascript)
 
+    def test_virtual_folders_use_desktop_sized_folder_icons(self):
+        self.assertIn('return addImage("NewFolder.png")', self.javascript)
+        self.assertIn(".desktop-icon .explorer-item-icon img", self.css)
+        self.assertRegex(
+            self.css,
+            r"\.desktop-icon \.explorer-item-icon img\s*\{[^}]*width:\s*38px",
+        )
+
+    def test_text_files_open_in_filesystem_backed_notepad(self):
+        self.assertJavascriptContains(
+            'fs.registerFileType(".txt", (file) => openNotepad(file))',
+            'fs.setContent(node.id, editor.value)',
+            'XPDialogs.openFile({ title: "Open"',
+            'XPDialogs.saveFile({ title: "Save As"',
+            'win.beforeClose = confirmSaveChanges',
+        )
+        for label in ("&File", "&Edit", "F&ormat", "&View", "&Help"):
+            self.assertIn(label, self.javascript)
+        self.assertIn(".notepad-editor", self.css)
+
     def test_selected_desktop_icon_shows_full_label(self):
         match = re.search(
             r"\.desktop-icon\.selected \.icon-label\s*\{([^}]*)\}",

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -24,6 +24,10 @@ RUFFLE_LATEST_RELEASE_URL = (
 )
 RUFFLE_ASSET_SUFFIX = "-web-selfhosted.zip"
 RUFFLE_FILE_SUFFIXES = (".js", ".js.map", ".wasm")
+MAIN_BRANCH = "main"
+APP_VERSION_PATTERN = re.compile(
+    r'const APP_VERSION = "([0-9]{2}\.[0-9]{2}\.[0-9]{2}(?:-\d+)?)";'
+)
 
 ASSET_PATHS = {
     "ruffle": JS_DIR / "ruffle.js",
@@ -109,30 +113,64 @@ def get_short_hash(file_path):
     return sha384.hexdigest()[:8]
 
 
-def get_current_version():
-    if not MAIN_JS_PATH.exists():
-        return None
-    content = MAIN_JS_PATH.read_text(encoding="utf-8")
-    version_match = re.search(
-        r'const APP_VERSION = "([0-9.]+(?:-\d+)?)";',
-        content,
-    )
+def extract_app_version(content):
+    version_match = APP_VERSION_PATTERN.search(content)
     return version_match.group(1) if version_match else None
 
 
-def get_next_version():
-    today = datetime.now().strftime("%y.%m.%d")
-    current = get_current_version()
+def get_current_version():
+    if not MAIN_JS_PATH.exists():
+        return None
+    return extract_app_version(MAIN_JS_PATH.read_text(encoding="utf-8"))
 
-    if not current:
+
+def get_main_version():
+    try:
+        main_javascript_path = MAIN_JS_PATH.relative_to(PROJECT_DIR).as_posix()
+    except ValueError as error:
+        raise RuntimeError("MAIN_JS_PATH must be inside the repository") from error
+
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{MAIN_BRANCH}:{main_javascript_path}"],
+            cwd=PROJECT_DIR,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise RuntimeError(
+            f'Could not read APP_VERSION from the "{MAIN_BRANCH}" branch'
+        ) from error
+
+    version = extract_app_version(result.stdout)
+    if not version:
+        raise RuntimeError(
+            f'Could not find APP_VERSION in "{MAIN_BRANCH}:{main_javascript_path}"'
+        )
+    return version
+
+
+def split_version(version):
+    date_part, separator, build_part = version.partition("-")
+    return tuple(int(part) for part in date_part.split(".")), (
+        int(build_part) if separator else 0
+    )
+
+
+def get_next_version(today=None):
+    today = today or datetime.now().strftime("%y.%m.%d")
+    main_version = get_main_version()
+    today_date, _ = split_version(today)
+    main_date, main_build = split_version(main_version)
+
+    if today_date > main_date:
         return today
 
-    if current.startswith(today):
-        build_match = re.search(r"-(\d+)$", current)
-        build_num = int(build_match.group(1)) + 1 if build_match else 1
-        return f"{today}-{build_num}"
-
-    return today
+    # Same-day deployments increment main's build. If the local clock is
+    # behind main, keep main's date and increment it rather than decreasing
+    # the deployed version.
+    return f"{main_version.split('-', 1)[0]}-{main_build + 1}"
 
 
 def update_html():


### PR DESCRIPTION
## Summary

- Add a Windows XP-style Notepad with open, save, save-as, edit commands, word wrap, status bar, and unsaved-change confirmation
- Register `.txt` files to open in Notepad
- Use desktop-sized folder icons and the correct `NewFolder.png` asset
- Ensure deployment versions are read from the committed `main` branch and never decrease
- Add shell and deployment regression tests

## Testing

- Not run (not requested)