### PR TITLE
Update README for current features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,27 @@
-# Flash Collection
+# Astro Flash Collection
 
-A curated archive of Flash games
+A browser-based collection of classic Flash, HTML5, and DOS games presented as
+a Windows XP desktop.
+
+[Open Astro Flash Collection](https://flash.4st.li/)
 
 ## Features
 
-- Windows XP desktop simulation with boot, login and turn-off screens
-- Windows XP assets: Bliss wallpaper, arrow cursor, boot/login artwork and system sounds
-- Games as desktop icons, opened in draggable/resizable windows
-- Start menu with game categories, search, favorites and recently played
-- Taskbar with window buttons and tray clock
-- Flash emulation by Ruffle
-- DOS emulation by js-dos
-- Download the complete collection for offline play
-- Check for updates, apply them safely, and repair incomplete offline data
-- FPS optimized per game
-- Fast CDN
-- Flawless screen adaptation
-- No requests to external resources
-- Automatic sitelock bypass
-- Fullscreen support
-- Volume controls for both Flash and HTML5 games
-- Persistent volume settings across sessions
-- Mute/unmute functionality
-- Per-window volume controls with focus-based muting
-- Up to 4 game windows open simultaneously
-- Deep linking via URL hash (#game-id)
+- Windows XP shell with boot, login, shutdown, Start menu, taskbar, system tray,
+  desktop context menus, and keyboard navigation
+- Draggable and resizable game windows with minimize, maximize, fullscreen,
+  task switching, taskbar overflow, and window arrangement controls
+- Persistent virtual filesystem with Explorer windows, file operations, Recycle
+  Bin, search, and an editable Notepad
+- Game categories, favorites, recently played items, Run commands, and URL hash
+  deep links
+- Flash emulation through Ruffle and DOS emulation through js-dos
+- Master and per-game volume controls, persistent settings, and automatic muting
+  of unfocused games
+- Desktop themes, wallpapers, screen savers, appearance schemes, and simulated
+  display resolutions
+- Optional full-collection offline download with update checks, progress,
+  storage reporting, and repair controls
 
 ## Development
 
@@ -85,19 +82,21 @@ worker activates and reloads the page.
 ### Game Support
 
 The collection supports two types of games:
+
 - SWF (Flash) games using Ruffle emulation
 - DOS and HTML5 games via iframe integration
 
 Each game can be configured with specific settings:
+
 ```javascript
 {
-    type: "swf",              // Game type: "swf" or "iframe"
-    title: "Display Name",     // Optional: Preserve original title styling
-    icon: "assets/icons/x.png", // Sourced PNG used throughout the shell
-    frameRate: 45,            // Optional: Set specific frame rate
-    category: "Racing",       // Game category for organization
-    aspectRatio: 480/360,     // Optional: Force specific aspect ratio
-    spoofUrl: "example.com"   // Optional: URL spoofing for sitelock bypass
+  type: "swf",               // "swf" or "iframe"
+  title: "Display Name",      // Optional display title
+  icon: "assets/icons/x.png", // Sourced PNG used throughout the shell
+  frameRate: 45,             // Optional frame rate
+  category: "Racing",
+  aspectRatio: 480 / 360,    // Optional forced aspect ratio
+  spoofUrl: "example.com",   // Optional URL spoofing for sitelock compatibility
 }
 ```
 
@@ -107,18 +106,10 @@ game has a valid, source-documented PNG. `tools/sync_game_icons.py` contains the
 reviewed Flashpoint UUID mappings and can refresh those assets without fuzzy
 auto-matching.
 
-### Volume Control Implementation
-
-The project implements unified volume controls that work across both Flash and HTML5 games:
-- Flash games use Ruffle's native volume control
-- HTML5 games use postMessage API for volume control
-- Volume settings persist in localStorage
-- Supports mute/unmute with volume memory
-- Volume slider with real-time updates
-
 ### Contributing
 
 Contributions are welcome! Please ensure that:
+
 - Games are tested for compatibility
 - Frame rates are optimized for performance
 - Proper categorization is maintained


### PR DESCRIPTION
## Summary

- rename the README heading to Astro Flash Collection and add the live-site link
- replace stale and vague feature claims with the current XP shell, window management, Explorer, virtual filesystem, Notepad, personalization, and offline behavior
- remove the obsolete four-game-window limit
- simplify the game configuration and volume documentation

## Why

The README had not kept pace with the recent shell and offline improvements. It still claimed that only four game windows could be open even though the window manager no longer imposes that limit, and it omitted several implemented features.

## Impact

The project overview now describes observable behavior without imposing a stale fixed window limit or making unverifiable marketing claims.

## Validation

- `git diff --check`
- `bun run test` — 80 tests passed