### PR TITLE
Fix Cloudflare Worker runtime entrypoint

### DIFF
--- a/tests/catalog_worker_node_tests.mjs
+++ b/tests/catalog_worker_node_tests.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  default as catalogWorker,
   legacyAssetUrl,
   parseGameDetails,
   parseSearchResults,
@@ -83,5 +84,22 @@ assert.equal(
   "https://infinity.unstable.life/Flashpoint/Legacy/htdocs/localflash/game/main.swf",
 );
 assert.throws(() => legacyAssetUrl("content/localflash/../secret"), /Invalid Legacy/);
+
+const originalFetch = globalThis.fetch;
+try {
+  globalThis.fetch = async () =>
+    new Response(searchHtml, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  const runtimeResponse = await catalogWorker.fetch(
+    new Request("https://flash.example/api/games?q=bike%20mania"),
+    { binding: "Cloudflare environment object" },
+    { waitUntil() {} },
+  );
+  assert.equal(runtimeResponse.status, 200);
+  assert.equal((await runtimeResponse.json()).games[0].title, "Bike Mania Arena");
+} finally {
+  globalThis.fetch = originalFetch;
+}
 
 console.log("catalog worker tests passed");

--- a/worker/catalog-worker.mjs
+++ b/worker/catalog-worker.mjs
@@ -330,4 +330,8 @@ export async function handleRequest(request, fetchObject = fetch) {
   }
 }
 
-export default { fetch: handleRequest };
+export default {
+  fetch(request) {
+    return handleRequest(request);
+  },
+};


### PR DESCRIPTION
## Summary
- prevent Cloudflare's environment argument from replacing the injected fetch function
- add a regression test covering the production Worker `fetch(request, env, ctx)` signature

## Validation
- `node tests/catalog_worker_node_tests.mjs`
- `bun run test` (89 tests)