### PR TITLE
Add Astro Flash recovery controls

### DIFF
--- a/site/css/main.css
+++ b/site/css/main.css
@@ -2122,6 +2122,16 @@ html[data-xp-appearance="silver"] {
     margin: 0 0 10px;
 }
 
+.project-recovery-group {
+    margin: 12px 0 10px;
+    padding: 8px 8px 2px;
+}
+
+.project-recovery-group p {
+    margin: 2px 0 8px;
+    color: #444;
+}
+
 .project-suggestions-link {
     color: #0000ee;
 }

--- a/site/js/filesystem.js
+++ b/site/js/filesystem.js
@@ -560,6 +560,14 @@
     [...nodes[WELL_KNOWN.RECYCLE_BIN].children].forEach(destroy);
   };
 
+  // Restores the filesystem to the original protected folder structure.
+  // Registered handlers and subscribers deliberately remain active so this
+  // is safe to use from the running application, not only from tests.
+  const reset = () => {
+    nodes = seedNodes();
+    emitChange();
+  };
+
   const getContent = (id) => {
     const node = requireNode(id);
     return node.type === "file" ? node.content : null;
@@ -644,6 +652,7 @@
     restore,
     destroy,
     emptyRecycleBin,
+    reset,
     getContent,
     setContent,
     registerFileType,

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -27,6 +27,18 @@ let screenSaverWired = false;
 const gamesList = window.FLASH_GAMES;
 
 const DISPLAY_SETTINGS_KEY = "displaySettings";
+const USER_STORAGE_KEYS = Object.freeze([
+  DISPLAY_SETTINGS_KEY,
+  "clockOffsetMs",
+  "desktopIconPositions",
+  "desktopLayoutSettings",
+  "favorites",
+  "gameStats",
+  "gameVolumes",
+  "isMuted",
+  "runHistory",
+  "volume",
+]);
 const MAX_CUSTOM_WALLPAPER_BYTES = 1024 * 1024;
 const DISPLAY_WALLPAPERS = {
   bliss: 'url("../assets/xp/bliss.jpg")',
@@ -3538,6 +3550,21 @@ fs.registerFileType(".game", (file) => {
   }
 });
 
+const restoreDefaultDesktop = () => {
+  Object.keys(gamesList).forEach((gameId) => {
+    fs.findByApp(gameId).forEach((node) => fs.destroy(node.id));
+  });
+  localStorage.removeItem("desktopIconPositions");
+  localStorage.removeItem("desktopLayoutSettings");
+  syncGameFiles();
+};
+
+const resetAstroFlash = () => {
+  USER_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
+  fs.reset();
+  syncGameFiles();
+};
+
 const NOTEPAD_ID = "__notepad";
 
 const openNotepad = (file = null) => {
@@ -4685,6 +4712,30 @@ const wireProjectSettings = (win) => {
   repairButton.textContent = "Repair Offline Files";
   actions.append(checkButton, applyButton, repairButton);
 
+  const recoveryGroup = document.createElement("fieldset");
+  recoveryGroup.className = "project-recovery-group";
+  const recoveryLegend = document.createElement("legend");
+  recoveryLegend.textContent = "Recovery";
+  const recoveryDescription = document.createElement("p");
+  recoveryDescription.textContent =
+    "Restore the original desktop or erase personal files and preferences. Offline files are preserved.";
+  const recoveryActions = document.createElement("div");
+  recoveryActions.className = "project-settings-actions";
+  const restoreDesktopButton = document.createElement("button");
+  restoreDesktopButton.type = "button";
+  restoreDesktopButton.className = "xp-btn";
+  restoreDesktopButton.textContent = "Restore Default Desktop";
+  const resetButton = document.createElement("button");
+  resetButton.type = "button";
+  resetButton.className = "xp-btn";
+  resetButton.textContent = "Reset Astro Flash";
+  recoveryActions.append(restoreDesktopButton, resetButton);
+  recoveryGroup.append(
+    recoveryLegend,
+    recoveryDescription,
+    recoveryActions,
+  );
+
   const transientPhases = new Set([
     "starting",
     "downloading",
@@ -4767,6 +4818,26 @@ const wireProjectSettings = (win) => {
       status.textContent = error.message;
     });
   });
+  restoreDesktopButton.addEventListener("click", async () => {
+    const accepted = await XPDialogs.confirm(
+      "Restore all game shortcuts and the default desktop layout?\n\nYour personal files and other settings will be preserved.",
+      "Restore Default Desktop",
+      "question",
+    );
+    if (!accepted) return;
+    restoreDefaultDesktop();
+    window.location.reload();
+  });
+  resetButton.addEventListener("click", async () => {
+    const accepted = await XPDialogs.confirm(
+      "Reset Astro Flash to its original state?\n\nThis will permanently delete your personal files and reset all preferences. This cannot be undone.",
+      "Reset Astro Flash",
+      "warning",
+    );
+    if (!accepted) return;
+    resetAstroFlash();
+    window.location.reload();
+  });
 
   const suggestions = document.createElement("a");
   suggestions.className = "project-suggestions-link";
@@ -4781,6 +4852,7 @@ const wireProjectSettings = (win) => {
     status,
     downloadProgress,
     actions,
+    recoveryGroup,
     suggestions,
   );
 };

--- a/tests/fs_node_tests.js
+++ b/tests/fs_node_tests.js
@@ -179,4 +179,22 @@ reloaded.createFile(fs.MY_DOCUMENTS, "ping.txt");
 assert.ok(notified > 0, "listener fired");
 unsubscribe();
 
+// ---- Production reset preserves integrations and reseeds the filesystem ----
+let resetNotified = 0;
+reloaded.subscribe(() => {
+    resetNotified += 1;
+});
+reloaded.registerFileType(".txt", () => {});
+reloaded.createFile(reloaded.MY_DOCUMENTS, "delete-on-reset.txt");
+reloaded.reset();
+assert.strictEqual(
+    reloaded.findChild(reloaded.MY_DOCUMENTS, "delete-on-reset.txt"),
+    null,
+    "reset removes user-created files"
+);
+assert.ok(reloaded.getNode(reloaded.DESKTOP), "reset restores the seeded desktop");
+assert.strictEqual(resetNotified, 2, "create and reset both notify subscribers");
+const afterReset = reloaded.createFile(reloaded.MY_DOCUMENTS, "after-reset.txt");
+assert.strictEqual(reloaded.open(afterReset.id), true, "reset preserves file handlers");
+
 console.log("filesystem tests passed");


### PR DESCRIPTION
## What changed

- add **Restore Default Desktop** to recreate game shortcuts and reset desktop layout without deleting personal files
- add **Reset Astro Flash** to restore the original virtual filesystem and clear user preferences
- preserve offline downloads during both recovery flows
- add a production-safe virtual filesystem reset API and regression coverage

## Why

Deleted or moved content could leave Astro Flash without a clear way to return to its original state. These settings provide both a safe desktop repair and an explicitly confirmed full reset.

## Validation

- `bun run test` — 81 tests passed
- JavaScript syntax checks passed
- 39 sourced icons validated with no fallbacks
- `git diff --check` passed