### PR TITLE
Fix offline settings status

### DIFF
--- a/site/js/main.js
+++ b/site/js/main.js
@@ -4592,6 +4592,9 @@ const projectStorageText = (state) => {
     : `${usage} of ${XPDialogs.formatBytes(state.quota)}`;
 };
 
+const formatProjectState = (value) =>
+  value ? `${value.charAt(0).toUpperCase()}${value.slice(1)}` : "Unavailable";
+
 const maybePromptForUpdate = (state) => {
   if (
     !loggedIn ||
@@ -4690,10 +4693,14 @@ const openProjectSettings = () => {
     detailValues.games.textContent = String(Object.keys(gamesList).length);
     detailValues.downloadSize.textContent =
       state.downloadBytes === null
-        ? "Checking..."
+        ? state.downloadMetadataError
+          ? "Unavailable"
+          : "Checking..."
         : XPDialogs.formatBytes(state.downloadBytes);
     detailValues.connection.textContent = state.online ? "Online" : "Offline";
-    detailValues.offlineFiles.textContent = state.workerState;
+    detailValues.offlineFiles.textContent = formatProjectState(
+      state.workerState,
+    );
     detailValues.storage.textContent = projectStorageText(state);
     detailValues.lastChecked.textContent = formatUpdateCheckTime(
       state.lastChecked,

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -10,6 +10,8 @@
 })(typeof globalThis !== "undefined" ? globalThis : this, () => {
   const ENABLED_KEY = "offlineModeEnabled";
   const LAST_CHECKED_KEY = "astroFlashLastUpdateCheck";
+  const DOWNLOAD_VERSION_KEY = "astroFlashDownloadVersion";
+  const DOWNLOAD_BYTES_KEY = "astroFlashDownloadBytes";
   const DEFAULT_CHECK_INTERVAL = 60 * 60 * 1000;
 
   const waitForWorker = (worker) =>
@@ -52,6 +54,10 @@
     let reloadWhenControlled = false;
     let lifecycleListenersAttached = false;
 
+    const cachedDownloadBytes =
+      storage.getItem(DOWNLOAD_VERSION_KEY) === currentVersion
+        ? Number(storage.getItem(DOWNLOAD_BYTES_KEY)) || null
+        : null;
     let state = {
       enabled: storage.getItem(ENABLED_KEY) === "true",
       online: navigatorObject.onLine !== false,
@@ -60,7 +66,8 @@
       currentVersion,
       availableVersion: null,
       availableRevision: null,
-      downloadBytes: null,
+      downloadBytes: cachedDownloadBytes,
+      downloadMetadataError: false,
       lastChecked: Number(storage.getItem(LAST_CHECKED_KEY)) || null,
       updateReady: false,
       workerState: "unregistered",
@@ -96,11 +103,21 @@
       return snapshot();
     };
 
+    const rememberVersionMetadata = (metadata) => {
+      storage.setItem(DOWNLOAD_VERSION_KEY, metadata.version);
+      storage.setItem(DOWNLOAD_BYTES_KEY, String(metadata.offlineBytes));
+      setState({
+        downloadBytes: metadata.offlineBytes,
+        downloadMetadataError: false,
+      });
+    };
+
     const markWaitingUpdate = async (worker) => {
       if (!worker) return;
       let metadata = null;
       try {
         metadata = await fetchVersion();
+        rememberVersionMetadata(metadata);
       } catch {
         // A waiting worker is enough to prove that an update is ready.
       }
@@ -226,6 +243,7 @@
         setState({ phase: "checking", error: null });
         try {
           const metadata = await fetchVersion();
+          rememberVersionMetadata(metadata);
           if (state.enabled) {
             if (!registration) await registerAndWait();
             await registration.update();
@@ -260,6 +278,7 @@
                 ? previousPhase
                 : "error",
             error: error.message,
+            downloadMetadataError: state.downloadBytes === null,
           });
           throw error;
         } finally {
@@ -384,6 +403,13 @@
     const initialize = async () => {
       attachLifecycleListeners();
       await refreshStorageEstimate();
+      if (state.downloadBytes === null && navigatorObject.onLine !== false) {
+        try {
+          rememberVersionMetadata(await fetchVersion());
+        } catch {
+          setState({ downloadMetadataError: true });
+        }
+      }
       if (!state.enabled) return snapshot();
       try {
         await registerAndWait();

--- a/tests/offline_node_tests.js
+++ b/tests/offline_node_tests.js
@@ -216,6 +216,12 @@ const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
     currentVersion: "26.07.28-aaaaaaa",
     environment: disabled.environment,
   });
+  await disabledManager.initialize();
+  assert.strictEqual(disabledManager.getSnapshot().downloadBytes, 172_000_000);
+  assert.strictEqual(
+    disabled.environment.localStorage.getItem("astroFlashDownloadVersion"),
+    "26.07.29-bbbbbbb",
+  );
   await disabledManager.checkForUpdates();
   assert.strictEqual(disabledManager.getSnapshot().phase, "update-available");
   await disabledManager.applyUpdate();

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -563,6 +563,8 @@ class ShellSourceTests(unittest.TestCase):
             '"Repair Offline Files"',
             '"Offline download progress"',
             "state.downloadBytes",
+            "state.downloadMetadataError",
+            "formatProjectState(",
             '"https://github.com/astrovm/flash/issues"',
             'case "project": openProjectSettings();',
         )


### PR DESCRIPTION
## Summary

- load and cache the current deployment size independently of the hourly update-check throttle
- show `Unavailable` if deployment metadata cannot be fetched instead of remaining on `Checking...`
- capitalize service-worker states in the settings window

## Root cause

The deployment size was only populated by the throttled automatic update check. When a recent check caused that request to be skipped, the value remained unknown for the lifetime of the page.

## Validation

- `bun run test` — 80 tests passed
- `bun run build` — production artifact generated successfully
- built-in browser — settings showed `164.32 MB (172,304,800 bytes)` and the capitalized worker state `Unregistered`
