### PR TITLE
Improve offline updates and settings

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13.14"
           cache: pip
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.14"
 
@@ -50,11 +50,11 @@ jobs:
 
       - name: Configure Pages
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist
 
@@ -74,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/update-ruffle.yml
+++ b/.github/workflows/update-ruffle.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13.14"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A curated archive of Flash games
 - Taskbar with window buttons and tray clock
 - Flash emulation by Ruffle
 - DOS emulation by js-dos
-- Play offline, no internet connection required
+- Download the complete collection for offline play
+- Check for updates, apply them safely, and repair incomplete offline data
 - FPS optimized per game
 - Fast CDN
 - Flawless screen adaptation
@@ -62,6 +63,7 @@ build without deploying. The build:
 - Copies `site/` into a fresh `dist/`
 - Downloads the pinned self-hosted Ruffle release and verifies its SHA-256
 - Generates a date-plus-commit deployment version and asset hashes
+- Generates uncached `version.json` metadata for client update checks
 - Generates the Workbox service worker
 - Validates representative Flash, DOS, and HTML5 artifacts
 
@@ -73,6 +75,12 @@ Ruffle release metadata is pinned in `tools/ruffle-release.json`. A weekly
 workflow checks for a newer stable release and opens a reviewable dependency PR.
 Repository settings must allow GitHub Actions to create pull requests for that
 automation to work. Ruffle update PRs are never auto-merged.
+
+When offline mode is enabled, the settings dialog reports the actual worker
+state while the complete collection downloads. Astro Flash checks for updates
+at startup, when connectivity returns, and when a long-lived tab becomes
+visible again. An installed update waits for user confirmation before the
+worker activates and reloads the page.
 
 ### Game Support
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "bun@1.3.14",
   "scripts": {
-    "test": "python -m unittest discover -s tests -v && node --check site/js/games.js && node --check site/js/filesystem.js && node --check site/js/file-operations.js && node --check site/js/dialogs.js && node --check site/js/main.js && node tools/validate_icons.mjs",
+    "test": "python -m unittest discover -s tests -v && node --check site/js/games.js && node --check site/js/filesystem.js && node --check site/js/file-operations.js && node --check site/js/dialogs.js && node --check site/js/offline.js && node --check site/js/main.js && node tools/validate_icons.mjs",
     "build": "python tools/deploy.py",
     "validate:icons": "node tools/validate_icons.mjs --require-all"
   },

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -2039,11 +2039,6 @@ html[data-xp-appearance="silver"] {
 
 /* Astro Flash project settings */
 
-.project-settings-title {
-    margin: 0 0 10px;
-    font-size: 14px;
-}
-
 .project-offline-setting {
     display: block;
     margin: 10px 0 4px;
@@ -2053,6 +2048,19 @@ html[data-xp-appearance="silver"] {
     min-height: 14px;
     margin: 0 0 10px 20px;
     color: #444;
+}
+
+.project-settings-progress {
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0 0 10px;
+}
+
+.project-settings-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: 0 0 10px;
 }
 
 .project-suggestions-link {

--- a/site/index.html
+++ b/site/index.html
@@ -16,6 +16,7 @@
         <script src="js/filesystem.js?v=750917fa"></script>
         <script src="js/file-operations.js?v=f2bf59d7"></script>
         <script src="js/dialogs.js?v=63482d98"></script>
+        <script src="js/offline.js?v=1"></script>
         <script src="js/main.js?v=2b29c40f"></script>
         <link rel="stylesheet" href="css/main.css?v=6194f8c9">
     </head>

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -10,6 +10,9 @@ const MOVE_SIZE_STEP = 8;
 const BOOT_DURATION_MS = 2600;
 const WELCOME_DURATION_MS = 1200;
 const APP_VERSION = "26.07.28-2";
+const offlineManager = window.AstroOffline.createManager({
+  currentVersion: APP_VERSION,
+});
 
 let bootTimeout = null;
 let shutdownTimeout = null;
@@ -4555,33 +4558,67 @@ const openNetworkStatus = () => {
   dialog.onResult(() => clearInterval(timer));
 };
 
-const setOfflineModeEnabled = async (enabled) => {
-  if (!("serviceWorker" in navigator)) {
-    throw new Error("Offline mode is not supported by this browser.");
-  }
+let offlineManagerInitialized = false;
+let promptedUpdateVersion = null;
 
-  if (enabled) {
-    await navigator.serviceWorker.register("sw.js");
-    localStorage.setItem("offlineModeEnabled", "true");
+const offlineStatusText = (state) => {
+  const messages = {
+    disabled: "Offline caching is disabled.",
+    starting: "Preparing the offline download...",
+    downloading: "Downloading all files for offline use...",
+    ready: "All files are available offline.",
+    checking: "Checking for updates...",
+    updating: "Downloading the latest update...",
+    "update-available": state.enabled
+      ? "An update is downloading..."
+      : "An update is available.",
+    "update-ready": "An update is ready. Restart Astro Flash to apply it.",
+    applying: "Applying the update...",
+    repairing: "Clearing and downloading all offline files again...",
+    error: "Offline files are incomplete.",
+  };
+  const message = messages[state.phase] || "Offline status is unavailable.";
+  return state.error ? `${message} ${state.error}` : message;
+};
+
+const formatUpdateCheckTime = (timestamp) =>
+  timestamp ? new Date(timestamp).toLocaleString() : "Never";
+
+const projectStorageText = (state) => {
+  if (state.usage === null) return "Unavailable";
+  const usage = XPDialogs.formatBytes(state.usage);
+  return state.quota === null
+    ? usage
+    : `${usage} of ${XPDialogs.formatBytes(state.quota)}`;
+};
+
+const maybePromptForUpdate = (state) => {
+  if (
+    !loggedIn ||
+    !state.updateReady ||
+    !state.availableVersion ||
+    promptedUpdateVersion === state.availableVersion
+  ) {
     return;
   }
-
-  const registration = await navigator.serviceWorker.getRegistration("./");
-  if (registration) await registration.unregister();
-  if ("caches" in window) {
-    const cacheNames = await caches.keys();
-    await Promise.all(
-      cacheNames
-        .filter((name) => name.startsWith("astro-flash"))
-        .map((name) => caches.delete(name)),
-    );
-  }
-  localStorage.setItem("offlineModeEnabled", "false");
+  promptedUpdateVersion = state.availableVersion;
+  XPDialogs.confirm(
+    `Astro Flash ${state.availableVersion} is ready.\nRestart now to apply the update?`,
+    "Astro Flash Update",
+    "info",
+  ).then((accepted) => {
+    if (!accepted) return;
+    offlineManager.applyUpdate().catch((error) => {
+      XPDialogs.alert(error.message, "Astro Flash Update", "error");
+    });
+  });
 };
 
 const initializeOfflineMode = () => {
-  if (localStorage.getItem("offlineModeEnabled") !== "true") return;
-  setOfflineModeEnabled(true).catch((error) => {
+  if (offlineManagerInitialized) return;
+  offlineManagerInitialized = true;
+  offlineManager.subscribe(maybePromptForUpdate);
+  offlineManager.initialize().catch((error) => {
     console.error("Offline mode initialization failed:", error);
   });
 };
@@ -4591,57 +4628,127 @@ const openProjectSettings = () => {
     title: "Astro Flash Collection",
   });
 
-  const heading = document.createElement("h2");
-  heading.className = "project-settings-title";
-  heading.textContent = "Astro Flash Collection";
-
   const details = document.createElement("dl");
   details.className = "dlg-props-table";
-  const addDetail = (label, value) => {
+  const detailValues = {};
+  const addDetail = (label, id) => {
     const term = document.createElement("dt");
     term.textContent = label;
     const description = document.createElement("dd");
-    description.textContent = value;
+    detailValues[id] = description;
     details.append(term, description);
   };
-  addDetail("Version:", APP_VERSION);
-  addDetail("Installed games:", String(Object.keys(gamesList).length));
-  addDetail("Connection:", navigator.onLine ? "Online" : "Offline");
-  addDetail(
-    "Service worker:",
-    "serviceWorker" in navigator ? "Supported" : "Unavailable",
-  );
+  addDetail("Installed version:", "version");
+  addDetail("Available version:", "availableVersion");
+  addDetail("Installed games:", "games");
+  addDetail("Offline download:", "downloadSize");
+  addDetail("Connection:", "connection");
+  addDetail("Offline files:", "offlineFiles");
+  addDetail("Site storage:", "storage");
+  addDetail("Last update check:", "lastChecked");
 
   const offlineLabel = document.createElement("label");
   offlineLabel.className = "project-offline-setting";
   const offlineToggle = document.createElement("input");
   offlineToggle.type = "checkbox";
-  offlineToggle.checked = localStorage.getItem("offlineModeEnabled") === "true";
-  offlineToggle.disabled = !("serviceWorker" in navigator);
-  offlineLabel.append(offlineToggle, " Enable Offline Mode");
+  offlineLabel.append(offlineToggle, " Download all files for offline use");
 
   const status = document.createElement("p");
   status.className = "project-settings-status";
-  status.textContent = offlineToggle.checked
-    ? "Offline caching is enabled."
-    : "Offline caching is disabled.";
+  const downloadProgress = document.createElement("progress");
+  downloadProgress.className = "project-settings-progress";
+  downloadProgress.setAttribute("aria-label", "Offline download progress");
+
+  const actions = document.createElement("div");
+  actions.className = "project-settings-actions";
+  const checkButton = document.createElement("button");
+  checkButton.type = "button";
+  checkButton.className = "xp-btn";
+  checkButton.textContent = "Check for Updates";
+  const applyButton = document.createElement("button");
+  applyButton.type = "button";
+  applyButton.className = "xp-btn";
+  applyButton.textContent = "Restart to Update";
+  const repairButton = document.createElement("button");
+  repairButton.type = "button";
+  repairButton.className = "xp-btn";
+  repairButton.textContent = "Repair Offline Files";
+  actions.append(checkButton, applyButton, repairButton);
+
+  const transientPhases = new Set([
+    "starting",
+    "downloading",
+    "checking",
+    "updating",
+    "applying",
+    "repairing",
+  ]);
+  const render = (state) => {
+    detailValues.version.textContent = APP_VERSION;
+    detailValues.availableVersion.textContent =
+      state.availableVersion || "None";
+    detailValues.games.textContent = String(Object.keys(gamesList).length);
+    detailValues.downloadSize.textContent =
+      state.downloadBytes === null
+        ? "Checking..."
+        : XPDialogs.formatBytes(state.downloadBytes);
+    detailValues.connection.textContent = state.online ? "Online" : "Offline";
+    detailValues.offlineFiles.textContent = state.workerState;
+    detailValues.storage.textContent = projectStorageText(state);
+    detailValues.lastChecked.textContent = formatUpdateCheckTime(
+      state.lastChecked,
+    );
+    offlineToggle.checked = state.enabled;
+    offlineToggle.disabled =
+      !("serviceWorker" in navigator) || transientPhases.has(state.phase);
+    status.textContent = offlineStatusText(state);
+    downloadProgress.hidden = ![
+      "starting",
+      "downloading",
+      "updating",
+      "repairing",
+    ].includes(state.phase);
+    checkButton.disabled =
+      !state.online || transientPhases.has(state.phase);
+    applyButton.hidden = !state.availableVersion;
+    applyButton.disabled =
+      state.enabled ? !state.updateReady : transientPhases.has(state.phase);
+    repairButton.disabled =
+      !state.enabled || !state.online || transientPhases.has(state.phase);
+  };
+  const unsubscribe = offlineManager.subscribe(render);
+  dialog.onResult(unsubscribe);
 
   offlineToggle.addEventListener("change", async () => {
     offlineToggle.disabled = true;
-    status.textContent = offlineToggle.checked
-      ? "Enabling offline caching..."
-      : "Disabling offline caching...";
     try {
-      await setOfflineModeEnabled(offlineToggle.checked);
-      status.textContent = offlineToggle.checked
-        ? "Offline caching is enabled."
-        : "Offline caching is disabled.";
+      await offlineManager.setEnabled(offlineToggle.checked);
+      if (offlineToggle.checked) {
+        await offlineManager.checkForUpdates();
+      }
     } catch (error) {
-      offlineToggle.checked = !offlineToggle.checked;
       status.textContent = error.message;
-    } finally {
-      offlineToggle.disabled = !("serviceWorker" in navigator);
     }
+  });
+
+  checkButton.addEventListener("click", () => {
+    offlineManager.checkForUpdates().catch(() => {});
+  });
+  applyButton.addEventListener("click", () => {
+    offlineManager.applyUpdate().catch((error) => {
+      status.textContent = error.message;
+    });
+  });
+  repairButton.addEventListener("click", async () => {
+    const accepted = await XPDialogs.confirm(
+      "Clear and download all offline files again?",
+      "Repair Offline Files",
+      "question",
+    );
+    if (!accepted) return;
+    offlineManager.repair().catch((error) => {
+      status.textContent = error.message;
+    });
   });
 
   const suggestions = document.createElement("a");
@@ -4651,7 +4758,14 @@ const openProjectSettings = () => {
   suggestions.rel = "noopener noreferrer";
   suggestions.textContent = "Send suggestions or report a problem";
 
-  dialog.body.append(heading, details, offlineLabel, status, suggestions);
+  dialog.body.append(
+    details,
+    offlineLabel,
+    status,
+    downloadProgress,
+    actions,
+    suggestions,
+  );
   XPDialogs.addButtonRow(dialog, [
     { id: "close", label: "Close", isDefault: true, isCancel: true },
   ]);
@@ -6467,7 +6581,6 @@ const login = (playSound = true) => {
     buildDesktopIcons();
     buildPlaces();
     setupSearch();
-    initializeOfflineMode();
     setupScreenSaver();
     startClock();
 
@@ -6477,6 +6590,7 @@ const login = (playSound = true) => {
       openGameWindow(gameId);
     }
   }
+  maybePromptForUpdate(offlineManager.getSnapshot());
   scheduleScreenSaver();
 };
 
@@ -6655,6 +6769,7 @@ const confirmPermanentDelete = (ids) =>
   ).then((yes) => yes && ids.forEach((id) => fs.destroy(id)));
 
 window.addEventListener("load", () => {
+  initializeOfflineMode();
   setupScreenFlow();
   setupDesktopContextMenu();
   setupWindowSystemMenu();

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -1,0 +1,413 @@
+"use strict";
+
+(function exposeOfflineManager(root, factory) {
+  const api = factory();
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  } else {
+    root.AstroOffline = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, () => {
+  const ENABLED_KEY = "offlineModeEnabled";
+  const LAST_CHECKED_KEY = "astroFlashLastUpdateCheck";
+  const DEFAULT_CHECK_INTERVAL = 60 * 60 * 1000;
+
+  const waitForWorker = (worker) =>
+    new Promise((resolve, reject) => {
+      if (!worker || worker.state === "activated") {
+        resolve();
+        return;
+      }
+      if (worker.state === "redundant") {
+        reject(new Error("The offline download was interrupted."));
+        return;
+      }
+      const onStateChange = () => {
+        if (worker.state === "activated") {
+          worker.removeEventListener("statechange", onStateChange);
+          resolve();
+        } else if (worker.state === "redundant") {
+          worker.removeEventListener("statechange", onStateChange);
+          reject(new Error("The offline download was interrupted."));
+        }
+      };
+      worker.addEventListener("statechange", onStateChange);
+    });
+
+  const createManager = ({
+    currentVersion,
+    environment = globalThis,
+    serviceWorkerUrl = "sw.js",
+    versionUrl = "version.json",
+    cachePrefix = "astro-flash",
+    checkInterval = DEFAULT_CHECK_INTERVAL,
+  }) => {
+    const navigatorObject = environment.navigator;
+    const storage = environment.localStorage;
+    const listeners = new Set();
+    const trackedRegistrations = new WeakSet();
+    const trackedWorkers = new WeakSet();
+    let registration = null;
+    let checkPromise = null;
+    let reloadWhenControlled = false;
+    let lifecycleListenersAttached = false;
+
+    let state = {
+      enabled: storage.getItem(ENABLED_KEY) === "true",
+      online: navigatorObject.onLine !== false,
+      phase:
+        storage.getItem(ENABLED_KEY) === "true" ? "starting" : "disabled",
+      currentVersion,
+      availableVersion: null,
+      availableRevision: null,
+      downloadBytes: null,
+      lastChecked: Number(storage.getItem(LAST_CHECKED_KEY)) || null,
+      updateReady: false,
+      workerState: "unregistered",
+      usage: null,
+      quota: null,
+      error: null,
+    };
+
+    const snapshot = () => ({ ...state });
+    const notify = () => listeners.forEach((listener) => listener(snapshot()));
+    const setState = (patch) => {
+      state = { ...state, ...patch };
+      notify();
+    };
+
+    const subscribe = (listener) => {
+      listeners.add(listener);
+      listener(snapshot());
+      return () => listeners.delete(listener);
+    };
+
+    const refreshStorageEstimate = async () => {
+      if (!navigatorObject.storage?.estimate) return snapshot();
+      try {
+        const estimate = await navigatorObject.storage.estimate();
+        setState({
+          usage: Number.isFinite(estimate.usage) ? estimate.usage : null,
+          quota: Number.isFinite(estimate.quota) ? estimate.quota : null,
+        });
+      } catch {
+        // Storage estimates are optional and should never break offline mode.
+      }
+      return snapshot();
+    };
+
+    const markWaitingUpdate = async (worker) => {
+      if (!worker) return;
+      let metadata = null;
+      try {
+        metadata = await fetchVersion();
+      } catch {
+        // A waiting worker is enough to prove that an update is ready.
+      }
+      setState({
+        phase: "update-ready",
+        updateReady: true,
+        workerState: "waiting",
+        availableVersion: metadata?.version || state.availableVersion,
+        availableRevision: metadata?.revision || state.availableRevision,
+        downloadBytes: metadata?.offlineBytes || state.downloadBytes,
+        error: null,
+      });
+    };
+
+    const trackInstallingWorker = (worker, isUpdate) => {
+      if (!worker || trackedWorkers.has(worker)) return;
+      trackedWorkers.add(worker);
+      setState({
+        phase: isUpdate ? "updating" : "downloading",
+        workerState: worker.state,
+        error: null,
+      });
+      worker.addEventListener("statechange", () => {
+        setState({ workerState: worker.state });
+        if (worker.state === "installed" && registration?.waiting && isUpdate) {
+          void markWaitingUpdate(registration.waiting);
+        } else if (worker.state === "activated" && !isUpdate) {
+          setState({ phase: "ready", workerState: "active", error: null });
+          void refreshStorageEstimate();
+        } else if (
+          worker.state === "redundant" &&
+          !registration?.active
+        ) {
+          setState({
+            phase: "error",
+            workerState: "failed",
+            error: "The offline download did not complete.",
+          });
+        }
+      });
+    };
+
+    const trackRegistration = (nextRegistration) => {
+      registration = nextRegistration;
+      if (trackedRegistrations.has(nextRegistration)) return;
+      trackedRegistrations.add(nextRegistration);
+      nextRegistration.addEventListener("updatefound", () => {
+        trackInstallingWorker(
+          nextRegistration.installing,
+          Boolean(nextRegistration.active || navigatorObject.serviceWorker.controller),
+        );
+      });
+      if (nextRegistration.waiting && nextRegistration.active) {
+        void markWaitingUpdate(nextRegistration.waiting);
+      } else if (nextRegistration.installing) {
+        trackInstallingWorker(
+          nextRegistration.installing,
+          Boolean(nextRegistration.active || navigatorObject.serviceWorker.controller),
+        );
+      }
+    };
+
+    const registerAndWait = async () => {
+      if (!navigatorObject.serviceWorker) {
+        throw new Error("Offline mode is not supported by this browser.");
+      }
+      const nextRegistration = await navigatorObject.serviceWorker.register(
+        serviceWorkerUrl,
+        { updateViaCache: "none" },
+      );
+      trackRegistration(nextRegistration);
+
+      if (nextRegistration.active) {
+        setState({
+          phase: nextRegistration.waiting ? "update-ready" : "ready",
+          workerState: nextRegistration.waiting ? "waiting" : "active",
+          updateReady: Boolean(nextRegistration.waiting),
+          error: null,
+        });
+        return nextRegistration;
+      }
+
+      const worker = nextRegistration.installing || nextRegistration.waiting;
+      if (worker) {
+        setState({ phase: "downloading", workerState: worker.state, error: null });
+        await waitForWorker(worker);
+      } else {
+        await navigatorObject.serviceWorker.ready;
+      }
+      setState({ phase: "ready", workerState: "active", error: null });
+      await refreshStorageEstimate();
+      return nextRegistration;
+    };
+
+    async function fetchVersion() {
+      if (navigatorObject.onLine === false) {
+        throw new Error("Connect to the internet to check for updates.");
+      }
+      const separator = versionUrl.includes("?") ? "&" : "?";
+      const response = await environment.fetch(
+        `${versionUrl}${separator}t=${environment.Date.now()}`,
+        { cache: "no-store" },
+      );
+      if (!response.ok) {
+        throw new Error(`Update check failed (${response.status}).`);
+      }
+      const metadata = await response.json();
+      if (
+        typeof metadata.version !== "string" ||
+        typeof metadata.revision !== "string" ||
+        !Number.isFinite(metadata.offlineBytes) ||
+        metadata.offlineBytes <= 0
+      ) {
+        throw new Error("The update server returned invalid version metadata.");
+      }
+      return metadata;
+    }
+
+    const checkForUpdates = async () => {
+      if (checkPromise) return checkPromise;
+      checkPromise = (async () => {
+        const previousPhase = state.phase;
+        setState({ phase: "checking", error: null });
+        try {
+          const metadata = await fetchVersion();
+          if (state.enabled) {
+            if (!registration) await registerAndWait();
+            await registration.update();
+          }
+          const checkedAt = environment.Date.now();
+          storage.setItem(LAST_CHECKED_KEY, String(checkedAt));
+          const updateAvailable = metadata.version !== currentVersion;
+          setState({
+            phase: updateAvailable
+              ? registration?.waiting
+                ? "update-ready"
+                : "update-available"
+              : state.enabled
+                ? "ready"
+                : "disabled",
+            availableVersion: updateAvailable ? metadata.version : null,
+            availableRevision: updateAvailable ? metadata.revision : null,
+            downloadBytes: metadata.offlineBytes,
+            lastChecked: checkedAt,
+            updateReady: updateAvailable && Boolean(registration?.waiting),
+            workerState: registration?.waiting
+              ? "waiting"
+              : registration?.active
+                ? "active"
+                : "unregistered",
+            error: null,
+          });
+        } catch (error) {
+          setState({
+            phase:
+              previousPhase === "disabled" || previousPhase === "ready"
+                ? previousPhase
+                : "error",
+            error: error.message,
+          });
+          throw error;
+        } finally {
+          checkPromise = null;
+        }
+        return snapshot();
+      })();
+      return checkPromise;
+    };
+
+    const deleteOfflineCaches = async () => {
+      if (!environment.caches) return;
+      const names = await environment.caches.keys();
+      await Promise.all(
+        names
+          .filter((name) => name.startsWith(cachePrefix))
+          .map((name) => environment.caches.delete(name)),
+      );
+    };
+
+    const setEnabled = async (enabled) => {
+      if (enabled) {
+        storage.setItem(ENABLED_KEY, "true");
+        setState({ enabled: true, phase: "starting", error: null });
+        try {
+          await registerAndWait();
+          return snapshot();
+        } catch (error) {
+          setState({ phase: "error", error: error.message });
+          throw error;
+        }
+      }
+
+      const currentRegistration =
+        registration ||
+        (await navigatorObject.serviceWorker?.getRegistration("./"));
+      if (currentRegistration) await currentRegistration.unregister();
+      await deleteOfflineCaches();
+      registration = null;
+      storage.setItem(ENABLED_KEY, "false");
+      setState({
+        enabled: false,
+        phase: "disabled",
+        updateReady: false,
+        workerState: "unregistered",
+        usage: null,
+        quota: null,
+        error: null,
+      });
+      return snapshot();
+    };
+
+    const applyUpdate = async () => {
+      if (registration?.waiting) {
+        reloadWhenControlled = true;
+        setState({ phase: "applying", error: null });
+        registration.waiting.postMessage({ type: "SKIP_WAITING" });
+        return;
+      }
+      if (state.availableVersion && !state.enabled) {
+        environment.location.reload();
+        return;
+      }
+      throw new Error(
+        registration?.installing
+          ? "The update is still downloading."
+          : "No update is ready to install.",
+      );
+    };
+
+    const repair = async () => {
+      if (navigatorObject.onLine === false) {
+        throw new Error("Connect to the internet to repair offline files.");
+      }
+      setState({ phase: "repairing", error: null });
+      const currentRegistration =
+        registration ||
+        (await navigatorObject.serviceWorker?.getRegistration("./"));
+      if (currentRegistration) await currentRegistration.unregister();
+      await deleteOfflineCaches();
+      registration = null;
+      storage.setItem(ENABLED_KEY, "true");
+      setState({ enabled: true, phase: "starting", updateReady: false });
+      await registerAndWait();
+      await checkForUpdates();
+      return snapshot();
+    };
+
+    const automaticCheck = () => {
+      if (
+        !state.enabled ||
+        navigatorObject.onLine === false ||
+        (state.lastChecked &&
+          environment.Date.now() - state.lastChecked < checkInterval)
+      ) {
+        return;
+      }
+      void checkForUpdates().catch(() => {});
+    };
+
+    const attachLifecycleListeners = () => {
+      if (lifecycleListenersAttached) return;
+      lifecycleListenersAttached = true;
+      navigatorObject.serviceWorker?.addEventListener(
+        "controllerchange",
+        () => {
+          if (reloadWhenControlled) environment.location.reload();
+        },
+      );
+      environment.addEventListener?.("online", () => {
+        setState({ online: true });
+        automaticCheck();
+      });
+      environment.addEventListener?.("offline", () => {
+        setState({ online: false });
+      });
+      environment.document?.addEventListener("visibilitychange", () => {
+        if (environment.document.visibilityState === "visible") automaticCheck();
+      });
+    };
+
+    const initialize = async () => {
+      attachLifecycleListeners();
+      await refreshStorageEstimate();
+      if (!state.enabled) return snapshot();
+      try {
+        await registerAndWait();
+        automaticCheck();
+      } catch (error) {
+        setState({ phase: "error", error: error.message });
+      }
+      return snapshot();
+    };
+
+    return {
+      applyUpdate,
+      checkForUpdates,
+      getSnapshot: snapshot,
+      initialize,
+      refreshStorageEstimate,
+      repair,
+      setEnabled,
+      subscribe,
+    };
+  };
+
+  return {
+    createManager,
+    waitForWorker,
+  };
+});

--- a/tests/offline_node_tests.js
+++ b/tests/offline_node_tests.js
@@ -1,0 +1,236 @@
+"use strict";
+
+const assert = require("assert");
+const {
+  createManager,
+  waitForWorker,
+} = require("../site/js/offline.js");
+
+class Events {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(name, listener) {
+    if (!this.listeners.has(name)) this.listeners.set(name, new Set());
+    this.listeners.get(name).add(listener);
+  }
+
+  removeEventListener(name, listener) {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  dispatch(name) {
+    this.listeners.get(name)?.forEach((listener) => listener());
+  }
+}
+
+class Worker extends Events {
+  constructor(state = "installing") {
+    super();
+    this.state = state;
+    this.messages = [];
+  }
+
+  transition(state) {
+    this.state = state;
+    this.dispatch("statechange");
+  }
+
+  postMessage(message) {
+    this.messages.push(message);
+  }
+}
+
+class Registration extends Events {
+  constructor({ active = null, installing = null, waiting = null } = {}) {
+    super();
+    this.active = active;
+    this.installing = installing;
+    this.waiting = waiting;
+    this.updateCalls = 0;
+    this.unregisterCalls = 0;
+  }
+
+  async update() {
+    this.updateCalls += 1;
+  }
+
+  async unregister() {
+    this.unregisterCalls += 1;
+  }
+}
+
+class MemoryStorage {
+  constructor(values = {}) {
+    this.values = new Map(Object.entries(values));
+  }
+
+  getItem(key) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+}
+
+const makeEnvironment = ({
+  registration,
+  enabled = false,
+  remoteVersion = "26.07.29-bbbbbbb",
+} = {}) => {
+  const serviceWorker = new Events();
+  serviceWorker.controller = registration?.active || null;
+  serviceWorker.registerCalls = [];
+  serviceWorker.register = async (...args) => {
+    serviceWorker.registerCalls.push(args);
+    return registration;
+  };
+  serviceWorker.getRegistration = async () => registration;
+  serviceWorker.ready = Promise.resolve(registration);
+
+  const windowEvents = new Events();
+  const documentEvents = new Events();
+  documentEvents.visibilityState = "visible";
+  const deletedCaches = [];
+  let reloads = 0;
+  let now = 1_800_000_000_000;
+
+  return {
+    environment: {
+      navigator: {
+        onLine: true,
+        serviceWorker,
+        storage: {
+          estimate: async () => ({ usage: 138_000_000, quota: 500_000_000 }),
+        },
+      },
+      localStorage: new MemoryStorage({
+        offlineModeEnabled: enabled ? "true" : "false",
+      }),
+      fetch: async (_url, options) => {
+        assert.strictEqual(options.cache, "no-store");
+        return {
+          ok: true,
+          json: async () => ({
+            version: remoteVersion,
+            revision: remoteVersion.split("-").at(-1),
+            offlineBytes: 172_000_000,
+          }),
+        };
+      },
+      caches: {
+        keys: async () => ["astro-flash-precache", "unrelated-cache"],
+        delete: async (name) => {
+          deletedCaches.push(name);
+          return true;
+        },
+      },
+      location: {
+        reload: () => {
+          reloads += 1;
+        },
+      },
+      Date: {
+        now: () => now,
+      },
+      document: documentEvents,
+      addEventListener: (...args) => windowEvents.addEventListener(...args),
+    },
+    deletedCaches,
+    getReloads: () => reloads,
+    setNow: (value) => {
+      now = value;
+    },
+    serviceWorker,
+    windowEvents,
+  };
+};
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+(async () => {
+  const activatingWorker = new Worker();
+  const activation = waitForWorker(activatingWorker);
+  activatingWorker.transition("activated");
+  await activation;
+
+  const failedWorker = new Worker();
+  const failure = waitForWorker(failedWorker);
+  failedWorker.transition("redundant");
+  await assert.rejects(failure, /interrupted/);
+
+  const initialWorker = new Worker();
+  const initialRegistration = new Registration({ installing: initialWorker });
+  const initial = makeEnvironment({ registration: initialRegistration });
+  const initialManager = createManager({
+    currentVersion: "26.07.28-aaaaaaa",
+    environment: initial.environment,
+  });
+  const enabling = initialManager.setEnabled(true);
+  await flushPromises();
+  assert.strictEqual(initialManager.getSnapshot().phase, "downloading");
+  initialRegistration.active = initialWorker;
+  initialRegistration.installing = null;
+  initialWorker.transition("activated");
+  await enabling;
+  assert.strictEqual(initialManager.getSnapshot().phase, "ready");
+  assert.strictEqual(
+    initial.environment.localStorage.getItem("offlineModeEnabled"),
+    "true",
+  );
+  assert.deepStrictEqual(initial.serviceWorker.registerCalls[0], [
+    "sw.js",
+    { updateViaCache: "none" },
+  ]);
+
+  const activeWorker = new Worker("activated");
+  const updateRegistration = new Registration({ active: activeWorker });
+  const update = makeEnvironment({
+    registration: updateRegistration,
+    enabled: true,
+  });
+  const updateManager = createManager({
+    currentVersion: "26.07.28-aaaaaaa",
+    environment: update.environment,
+  });
+  await updateManager.initialize();
+  const waitingWorker = new Worker();
+  updateRegistration.installing = waitingWorker;
+  updateRegistration.dispatch("updatefound");
+  updateRegistration.installing = null;
+  updateRegistration.waiting = waitingWorker;
+  waitingWorker.transition("installed");
+  await flushPromises();
+  assert.strictEqual(updateManager.getSnapshot().phase, "update-ready");
+  assert.strictEqual(updateManager.getSnapshot().updateReady, true);
+  await updateManager.applyUpdate();
+  assert.deepStrictEqual(waitingWorker.messages, [{ type: "SKIP_WAITING" }]);
+  update.serviceWorker.dispatch("controllerchange");
+  assert.strictEqual(update.getReloads(), 1);
+
+  const disabledRegistration = new Registration();
+  const disabled = makeEnvironment({ registration: disabledRegistration });
+  const disabledManager = createManager({
+    currentVersion: "26.07.28-aaaaaaa",
+    environment: disabled.environment,
+  });
+  await disabledManager.checkForUpdates();
+  assert.strictEqual(disabledManager.getSnapshot().phase, "update-available");
+  await disabledManager.applyUpdate();
+  assert.strictEqual(disabled.getReloads(), 1);
+
+  await updateManager.setEnabled(false);
+  assert.deepStrictEqual(update.deletedCaches, ["astro-flash-precache"]);
+  assert.strictEqual(
+    update.environment.localStorage.getItem("offlineModeEnabled"),
+    "false",
+  );
+  assert.strictEqual(updateManager.getSnapshot().phase, "disabled");
+
+  console.log("offline update tests passed");
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -48,6 +48,7 @@ class DeployTests(unittest.TestCase):
                     '<script src="js/filesystem.js?v=old"></script>',
                     '<script src="js/file-operations.js?v=old"></script>',
                     '<script src="js/dialogs.js?v=old"></script>',
+                    '<script src="js/offline.js?v=old"></script>',
                     '<script src="js/main.js?v=old"></script>',
                     '<link rel="stylesheet" href="css/main.css?v=old">',
                 ]
@@ -56,6 +57,7 @@ class DeployTests(unittest.TestCase):
             "js/filesystem.js": "filesystem",
             "js/file-operations.js": "file operations",
             "js/dialogs.js": "dialogs",
+            "js/offline.js": "offline",
             "js/main.js": 'const APP_VERSION = "old";\n',
             "css/main.css": "css",
             "swf/bike-mania/main.swf": "swf",
@@ -164,6 +166,7 @@ class DeployTests(unittest.TestCase):
         paths = deploy.BuildPaths(self.source_dir)
 
         deploy.update_html(paths, "26.07.28-abcdef1")
+        deploy.write_version_metadata(paths, "26.07.28-abcdef1")
 
         main = paths.main_js.read_text(encoding="utf-8")
         html = paths.html.read_text(encoding="utf-8")
@@ -176,6 +179,16 @@ class DeployTests(unittest.TestCase):
             "js/file-operations.js?v="
             f'{deploy.get_short_hash(paths.js / "file-operations.js")}"',
             html,
+        )
+        self.assertIn(
+            f'js/offline.js?v={deploy.get_short_hash(paths.js / "offline.js")}"',
+            html,
+        )
+        metadata = json.loads(paths.version_json.read_text(encoding="utf-8"))
+        self.assertGreater(metadata.pop("offlineBytes"), 0)
+        self.assertEqual(
+            metadata,
+            {"revision": "abcdef1", "version": "26.07.28-abcdef1"},
         )
 
     def test_update_html_fails_if_an_asset_reference_is_missing(self):
@@ -219,6 +232,10 @@ class DeployTests(unittest.TestCase):
         self.make_source()
         self.add_generated_runtime(self.source_dir)
         deploy.update_html(
+            deploy.BuildPaths(self.source_dir),
+            "26.07.28-abcdef1",
+        )
+        deploy.write_version_metadata(
             deploy.BuildPaths(self.source_dir),
             "26.07.28-abcdef1",
         )
@@ -271,6 +288,14 @@ class DeployTests(unittest.TestCase):
         self.assertEqual(current_files, original_files)
         self.assertFalse((self.output_dir / "stale.txt").exists())
         self.assertTrue((self.output_dir / "sw.js").is_file())
+        metadata = json.loads(
+            (self.output_dir / "version.json").read_text(encoding="utf-8")
+        )
+        self.assertGreater(metadata.pop("offlineBytes"), 0)
+        self.assertEqual(
+            metadata,
+            {"revision": "abcdef1", "version": "26.07.28-abcdef1"},
+        )
 
     def test_failed_build_preserves_previous_output(self):
         self.make_source()

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -1,0 +1,19 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+
+
+class OfflineUpdateTests(unittest.TestCase):
+    def test_offline_update_node_suite(self):
+        subprocess.run(
+            ["node", "tests/offline_node_tests.js"],
+            cwd=PROJECT_DIR,
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -7,7 +7,9 @@ from pathlib import Path
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 INDEX_HTML = PROJECT_DIR / "site" / "index.html"
 MAIN_JS = PROJECT_DIR / "site" / "js" / "main.js"
+OFFLINE_JS = PROJECT_DIR / "site" / "js" / "offline.js"
 MAIN_CSS = PROJECT_DIR / "site" / "css" / "main.css"
+WORKBOX_CONFIG = PROJECT_DIR / "workbox-config.js"
 XP_ICONS_DIR = PROJECT_DIR / "site" / "assets" / "xp" / "icons"
 
 
@@ -59,7 +61,9 @@ class ShellSourceTests(unittest.TestCase):
         cls.html = INDEX_HTML.read_text(encoding="utf-8")
         cls.javascript = MAIN_JS.read_text(encoding="utf-8")
         cls.javascript_compact = _compact_source(cls.javascript)
+        cls.offline_javascript = OFFLINE_JS.read_text(encoding="utf-8")
         cls.css = MAIN_CSS.read_text(encoding="utf-8")
+        cls.workbox_config = WORKBOX_CONFIG.read_text(encoding="utf-8")
 
     def assertJavascriptContains(self, *tokens):
         for token in tokens:
@@ -141,10 +145,10 @@ class ShellSourceTests(unittest.TestCase):
     def test_text_files_open_in_filesystem_backed_notepad(self):
         self.assertJavascriptContains(
             'fs.registerFileType(".txt", (file) => openNotepad(file))',
-            'fs.setContent(node.id, editor.value)',
+            "fs.setContent(node.id, editor.value)",
             'XPDialogs.openFile({ title: "Open"',
             'XPDialogs.saveFile({ title: "Save As"',
-            'win.beforeClose = confirmSaveChanges',
+            "win.beforeClose = confirmSaveChanges",
         )
         for label in ("&File", "&Edit", "F&ormat", "&View", "&Help"):
             self.assertIn(label, self.javascript)
@@ -552,11 +556,33 @@ class ShellSourceTests(unittest.TestCase):
     def test_project_controls_live_in_a_separate_dialog(self):
         self.assertJavascriptContains(
             'title: "Astro Flash Collection"',
-            'localStorage.getItem("offlineModeEnabled")',
-            'navigator.serviceWorker.register("sw.js")',
+            "offlineManager.checkForUpdates()",
+            "offlineManager.applyUpdate()",
+            "offlineManager.repair()",
+            '"Check for Updates"',
+            '"Repair Offline Files"',
+            '"Offline download progress"',
+            "state.downloadBytes",
             '"https://github.com/astrovm/flash/issues"',
             'case "project": openProjectSettings();',
         )
+        self.assertNotIn(
+            'heading.textContent = "Astro Flash Collection"', self.javascript
+        )
+        for token in (
+            "navigatorObject.serviceWorker.register(",
+            '{ updateViaCache: "none" }',
+            '"updatefound"',
+            '"controllerchange"',
+            '{ type: "SKIP_WAITING" }',
+            'cache: "no-store"',
+            '"visibilitychange"',
+            '"online"',
+        ):
+            self.assertIn(token, self.offline_javascript)
+        self.assertIn('globIgnores: ["version.json"]', self.workbox_config)
+        self.assertIn("skipWaiting: false", self.workbox_config)
+        self.assertIn("clientsClaim: true", self.workbox_config)
 
     def test_game_controls_share_one_compact_menu_row(self):
         self.assertJavascriptContains(

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -20,6 +20,28 @@ DEFAULT_OUTPUT_DIR = PROJECT_DIR / "dist"
 RUFFLE_RELEASE_PATH = PROJECT_DIR / "tools" / "ruffle-release.json"
 RUFFLE_DOWNLOAD_ROOT = "https://github.com/ruffle-rs/ruffle/releases/download"
 RUFFLE_FILE_SUFFIXES = (".js", ".js.map", ".wasm")
+PRECACHE_FILE_SUFFIXES = {
+    ".woff",
+    ".woff2",
+    ".css",
+    ".ico",
+    ".svg",
+    ".mp3",
+    ".wav",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".cur",
+    ".json",
+    ".html",
+    ".js",
+    ".mjs",
+    ".wasm",
+    ".swf",
+    ".jsdos",
+    ".xml",
+    ".phtml",
+}
 APP_VERSION_PATTERN = re.compile(r'const APP_VERSION = "[^"]+";')
 
 
@@ -44,6 +66,10 @@ class BuildPaths:
         return self.js / "main.js"
 
     @property
+    def version_json(self):
+        return self.root / "version.json"
+
+    @property
     def asset_paths(self):
         return {
             "ruffle": self.js / "ruffle.js",
@@ -51,6 +77,7 @@ class BuildPaths:
             "filesystem_js": self.js / "filesystem.js",
             "file_operations_js": self.js / "file-operations.js",
             "dialogs_js": self.js / "dialogs.js",
+            "offline_js": self.js / "offline.js",
             "main_js": self.main_js,
             "main_css": self.css / "main.css",
         }
@@ -185,6 +212,9 @@ def update_html(paths, version):
         r'<script src="js/dialogs\.[^"]+" ?[^>]*></script>': (
             f'<script src="js/dialogs.js?v={short_hashes["dialogs_js"]}"></script>'
         ),
+        r'<script src="js/offline\.[^"]+" ?[^>]*></script>': (
+            f'<script src="js/offline.js?v={short_hashes["offline_js"]}"></script>'
+        ),
         r'<script src="js/main\.[^"]+" ?[^>]*></script>': (
             f'<script src="js/main.js?v={short_hashes["main_js"]}"></script>'
         ),
@@ -198,6 +228,30 @@ def update_html(paths, version):
             raise RuntimeError(f"Could not update asset reference matching {pattern}")
     paths.html.write_text(content, encoding="utf-8")
     print(f"  - Set deployment version to {version}")
+
+
+def write_version_metadata(paths, version):
+    revision = version.rsplit("-", maxsplit=1)[-1]
+    offline_bytes = sum(
+        path.stat().st_size
+        for path in paths.root.rglob("*")
+        if path.is_file()
+        and path != paths.version_json
+        and path.suffix.lower() in PRECACHE_FILE_SUFFIXES
+    )
+    paths.version_json.write_text(
+        json.dumps(
+            {
+                "offlineBytes": offline_bytes,
+                "revision": revision,
+                "version": version,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def get_workbox_files(output_dir):
@@ -253,6 +307,7 @@ def validate_output(output_dir):
     paths = BuildPaths(output_dir)
     required = (
         paths.html,
+        paths.version_json,
         output_dir / "sw.js",
         output_dir / "swf" / "bike-mania" / "main.swf",
         output_dir / "iframe" / "doom" / "index.html",
@@ -270,6 +325,7 @@ def validate_output(output_dir):
         "js/filesystem.js",
         "js/file-operations.js",
         "js/dialogs.js",
+        "js/offline.js",
         "js/main.js",
         "css/main.css",
     ):
@@ -279,6 +335,19 @@ def validate_output(output_dir):
         raise RuntimeError("Build output has no Ruffle core JavaScript")
     if not any(paths.js.glob("*.wasm")):
         raise RuntimeError("Build output has no Ruffle WebAssembly")
+    try:
+        version_metadata = json.loads(paths.version_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as error:
+        raise RuntimeError("Build output has invalid version metadata") from error
+    if set(version_metadata) != {"offlineBytes", "revision", "version"}:
+        raise RuntimeError("Build output has invalid version metadata")
+    if (
+        not isinstance(version_metadata["offlineBytes"], int)
+        or version_metadata["offlineBytes"] <= 0
+    ):
+        raise RuntimeError("Build output has invalid offline download size")
+    if not version_metadata["version"].endswith(f"-{version_metadata['revision']}"):
+        raise RuntimeError("Build output has inconsistent version metadata")
     print("Build output validated successfully")
 
 
@@ -312,6 +381,7 @@ def build(output_dir=DEFAULT_OUTPUT_DIR, revision="HEAD"):
         paths = BuildPaths(staging_dir)
         download_ruffle(paths.js)
         update_html(paths, version)
+        write_version_metadata(paths, version)
         generate_service_worker(staging_dir)
         validate_output(staging_dir)
         replace_output(staging_dir, output_dir)

--- a/workbox-config.js
+++ b/workbox-config.js
@@ -7,12 +7,13 @@ module.exports = {
 	globPatterns: [
 		"**/*.{woff,woff2,css,ico,svg,mp3,wav,png,jpg,jpeg,cur,json,html,js,mjs,wasm,swf,jsdos,xml,phtml}",
 	],
+	globIgnores: ["version.json"],
 	swDest: path.join(outputDirectory, "sw.js"),
 	maximumFileSizeToCacheInBytes: 25000000,
 	ignoreURLParametersMatching: [/^utm_/, /^fbclid$/, /^v$/],
 	sourcemap: false,
 	cacheId: 'astro-flash',
 	cleanupOutdatedCaches: true,
-	skipWaiting: true,
+	skipWaiting: false,
 	clientsClaim: true
 };


### PR DESCRIPTION
## Summary

- add a dedicated offline/update manager with startup, reconnect, visibility, and manual update checks
- keep the complete collection available offline while reporting download, worker, storage, failure, and repair states
- activate updates through a waiting-worker prompt and reload after the new worker takes control
- generate uncached deployment metadata with the version, revision, and offline download size
- remove the duplicated Astro Flash Collection heading from the settings content
- SHA-pin and update GitHub Actions with Pinact

## Why

Offline mode previously stored only a preference, reported success before the full cache was known to be ready, and had no application-level service-worker update lifecycle. A deployed update could therefore leave a long-running or cached page on an old application version without a recovery path.

## Validation

- `bun run test` — 80 tests passed, including the new Node lifecycle suite
- `python -m ruff check tools tests`
- `python -m ruff format --check tools/deploy.py tests/test_deploy.py tests/test_shell.py tests/test_offline.py`
- `pinact run --check --verify-comment`
- `bun run build` — validated a production artifact precaching 188 URLs / 172 MB

Interactive browser verification was not available in the local Codex session; the generated worker, metadata, and settings behavior were validated through the production build and behavioral tests.
