### PR TITLE
Restore product name and skip docs-only CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,9 +2,19 @@ name: Test and deploy GitHub Pages
 
 on:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "**/LICENSE"
+      - "**/LICENSE.*"
+      - "**/LICENSE-*"
   push:
     branches:
       - main
+    paths-ignore:
+      - "**/*.md"
+      - "**/LICENSE"
+      - "**/LICENSE.*"
+      - "**/LICENSE-*"
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Astro Flash
+# Astro Flash Collection
 
 A Windows XP-style desktop for playing classic Flash, HTML5, and DOS games in
 the browser.
 
-[Open Astro Flash](https://flash.4st.li/)
+[Open Astro Flash Collection](https://flash.4st.li/)
 
 ## Highlights
 


### PR DESCRIPTION
## Summary
- restore the README product name to Astro Flash Collection
- skip the Pages build/deploy workflow when every changed file is Markdown or a license file
- preserve normal CI for mixed source/documentation changes and manual workflow dispatches

## Validation
- `bun run test` (89 tests)
- `git diff --check`