### PR TITLE
Add ESLint and Prettier checks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check formatting and lint
+        run: bun run quality
+
       - name: Run tests
         run: bun run test
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+source-media/
+site/iframe/inside-the-firewall/
+site/swf/
+site/vendor/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/bun.lock
+++ b/bun.lock
@@ -8,8 +8,15 @@
         "sharp": "^0.35.3",
       },
       "devDependencies": {
+        "@eslint/js": "10.0.1",
         "@types/bun": "^1.3.14",
-        "typescript": "^7.0.2",
+        "@typescript/native": "npm:typescript@7.0.2",
+        "eslint": "10.8.0",
+        "eslint-config-prettier": "10.1.8",
+        "globals": "17.8.0",
+        "prettier": "3.9.6",
+        "typescript": "6.0.2",
+        "typescript-eslint": "8.65.0",
         "workbox-build": "^7.4.1",
         "wrangler": "4.114.0",
       },
@@ -266,6 +273,32 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.10.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.7.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw=="],
+
+    "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
@@ -408,13 +441,39 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.65.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/type-utils": "8.65.0", "@typescript-eslint/utils": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.65.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.65.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.65.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.65.0", "@typescript-eslint/types": "^8.65.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0" } }, "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.65.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/utils": "8.65.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.65.0", "", {}, "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.65.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.65.0", "@typescript-eslint/tsconfig-utils": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.65.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A=="],
+
+    "@typescript/native": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -456,9 +515,11 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
-    "acorn": ["acorn@8.14.0", "", { "bin": "bin/acorn" }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
-    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -482,7 +543,7 @@
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
-    "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "browserslist": ["browserslist@4.24.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001688", "electron-to-chromium": "^1.5.73", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.1" }, "bin": "cli.js" }, "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A=="],
 
@@ -528,6 +589,8 @@
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
@@ -560,6 +623,24 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@10.8.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.7.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ=="],
+
+    "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
@@ -570,11 +651,23 @@
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
     "fast-uri": ["fast-uri@3.0.5", "", {}, "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
     "filelist": ["filelist@1.0.4", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.3", "", {}, "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ=="],
 
     "for-each": ["for-each@0.3.3", "", { "dependencies": { "is-callable": "^1.1.3" } }, "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw=="],
 
@@ -602,7 +695,9 @@
 
     "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
-    "globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@17.8.0", "", {}, "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
@@ -626,6 +721,10 @@
 
     "idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
 
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
@@ -644,9 +743,13 @@
 
     "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
     "is-generator-function": ["is-generator-function@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "get-proto": "^1.0.0", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
 
@@ -690,9 +793,13 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": "bin/jsesc" }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -700,9 +807,15 @@
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
@@ -716,11 +829,13 @@
 
     "miniflare": ["miniflare@4.20260722.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.28.0", "workerd": "1.20260722.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw=="],
 
-    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
 
@@ -730,9 +845,17 @@
 
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -746,9 +869,13 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.0.0", "", {}, "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
     "pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
@@ -838,9 +965,15 @@
 
     "terser": ["terser@5.37.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.8.2", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": "bin/terser" }, "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA=="],
 
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@0.16.0", "", {}, "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="],
 
@@ -852,7 +985,9 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
-    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+
+    "typescript-eslint": ["typescript-eslint@8.65.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.65.0", "@typescript-eslint/parser": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/utils": "8.65.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
@@ -878,6 +1013,8 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.1.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg=="],
 
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
     "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
 
     "whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
@@ -891,6 +1028,8 @@
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
 
     "which-typed-array": ["which-typed-array@1.1.18", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "workbox-background-sync": ["workbox-background-sync@7.4.1", "", { "dependencies": { "idb": "^7.0.1", "workbox-core": "7.4.1" } }, "sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g=="],
 
@@ -932,9 +1071,13 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "@apideck/better-ajv-errors/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -944,9 +1087,15 @@
 
     "@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@babel/plugin-transform-classes/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
+
     "@babel/preset-env/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
+
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
@@ -954,11 +1103,25 @@
 
     "@rollup/pluginutils/@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
+    "@rollup/pluginutils/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
+
+    "@typescript-eslint/parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@typescript-eslint/project-service/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@typescript-eslint/type-utils/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@typescript-eslint/typescript-estree/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
+
+    "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "jake/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -970,7 +1133,15 @@
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "terser/acorn": ["acorn@8.14.0", "", { "bin": "bin/acorn" }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+
+    "workbox-build/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "@apideck/better-ajv-errors/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
     "jake/minimatch/brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
@@ -1023,6 +1194,8 @@
     "miniflare/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
 
     "miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
+
+    "workbox-build/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/catalog/catalog.ts
+++ b/catalog/catalog.ts
@@ -2,419 +2,419 @@ const SEARCH_ORIGIN = "https://flashpointarchive.org";
 const PLAYER_ORIGIN = "https://ooooooooo.ooo";
 const DOWNLOAD_ORIGIN = "https://download.unstable.life";
 const IMAGE_ORIGIN = "https://infinity.unstable.life";
-const LEGACY_SERVER =
-	"https://infinity.unstable.life/Flashpoint/Legacy/htdocs";
+const LEGACY_SERVER = "https://infinity.unstable.life/Flashpoint/Legacy/htdocs";
 const MAX_LEGACY_ASSET_BYTES = 64 * 1024 * 1024;
 export const UUID_PATTERN =
-	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export type CatalogFetcher = (
-	input: string | URL | Request,
-	init?: RequestInit,
+  input: string | URL | Request,
+  init?: RequestInit,
 ) => Promise<Response>;
 
 const NAMED_ENTITIES = Object.freeze<Record<string, string>>({
-	amp: "&",
-	apos: "'",
-	gt: ">",
-	lt: "<",
-	quot: '"',
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  quot: '"',
 });
 
 export interface CatalogSearchResult {
-	uuid: string;
-	title: string;
-	developer: string;
-	platform: string;
-	tags: string[];
-	logoUrl: string;
-	potentiallyCompatible: boolean;
+  uuid: string;
+  title: string;
+  developer: string;
+  platform: string;
+  tags: string[];
+  logoUrl: string;
+  potentiallyCompatible: boolean;
 }
 
 export interface CatalogGameDetails {
-	uuid: string;
-	title: string;
-	developer: string;
-	sourceUrl: string;
-	library: string;
-	platform: string;
-	status: string;
-	applicationPath: string;
-	launchCommand: string;
-	tags: string[];
-	logoUrl: string;
-	downloadUrl: string;
-	packageType: "gamezip" | "legacy" | null;
-	legacyFallback: boolean;
-	compatible: boolean;
-	incompatibleReason: string | null;
-	upstreamUrl: string;
-	gameZipUrl: string | null;
-	legacyServerUrl: string | null;
+  uuid: string;
+  title: string;
+  developer: string;
+  sourceUrl: string;
+  library: string;
+  platform: string;
+  status: string;
+  applicationPath: string;
+  launchCommand: string;
+  tags: string[];
+  logoUrl: string;
+  downloadUrl: string;
+  packageType: "gamezip" | "legacy" | null;
+  legacyFallback: boolean;
+  compatible: boolean;
+  incompatibleReason: string | null;
+  upstreamUrl: string;
+  gameZipUrl: string | null;
+  legacyServerUrl: string | null;
 }
 
 const errorMessage = (error: unknown, fallback: string): string =>
-	error instanceof Error && error.message ? error.message : fallback;
+  error instanceof Error && error.message ? error.message : fallback;
 
 const decodeHtml = (value = ""): string =>
-	value.replace(
-		/&(?:#(\d+)|#x([0-9a-f]+)|(amp|apos|gt|lt|quot));/gi,
-		(_entity, decimal: string, hexadecimal: string, named: string) => {
-			if (decimal) return String.fromCodePoint(Number(decimal));
-			if (hexadecimal) {
-				return String.fromCodePoint(Number.parseInt(hexadecimal, 16));
-			}
-			return NAMED_ENTITIES[named.toLowerCase()];
-		},
-	);
+  value.replace(
+    /&(?:#(\d+)|#x([0-9a-f]+)|(amp|apos|gt|lt|quot));/gi,
+    (_entity, decimal: string, hexadecimal: string, named: string) => {
+      if (decimal) return String.fromCodePoint(Number(decimal));
+      if (hexadecimal) {
+        return String.fromCodePoint(Number.parseInt(hexadecimal, 16));
+      }
+      return NAMED_ENTITIES[named.toLowerCase()];
+    },
+  );
 
 const plainText = (value = ""): string =>
-	decodeHtml(value).replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+  decodeHtml(value)
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 
 export function parseSearchResults(html: string): CatalogSearchResult[] {
-	const games: CatalogSearchResult[] = [];
-	const blocks = html.match(
-		/<div class="fp-search-result">[\s\S]*?(?=<div class="fp-search-result">|<\/div>\s*<\/div>\s*<div class="fp-search-navigation">|$)/g,
-	);
-	for (const block of blocks ?? []) {
-		const id = block.match(/\/view\?id=([0-9a-f-]{36})/i)?.[1];
-		const title = block.match(
-			/class="fp-search-result-title"[^>]*>([\s\S]*?)<\/a>/i,
-		)?.[1];
-		if (!id || !title || !UUID_PATTERN.test(id)) continue;
-		const creator = block.match(
-			/class="fp-search-result-creator"[^>]*>([\s\S]*?)<\/span>/i,
-		)?.[1];
-		const info = plainText(
-			block.match(
-				/class="fp-search-result-info"[^>]*>([\s\S]*?)<\/div>/i,
-			)?.[1] ?? "",
-		);
-		const [platformPart = "", tagPart = ""] = info.split(
-			/\s+game\s+-\s+/i,
-		);
-		const tags = tagPart
-			.split(/\s+-\s+/)
-			.map((tag) => tag.trim())
-			.filter(Boolean);
-		const uuid = id.toLowerCase();
-		games.push({
-			uuid,
-			title: plainText(title),
-			developer: plainText(creator ?? "").replace(/^by\s+/i, ""),
-			platform: platformPart,
-			tags,
-			logoUrl: `/api/games/${uuid}/logo`,
-			potentiallyCompatible: platformPart.toLowerCase() === "flash",
-		});
-	}
-	return games;
+  const games: CatalogSearchResult[] = [];
+  const blocks = html.match(
+    /<div class="fp-search-result">[\s\S]*?(?=<div class="fp-search-result">|<\/div>\s*<\/div>\s*<div class="fp-search-navigation">|$)/g,
+  );
+  for (const block of blocks ?? []) {
+    const id = block.match(/\/view\?id=([0-9a-f-]{36})/i)?.[1];
+    const title = block.match(
+      /class="fp-search-result-title"[^>]*>([\s\S]*?)<\/a>/i,
+    )?.[1];
+    if (!id || !title || !UUID_PATTERN.test(id)) continue;
+    const creator = block.match(
+      /class="fp-search-result-creator"[^>]*>([\s\S]*?)<\/span>/i,
+    )?.[1];
+    const info = plainText(
+      block.match(
+        /class="fp-search-result-info"[^>]*>([\s\S]*?)<\/div>/i,
+      )?.[1] ?? "",
+    );
+    const [platformPart = "", tagPart = ""] = info.split(/\s+game\s+-\s+/i);
+    const tags = tagPart
+      .split(/\s+-\s+/)
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+    const uuid = id.toLowerCase();
+    games.push({
+      uuid,
+      title: plainText(title),
+      developer: plainText(creator ?? "").replace(/^by\s+/i, ""),
+      platform: platformPart,
+      tags,
+      logoUrl: `/api/games/${uuid}/logo`,
+      potentiallyCompatible: platformPart.toLowerCase() === "flash",
+    });
+  }
+  return games;
 }
 
 const attribute = (html: string, name: string): string =>
-	decodeHtml(
-		html.match(new RegExp(`\\b${name}="([^"]*)"`, "i"))?.[1] ?? "",
-	);
+  decodeHtml(html.match(new RegExp(`\\b${name}="([^"]*)"`, "i"))?.[1] ?? "");
 
 const detailRows = (html: string): Map<string, string> => {
-	const rows = new Map<string, string>();
-	for (const match of html.matchAll(
-		/<div class="row">\s*<div class="field">([\s\S]*?)<\/div>\s*<div class="value">([\s\S]*?)<\/div>\s*<\/div>/gi,
-	)) {
-		const label = plainText(match[1]).replace(/:$/, "");
-		if (!rows.has(label)) rows.set(label, plainText(match[2]));
-	}
-	return rows;
+  const rows = new Map<string, string>();
+  for (const match of html.matchAll(
+    /<div class="row">\s*<div class="field">([\s\S]*?)<\/div>\s*<div class="value">([\s\S]*?)<\/div>\s*<\/div>/gi,
+  )) {
+    const label = plainText(match[1]).replace(/:$/, "");
+    if (!rows.has(label)) rows.set(label, plainText(match[2]));
+  }
+  return rows;
 };
 
 export function parseGameDetails(
-	html: string,
-	requestOrigin: string,
-	uuid: string,
+  html: string,
+  requestOrigin: string,
+  uuid: string,
 ): CatalogGameDetails {
-	if (!UUID_PATTERN.test(uuid)) throw new Error("Invalid game UUID");
-	const rows = detailRows(html);
-	const gameZipUrl = attribute(html, "data-game-zip");
-	const legacyServer = attribute(html, "data-legacy-server");
-	const launchCommand = attribute(html, "data-launch-command");
-	const title = plainText(
-		html.match(/<div class="header-large">([\s\S]*?)<\/div>/i)?.[1] ?? "",
-	);
-	const tagsBlock =
-		html.match(
-			/<div class="field">Tags:<\/div>\s*<div class="value">([\s\S]*?)<\/div>/i,
-		)?.[1] ?? "";
-	const tags = [...tagsBlock.matchAll(/<li>([\s\S]*?)<\/li>/gi)].map(
-		(match) => plainText(match[1]),
-	);
-	const normalizedUuid = uuid.toLowerCase();
-	const expectedZipPath = new RegExp(
-		`^/gib-roms/Games/${normalizedUuid}-\\d+\\.zip$`,
-		"i",
-	);
-	let hasSafeGameZip = false;
-	if (gameZipUrl) {
-		try {
-			const parsed = new URL(gameZipUrl);
-			hasSafeGameZip =
-				parsed.origin === DOWNLOAD_ORIGIN &&
-				expectedZipPath.test(parsed.pathname);
-		} catch {
-			hasSafeGameZip = false;
-		}
-	}
-	const platform = rows.get("Platform") ?? "";
-	const library = rows.get("Library") ?? "";
-	const status = rows.get("Status") ?? "";
-	const applicationPath = rows.get("Application Path") ?? "";
-	const hasSafeLegacyServer =
-		legacyServer.replace(/\/+$/, "") === LEGACY_SERVER;
-	const playableFlash =
-		platform.toLowerCase() === "flash" &&
-		library.toLowerCase() === "games" &&
-		status.toLowerCase() === "playable" &&
-		/(?:flash\s*player|flashplayer)/i.test(applicationPath) &&
-		/\.swf(?:$|[?#])/i.test(launchCommand);
-	const compatible =
-		playableFlash && (hasSafeGameZip || hasSafeLegacyServer);
-	const packageType = hasSafeGameZip
-		? "gamezip"
-		: hasSafeLegacyServer
-			? "legacy"
-			: null;
+  if (!UUID_PATTERN.test(uuid)) throw new Error("Invalid game UUID");
+  const rows = detailRows(html);
+  const gameZipUrl = attribute(html, "data-game-zip");
+  const legacyServer = attribute(html, "data-legacy-server");
+  const launchCommand = attribute(html, "data-launch-command");
+  const title = plainText(
+    html.match(/<div class="header-large">([\s\S]*?)<\/div>/i)?.[1] ?? "",
+  );
+  const tagsBlock =
+    html.match(
+      /<div class="field">Tags:<\/div>\s*<div class="value">([\s\S]*?)<\/div>/i,
+    )?.[1] ?? "";
+  const tags = [...tagsBlock.matchAll(/<li>([\s\S]*?)<\/li>/gi)].map((match) =>
+    plainText(match[1]),
+  );
+  const normalizedUuid = uuid.toLowerCase();
+  const expectedZipPath = new RegExp(
+    `^/gib-roms/Games/${normalizedUuid}-\\d+\\.zip$`,
+    "i",
+  );
+  let hasSafeGameZip = false;
+  if (gameZipUrl) {
+    try {
+      const parsed = new URL(gameZipUrl);
+      hasSafeGameZip =
+        parsed.origin === DOWNLOAD_ORIGIN &&
+        expectedZipPath.test(parsed.pathname);
+    } catch {
+      hasSafeGameZip = false;
+    }
+  }
+  const platform = rows.get("Platform") ?? "";
+  const library = rows.get("Library") ?? "";
+  const status = rows.get("Status") ?? "";
+  const applicationPath = rows.get("Application Path") ?? "";
+  const hasSafeLegacyServer =
+    legacyServer.replace(/\/+$/, "") === LEGACY_SERVER;
+  const playableFlash =
+    platform.toLowerCase() === "flash" &&
+    library.toLowerCase() === "games" &&
+    status.toLowerCase() === "playable" &&
+    /(?:flash\s*player|flashplayer)/i.test(applicationPath) &&
+    /\.swf(?:$|[?#])/i.test(launchCommand);
+  const compatible = playableFlash && (hasSafeGameZip || hasSafeLegacyServer);
+  const packageType = hasSafeGameZip
+    ? "gamezip"
+    : hasSafeLegacyServer
+      ? "legacy"
+      : null;
 
-	return {
-		uuid: normalizedUuid,
-		title,
-		developer: rows.get("Developer") ?? "",
-		sourceUrl: rows.get("Source") ?? "",
-		library,
-		platform,
-		status,
-		applicationPath,
-		launchCommand,
-		tags,
-		logoUrl: `${requestOrigin}/api/games/${normalizedUuid}/logo`,
-		downloadUrl: `${requestOrigin}/api/games/${normalizedUuid}/download`,
-		packageType,
-		legacyFallback: hasSafeLegacyServer,
-		compatible,
-		incompatibleReason: compatible
-			? null
-			: !playableFlash
-				? "This entry is not a playable Flash game."
-				: "This entry does not have supported Flashpoint game data.",
-		upstreamUrl: `${SEARCH_ORIGIN}/view?id=${normalizedUuid}`,
-		gameZipUrl: hasSafeGameZip ? gameZipUrl : null,
-		legacyServerUrl: hasSafeLegacyServer ? LEGACY_SERVER : null,
-	};
+  return {
+    uuid: normalizedUuid,
+    title,
+    developer: rows.get("Developer") ?? "",
+    sourceUrl: rows.get("Source") ?? "",
+    library,
+    platform,
+    status,
+    applicationPath,
+    launchCommand,
+    tags,
+    logoUrl: `${requestOrigin}/api/games/${normalizedUuid}/logo`,
+    downloadUrl: `${requestOrigin}/api/games/${normalizedUuid}/download`,
+    packageType,
+    legacyFallback: hasSafeLegacyServer,
+    compatible,
+    incompatibleReason: compatible
+      ? null
+      : !playableFlash
+        ? "This entry is not a playable Flash game."
+        : "This entry does not have supported Flashpoint game data.",
+    upstreamUrl: `${SEARCH_ORIGIN}/view?id=${normalizedUuid}`,
+    gameZipUrl: hasSafeGameZip ? gameZipUrl : null,
+    legacyServerUrl: hasSafeLegacyServer ? LEGACY_SERVER : null,
+  };
 }
 
 export function legacyAssetUrl(archivePath: unknown): string {
-	const decoded = decodeURIComponent(String(archivePath ?? ""));
-	if (
-		decoded.length > 2048 ||
-		!decoded.startsWith("content/") ||
-		decoded.includes("\\") ||
-		decoded.includes("\0")
-	) {
-		throw new Error("Invalid Legacy asset path.");
-	}
-	const parts = decoded.split("/");
-	if (
-		parts.length < 3 ||
-		parts.some((part) => !part || part === "." || part === "..") ||
-		!/^[a-z0-9.-]+$/i.test(parts[1])
-	) {
-		throw new Error("Invalid Legacy asset path.");
-	}
-	return `${LEGACY_SERVER}/${parts.slice(1).map(encodeURIComponent).join("/")}`;
+  const decoded = decodeURIComponent(String(archivePath ?? ""));
+  if (
+    decoded.length > 2048 ||
+    !decoded.startsWith("content/") ||
+    decoded.includes("\\") ||
+    decoded.includes("\0")
+  ) {
+    throw new Error("Invalid Legacy asset path.");
+  }
+  const parts = decoded.split("/");
+  if (
+    parts.length < 3 ||
+    parts.some((part) => !part || part === "." || part === "..") ||
+    !/^[a-z0-9.-]+$/i.test(parts[1])
+  ) {
+    throw new Error("Invalid Legacy asset path.");
+  }
+  return `${LEGACY_SERVER}/${parts.slice(1).map(encodeURIComponent).join("/")}`;
 }
 
 const json = (
-	value: unknown,
-	status = 200,
-	extraHeaders: HeadersInit = {},
+  value: unknown,
+  status = 200,
+  extraHeaders: HeadersInit = {},
 ): Response =>
-	Response.json(value, {
-		status,
-		headers: {
-			"Access-Control-Allow-Origin": "*",
-			"Cache-Control": status === 200 ? "public, max-age=900" : "no-store",
-			"Content-Type": "application/json; charset=utf-8",
-			...Object.fromEntries(new Headers(extraHeaders)),
-		},
-	});
+  Response.json(value, {
+    status,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": status === 200 ? "public, max-age=900" : "no-store",
+      "Content-Type": "application/json; charset=utf-8",
+      ...Object.fromEntries(new Headers(extraHeaders)),
+    },
+  });
 
 const fetchText = async (
-	fetcher: CatalogFetcher,
-	url: string | URL,
+  fetcher: CatalogFetcher,
+  url: string | URL,
 ): Promise<string> => {
-	const response = await fetcher(url, {
-		headers: { "User-Agent": "Astro-Flash-Catalog/1.0" },
-	});
-	if (!response.ok) {
-		throw new Error(`Flashpoint upstream returned ${response.status}.`);
-	}
-	return response.text();
+  const response = await fetcher(url, {
+    headers: { "User-Agent": "Astro-Flash-Catalog/1.0" },
+  });
+  if (!response.ok) {
+    throw new Error(`Flashpoint upstream returned ${response.status}.`);
+  }
+  return response.text();
 };
 
 const fetchPlayerDetails = async (
-	fetcher: CatalogFetcher,
-	uuid: string,
-	requestOrigin: string,
+  fetcher: CatalogFetcher,
+  uuid: string,
+  requestOrigin: string,
 ): Promise<CatalogGameDetails> => {
-	const html = await fetchText(
-		fetcher,
-		`${PLAYER_ORIGIN}/?id=${encodeURIComponent(uuid)}`,
-	);
-	return parseGameDetails(html, requestOrigin, uuid);
+  const html = await fetchText(
+    fetcher,
+    `${PLAYER_ORIGIN}/?id=${encodeURIComponent(uuid)}`,
+  );
+  return parseGameDetails(html, requestOrigin, uuid);
 };
 
 const proxyResponse = (upstream: Response, cacheSeconds: number): Response => {
-	const headers = new Headers({
-		"Access-Control-Allow-Origin": "*",
-		"Cache-Control": `public, max-age=${cacheSeconds}`,
-		"Content-Type":
-			upstream.headers.get("content-type") ?? "application/octet-stream",
-	});
-	for (const name of [
-		"content-length",
-		"content-disposition",
-		"etag",
-		"last-modified",
-	]) {
-		const value = upstream.headers.get(name);
-		if (value) headers.set(name, value);
-	}
-	return new Response(upstream.body, { status: upstream.status, headers });
+  const headers = new Headers({
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": `public, max-age=${cacheSeconds}`,
+    "Content-Type":
+      upstream.headers.get("content-type") ?? "application/octet-stream",
+  });
+  for (const name of [
+    "content-length",
+    "content-disposition",
+    "etag",
+    "last-modified",
+  ]) {
+    const value = upstream.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  return new Response(upstream.body, { status: upstream.status, headers });
 };
 
 const checkedAssetResponse = (
-	upstream: Response,
-	cacheSeconds: number,
+  upstream: Response,
+  cacheSeconds: number,
 ): Response => {
-	const length = Number(upstream.headers.get("content-length")) || null;
-	if (length && length > MAX_LEGACY_ASSET_BYTES) {
-		return json(
-			{ error: "Legacy asset exceeds the supported size limit." },
-			413,
-		);
-	}
-	return proxyResponse(upstream, cacheSeconds);
+  const length = Number(upstream.headers.get("content-length")) || null;
+  if (length && length > MAX_LEGACY_ASSET_BYTES) {
+    return json(
+      { error: "Legacy asset exceeds the supported size limit." },
+      413,
+    );
+  }
+  return proxyResponse(upstream, cacheSeconds);
 };
 
 export async function handleCatalogRequest(
-	request: Request,
-	fetcher: CatalogFetcher = fetch,
+  request: Request,
+  fetcher: CatalogFetcher = fetch,
 ): Promise<Response> {
-	if (request.method === "OPTIONS") {
-		return new Response(null, {
-			status: 204,
-			headers: {
-				"Access-Control-Allow-Headers": "Content-Type",
-				"Access-Control-Allow-Methods": "GET, OPTIONS",
-				"Access-Control-Allow-Origin": "*",
-			},
-		});
-	}
-	if (request.method !== "GET") {
-		return json({ error: "Method not allowed." }, 405);
-	}
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  }
+  if (request.method !== "GET") {
+    return json({ error: "Method not allowed." }, 405);
+  }
 
-	const url = new URL(request.url);
-	const path = url.pathname.replace(/\/+$/, "") || "/";
-	if (path === "/api/games") {
-		const query = (url.searchParams.get("q") ?? "").trim();
-		if (!query || query.length > 100) {
-			return json(
-				{ error: "Enter a search between 1 and 100 characters." },
-				400,
-			);
-		}
-		try {
-			const upstream = new URL("/search", SEARCH_ORIGIN);
-			upstream.searchParams.set("query", query);
-			const html = await fetchText(fetcher, upstream);
-			return json({ games: parseSearchResults(html) });
-		} catch (error) {
-			return json({ error: errorMessage(error, "Catalog search failed.") }, 502);
-		}
-	}
+  const url = new URL(request.url);
+  const path = url.pathname.replace(/\/+$/, "") || "/";
+  if (path === "/api/games") {
+    const query = (url.searchParams.get("q") ?? "").trim();
+    if (!query || query.length > 100) {
+      return json(
+        { error: "Enter a search between 1 and 100 characters." },
+        400,
+      );
+    }
+    try {
+      const upstream = new URL("/search", SEARCH_ORIGIN);
+      upstream.searchParams.set("query", query);
+      const html = await fetchText(fetcher, upstream);
+      return json({ games: parseSearchResults(html) });
+    } catch (error) {
+      return json(
+        { error: errorMessage(error, "Catalog search failed.") },
+        502,
+      );
+    }
+  }
 
-	const match = path.match(
-		/^\/api\/games\/([0-9a-f-]{36})(?:\/(download|logo|asset))?$/i,
-	);
-	if (!match || !UUID_PATTERN.test(match[1])) {
-		return json({ error: "Not found." }, 404);
-	}
-	const uuid = match[1].toLowerCase();
-	const action = match[2];
-	try {
-		if (action === "logo") {
-			const logoPath = `Logos/${uuid.slice(0, 2)}/${uuid.slice(2, 4)}/${uuid}.png`;
-			const upstream = await fetcher(
-				`${IMAGE_ORIGIN}/images/${logoPath}?type=jpg`,
-			);
-			if (!upstream.ok) {
-				return json({ error: "Logo not found." }, upstream.status);
-			}
-			return proxyResponse(upstream, 86400);
-		}
-		const details = await fetchPlayerDetails(fetcher, uuid, url.origin);
-		if (action === "download") {
-			if (!details.compatible) {
-				return json({ error: details.incompatibleReason }, 422);
-			}
-			const launchUrl =
-				details.packageType === "legacy"
-					? new URL(details.launchCommand)
-					: null;
-			const upstreamUrl =
-				details.packageType === "gamezip"
-					? details.gameZipUrl
-					: legacyAssetUrl(
-							`content/${launchUrl?.hostname}${launchUrl?.pathname}`,
-						);
-			const upstream = await fetcher(upstreamUrl as string, {
-				headers: { "User-Agent": "Astro-Flash-Catalog/1.0" },
-			});
-			if (!upstream.ok) {
-				return json(
-					{ error: `Game download returned ${upstream.status}.` },
-					502,
-				);
-			}
-			return details.packageType === "legacy"
-				? checkedAssetResponse(upstream, 3600)
-				: proxyResponse(upstream, 3600);
-		}
-		if (action === "asset") {
-			if (!details.compatible || !details.legacyServerUrl) {
-				return json(
-					{ error: "Legacy assets are not available for this game." },
-					422,
-				);
-			}
-			const upstream = await fetcher(
-				legacyAssetUrl(url.searchParams.get("path")),
-				{ headers: { "User-Agent": "Astro-Flash-Catalog/1.0" } },
-			);
-			if (!upstream.ok) {
-				return json(
-					{ error: `Legacy asset returned ${upstream.status}.` },
-					404,
-				);
-			}
-			return checkedAssetResponse(upstream, 86400);
-		}
-		const {
-			gameZipUrl: _privateUpstreamUrl,
-			legacyServerUrl: _privateLegacyServer,
-			...publicDetails
-		} = details;
-		return json(publicDetails);
-	} catch (error) {
-		return json({ error: errorMessage(error, "Game lookup failed.") }, 502);
-	}
+  const match = path.match(
+    /^\/api\/games\/([0-9a-f-]{36})(?:\/(download|logo|asset))?$/i,
+  );
+  if (!match || !UUID_PATTERN.test(match[1])) {
+    return json({ error: "Not found." }, 404);
+  }
+  const uuid = match[1].toLowerCase();
+  const action = match[2];
+  try {
+    if (action === "logo") {
+      const logoPath = `Logos/${uuid.slice(0, 2)}/${uuid.slice(2, 4)}/${uuid}.png`;
+      const upstream = await fetcher(
+        `${IMAGE_ORIGIN}/images/${logoPath}?type=jpg`,
+      );
+      if (!upstream.ok) {
+        return json({ error: "Logo not found." }, upstream.status);
+      }
+      return proxyResponse(upstream, 86400);
+    }
+    const details = await fetchPlayerDetails(fetcher, uuid, url.origin);
+    if (action === "download") {
+      if (!details.compatible) {
+        return json({ error: details.incompatibleReason }, 422);
+      }
+      const launchUrl =
+        details.packageType === "legacy"
+          ? new URL(details.launchCommand)
+          : null;
+      const upstreamUrl =
+        details.packageType === "gamezip"
+          ? details.gameZipUrl
+          : legacyAssetUrl(
+              `content/${launchUrl?.hostname}${launchUrl?.pathname}`,
+            );
+      const upstream = await fetcher(upstreamUrl as string, {
+        headers: { "User-Agent": "Astro-Flash-Catalog/1.0" },
+      });
+      if (!upstream.ok) {
+        return json(
+          { error: `Game download returned ${upstream.status}.` },
+          502,
+        );
+      }
+      return details.packageType === "legacy"
+        ? checkedAssetResponse(upstream, 3600)
+        : proxyResponse(upstream, 3600);
+    }
+    if (action === "asset") {
+      if (!details.compatible || !details.legacyServerUrl) {
+        return json(
+          { error: "Legacy assets are not available for this game." },
+          422,
+        );
+      }
+      const upstream = await fetcher(
+        legacyAssetUrl(url.searchParams.get("path")),
+        { headers: { "User-Agent": "Astro-Flash-Catalog/1.0" } },
+      );
+      if (!upstream.ok) {
+        return json(
+          { error: `Legacy asset returned ${upstream.status}.` },
+          404,
+        );
+      }
+      return checkedAssetResponse(upstream, 86400);
+    }
+    const {
+      gameZipUrl: _privateUpstreamUrl,
+      legacyServerUrl: _privateLegacyServer,
+      ...publicDetails
+    } = details;
+    return json(publicDetails);
+  } catch (error) {
+    return json({ error: errorMessage(error, "Game lookup failed.") }, 502);
+  }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,76 @@
+import js from "@eslint/js";
+import prettier from "eslint-config-prettier";
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+export default defineConfig(
+  {
+    ignores: ["dist/", "site/iframe/inside-the-firewall/", "site/vendor/"],
+  },
+  {
+    files: ["eslint.config.mjs"],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
+  {
+    files: ["site/js/**/*.js"],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "script",
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.serviceworker,
+        XPDialogs: "readonly",
+      },
+    },
+    rules: {
+      "no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          caughtErrors: "none",
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      "catalog/**/*.ts",
+      "tests/**/*.ts",
+      "tools/**/*.ts",
+      "worker/**/*.ts",
+      "workbox-config.ts",
+    ],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
+    languageOptions: {
+      globals: {
+        ...globals.bunBuiltin,
+        ...globals.node,
+        ...globals.worker,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          caughtErrors: "none",
+          varsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+  {
+    files: ["tests/**/*.ts"],
+    rules: {
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
+  prettier,
+);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "deploy:worker": "wrangler deploy --config worker/wrangler.toml",
     "extract:swf": "bun tools/extract-swf.ts",
     "find:icons": "bun tools/find-flashpoint-icons.ts",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "quality": "bun run format:check && bun run lint",
     "sync:icons": "bun tools/sync-game-icons.ts",
     "typecheck": "tsc --noEmit",
     "update:ruffle": "bun tools/update-ruffle.ts",
@@ -14,8 +19,15 @@
     "validate:javascript": "bun tools/validate-javascript.ts"
   },
   "devDependencies": {
+    "@eslint/js": "10.0.1",
     "@types/bun": "^1.3.14",
-    "typescript": "^7.0.2",
+    "@typescript/native": "npm:typescript@7.0.2",
+    "eslint": "10.8.0",
+    "eslint-config-prettier": "10.1.8",
+    "globals": "17.8.0",
+    "prettier": "3.9.6",
+    "typescript": "6.0.2",
+    "typescript-eslint": "8.65.0",
     "workbox-build": "^7.4.1",
     "wrangler": "4.114.0"
   },

--- a/site/capture.html
+++ b/site/capture.html
@@ -1,65 +1,98 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-<meta charset="utf-8">
-<style>
-    html, body { margin: 0; padding: 0; width: 480px; height: 360px; overflow: hidden; background: #000; }
-    ruffle-player, iframe { width: 480px; height: 360px; display: block; border: 0; }
-</style>
-<script src="js/ruffle.js"></script>
-</head>
-<body>
-<script>
-    const params = new URLSearchParams(location.search);
-    const gameId = params.get("game");
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 480px;
+        height: 360px;
+        overflow: hidden;
+        background: #000;
+      }
+      ruffle-player,
+      iframe {
+        width: 480px;
+        height: 360px;
+        display: block;
+        border: 0;
+      }
+    </style>
+    <script src="js/ruffle.js"></script>
+  </head>
+  <body>
+    <script>
+      const params = new URLSearchParams(location.search);
+      const gameId = params.get("game");
 
-    // Mirrors gamesList config from js/main.js
-    const gameTypes = {
-        "doom": "iframe",
-        "inside-the-firewall": "iframe"
-    };
-    const spoofUrls = { "sugar-sugar": "https://www.friv.com/z/games/sugarsugar" };
-    const externalHosts = {
-        "simpsons-wrecking-ball": ["files.gamezhero.com"]
-    };
-    const frameRates = {
-        "big-truck-adventures": 45, "big-truck-adventures-2": 45,
-        "bike-mania": 60, "bike-mania-2": 60, "bike-mania-3": 60,
-        "bike-mania-4": 60, "bike-mania-5": 60, "bike-mania-arena": 60,
-        "bike-mania-arena-2": 60, "bike-mania-arena-3": 60,
-        "bike-mania-arena-4": 60, "bike-mania-arena-5": 60,
-        "knd-operation-startup": 30, "knd-operation-startup-final": 30,
-        "knd-numbuh-generator": 45
-    };
+      // Mirrors gamesList config from js/main.js
+      const gameTypes = {
+        doom: "iframe",
+        "inside-the-firewall": "iframe",
+      };
+      const spoofUrls = {
+        "sugar-sugar": "https://www.friv.com/z/games/sugarsugar",
+      };
+      const externalHosts = {
+        "simpsons-wrecking-ball": ["files.gamezhero.com"],
+      };
+      const frameRates = {
+        "big-truck-adventures": 45,
+        "big-truck-adventures-2": 45,
+        "bike-mania": 60,
+        "bike-mania-2": 60,
+        "bike-mania-3": 60,
+        "bike-mania-4": 60,
+        "bike-mania-5": 60,
+        "bike-mania-arena": 60,
+        "bike-mania-arena-2": 60,
+        "bike-mania-arena-3": 60,
+        "bike-mania-arena-4": 60,
+        "bike-mania-arena-5": 60,
+        "knd-operation-startup": 30,
+        "knd-operation-startup-final": 30,
+        "knd-numbuh-generator": 45,
+      };
 
-    if (gameTypes[gameId] === "iframe") {
+      if (gameTypes[gameId] === "iframe") {
         const ifr = document.createElement("iframe");
         ifr.src = `iframe/${gameId}/`;
         document.body.appendChild(ifr);
-    } else {
+      } else {
         // URL spoofing for sitelock bypass (same trick as js/main.js)
         const getSpoofedGameId = (hostname) => {
-            const spoofedGame = Object.entries(spoofUrls)
-                .find(([, url]) => new URL(url).hostname === hostname)?.[0];
-            return spoofedGame || Object.entries(externalHosts)
-                .find(([, hosts]) => hosts.includes(hostname))?.[0] || null;
+          const spoofedGame = Object.entries(spoofUrls).find(
+            ([, url]) => new URL(url).hostname === hostname,
+          )?.[0];
+          return (
+            spoofedGame ||
+            Object.entries(externalHosts).find(([, hosts]) =>
+              hosts.includes(hostname),
+            )?.[0] ||
+            null
+          );
         };
         const changeUrl = (request) => {
-            if (!request.url) return request;
-            const parsedUrl = new URL(request.url);
-            if (parsedUrl.hostname !== location.hostname) {
-                const gid = getSpoofedGameId(parsedUrl.hostname);
-                if (gid) return `swf/${gid}/${parsedUrl.pathname.split("/").pop()}`;
-            }
-            return request;
+          if (!request.url) return request;
+          const parsedUrl = new URL(request.url);
+          if (parsedUrl.hostname !== location.hostname) {
+            const gid = getSpoofedGameId(parsedUrl.hostname);
+            if (gid) return `swf/${gid}/${parsedUrl.pathname.split("/").pop()}`;
+          }
+          return request;
         };
         const originalFetch = window.fetch;
         window.fetch = async (...args) => {
-            const orig = args[0];
-            args[0] = changeUrl(orig);
-            const resp = await originalFetch(...args);
-            if (args[0] !== orig) Object.defineProperty(resp, "url", { value: orig.url || orig });
-            return resp;
+          const orig = args[0];
+          args[0] = changeUrl(orig);
+          const resp = await originalFetch(...args);
+          if (args[0] !== orig)
+            Object.defineProperty(resp, "url", {
+              value: orig.url || orig,
+            });
+          return resp;
         };
 
         const ruffle = window.RufflePlayer.newest();
@@ -68,17 +101,17 @@
 
         const spoof = spoofUrls[gameId];
         player.load({
-            url: spoof ? `${spoof}/main.swf` : `swf/${gameId}/main.swf`,
-            base: spoof ? `${spoof}/` : `swf/${gameId}/`,
-            letterbox: "on",
-            scale: "showAll",
-            forceScale: true,
-            autoplay: "on",
-            unmuteOverlay: "hidden",
-            frameRate: frameRates[gameId],
-            allowScriptAccess: false
+          url: spoof ? `${spoof}/main.swf` : `swf/${gameId}/main.swf`,
+          base: spoof ? `${spoof}/` : `swf/${gameId}/`,
+          letterbox: "on",
+          scale: "showAll",
+          forceScale: true,
+          autoplay: "on",
+          unmuteOverlay: "hidden",
+          frameRate: frameRates[gameId],
+          allowScriptAccess: false,
         });
-    }
-</script>
-</body>
+      }
+    </script>
+  </body>
 </html>

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -5,3141 +5,3641 @@
    ============================================ */
 
 @font-face {
-    font-family: "Tahoma";
-    src: url("fonts/tahoma.ttf") format("truetype");
-    font-style: normal;
-    font-weight: 400;
+  font-family: "Tahoma";
+  src: url("fonts/tahoma.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 400;
 }
 
 @font-face {
-    font-family: "Tahoma";
-    src: url("fonts/tahomabd.ttf") format("truetype");
-    font-style: normal;
-    font-weight: 700;
+  font-family: "Tahoma";
+  src: url("fonts/tahomabd.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 700;
 }
 
 @font-face {
-    font-family: "Trebuchet MS";
-    src: url("fonts/trebuc.ttf") format("truetype");
-    font-style: normal;
-    font-weight: 400;
+  font-family: "Trebuchet MS";
+  src: url("fonts/trebuc.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 400;
 }
 
 @font-face {
-    font-family: "Trebuchet MS";
-    src: url("fonts/trebucbd.ttf") format("truetype");
-    font-style: normal;
-    font-weight: 700;
+  font-family: "Trebuchet MS";
+  src: url("fonts/trebucbd.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 700;
 }
 
 @font-face {
-    font-family: "Lucida Console";
-    src: url("fonts/lucon.ttf") format("truetype");
-    font-style: normal;
-    font-weight: 400;
+  font-family: "Lucida Console";
+  src: url("fonts/lucon.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 400;
 }
 
 @font-face {
-    font-family: "Arial";
-    src: url("fonts/arial.ttf") format("truetype");
-    font-style: normal;
-    font-weight: 400;
+  font-family: "Arial";
+  src: url("fonts/arial.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 400;
 }
 
 @font-face {
-    font-family: "Arial";
-    src: url("fonts/arialbd.ttf") format("truetype");
-    font-style: normal;
-    font-weight: 700;
+  font-family: "Arial";
+  src: url("fonts/arialbd.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 700;
 }
 
 @font-face {
-    font-family: "Arial";
-    src: url("fonts/arialbi.ttf") format("truetype");
-    font-style: italic;
-    font-weight: 700;
+  font-family: "Arial";
+  src: url("fonts/arialbi.ttf") format("truetype");
+  font-style: italic;
+  font-weight: 700;
 }
 
 @font-face {
-    font-family: "Franklin Gothic Medium";
-    src: url("fonts/framdit.ttf") format("truetype");
-    font-style: italic;
-    font-weight: 400;
+  font-family: "Franklin Gothic Medium";
+  src: url("fonts/framdit.ttf") format("truetype");
+  font-style: italic;
+  font-weight: 400;
 }
 
 :root {
-    --xp-beige: #ece9d8;
-    --xp-beige-dark: #d6d2c2;
-    --xp-border-blue: #0053e0;
-    --xp-text: #1a1a1a;
-    /* Authentic Luna gradients (color stops sampled from Windows XP) */
-    --titlebar-active: linear-gradient(180deg,
-        #0997ff, #0053ee 8%, #0050ee 40%, #0066ff 88%,
-        #0066ff 93%, #005bff 95%, #003dd7 96%, #003dd7);
-    --titlebar-inactive: linear-gradient(180deg,
-        rgb(118, 151, 231) 0%, rgb(126, 158, 227) 3%, rgb(148, 175, 232) 6%,
-        rgb(151, 180, 233) 8%, rgb(130, 165, 228) 14%, rgb(124, 159, 226) 17%,
-        rgb(121, 150, 222) 25%, rgb(123, 153, 225) 56%, rgb(130, 169, 233) 81%,
-        rgb(128, 165, 231) 89%, rgb(123, 150, 225) 94%, rgb(122, 147, 223) 97%,
-        rgb(171, 186, 227) 100%);
-    --window-frame: inset -1px -1px #424fa2, inset 1px 1px #4e68d1,
-        inset -2px -2px #5669c0, inset 2px 2px #528eef,
-        inset -3px -3px #4e73d7, inset 3px 3px #5284da;
-    --window-frame-inactive: inset -1px -1px rgb(130, 165, 228),
-        inset 1px 1px rgb(130, 165, 228), inset -2px -2px rgb(130, 165, 228),
-        inset 2px 2px rgb(130, 165, 228), inset -3px -3px rgb(130, 165, 228),
-        inset 3px 3px rgb(130, 165, 228);
-    --taskbar-gradient: linear-gradient(180deg,
-        rgb(31, 47, 134) 0px, rgb(49, 101, 196) 3%, rgb(54, 130, 229) 6%,
-        rgb(68, 144, 230) 10%, rgb(56, 131, 229) 12%, rgb(43, 113, 224) 15%,
-        rgb(38, 99, 218) 18%, rgb(35, 91, 214) 20%, rgb(34, 88, 213) 23%,
-        rgb(33, 87, 214) 38%, rgb(36, 93, 219) 54%, rgb(37, 98, 223) 86%,
-        rgb(36, 95, 220) 89%, rgb(33, 88, 212) 92%, rgb(29, 78, 192) 95%,
-        rgb(25, 65, 165) 98%);
-    --tray-gradient: linear-gradient(180deg,
-        rgb(12, 89, 185) 1%, rgb(19, 158, 233) 6%, rgb(24, 181, 242) 10%,
-        rgb(19, 155, 235) 14%, rgb(18, 144, 232) 19%, rgb(13, 141, 234) 63%,
-        rgb(13, 159, 241) 81%, rgb(15, 158, 237) 88%, rgb(17, 155, 233) 91%,
-        rgb(19, 146, 226) 94%, rgb(19, 126, 215) 97%, rgb(9, 91, 201) 100%);
-    --menu-header-gradient: linear-gradient(180deg,
-        rgb(24, 104, 206) 0%, rgb(14, 96, 203) 12%, rgb(14, 96, 203) 20%,
-        rgb(17, 100, 207) 32%, rgb(22, 103, 207) 33%, rgb(27, 108, 211) 47%,
-        rgb(30, 112, 217) 54%, rgb(36, 118, 220) 60%, rgb(41, 122, 224) 65%,
-        rgb(52, 130, 227) 77%, rgb(55, 134, 229) 79%, rgb(66, 142, 233) 90%,
-        rgb(71, 145, 235) 100%);
-    --menu-footer-gradient: linear-gradient(180deg,
-        rgb(66, 130, 214) 0%, rgb(59, 133, 224) 3%, rgb(65, 138, 227) 5%,
-        rgb(65, 138, 227) 17%, rgb(60, 135, 226) 21%, rgb(55, 134, 228) 26%,
-        rgb(52, 130, 227) 29%, rgb(46, 126, 225) 39%, rgb(35, 116, 223) 49%,
-        rgb(32, 114, 219) 57%, rgb(25, 110, 219) 62%, rgb(23, 107, 216) 72%,
-        rgb(20, 104, 213) 75%, rgb(17, 101, 210) 83%, rgb(15, 97, 203) 88%);
-    --chrome-font: "Tahoma", "Segoe UI", "Geneva", sans-serif;
-    --xp-cursor: url("../assets/xp/cursor.cur"), default;
+  --xp-beige: #ece9d8;
+  --xp-beige-dark: #d6d2c2;
+  --xp-border-blue: #0053e0;
+  --xp-text: #1a1a1a;
+  /* Authentic Luna gradients (color stops sampled from Windows XP) */
+  --titlebar-active: linear-gradient(
+    180deg,
+    #0997ff,
+    #0053ee 8%,
+    #0050ee 40%,
+    #0066ff 88%,
+    #0066ff 93%,
+    #005bff 95%,
+    #003dd7 96%,
+    #003dd7
+  );
+  --titlebar-inactive: linear-gradient(
+    180deg,
+    rgb(118, 151, 231) 0%,
+    rgb(126, 158, 227) 3%,
+    rgb(148, 175, 232) 6%,
+    rgb(151, 180, 233) 8%,
+    rgb(130, 165, 228) 14%,
+    rgb(124, 159, 226) 17%,
+    rgb(121, 150, 222) 25%,
+    rgb(123, 153, 225) 56%,
+    rgb(130, 169, 233) 81%,
+    rgb(128, 165, 231) 89%,
+    rgb(123, 150, 225) 94%,
+    rgb(122, 147, 223) 97%,
+    rgb(171, 186, 227) 100%
+  );
+  --window-frame:
+    inset -1px -1px #424fa2, inset 1px 1px #4e68d1, inset -2px -2px #5669c0,
+    inset 2px 2px #528eef, inset -3px -3px #4e73d7, inset 3px 3px #5284da;
+  --window-frame-inactive:
+    inset -1px -1px rgb(130, 165, 228), inset 1px 1px rgb(130, 165, 228),
+    inset -2px -2px rgb(130, 165, 228), inset 2px 2px rgb(130, 165, 228),
+    inset -3px -3px rgb(130, 165, 228), inset 3px 3px rgb(130, 165, 228);
+  --taskbar-gradient: linear-gradient(
+    180deg,
+    rgb(31, 47, 134) 0px,
+    rgb(49, 101, 196) 3%,
+    rgb(54, 130, 229) 6%,
+    rgb(68, 144, 230) 10%,
+    rgb(56, 131, 229) 12%,
+    rgb(43, 113, 224) 15%,
+    rgb(38, 99, 218) 18%,
+    rgb(35, 91, 214) 20%,
+    rgb(34, 88, 213) 23%,
+    rgb(33, 87, 214) 38%,
+    rgb(36, 93, 219) 54%,
+    rgb(37, 98, 223) 86%,
+    rgb(36, 95, 220) 89%,
+    rgb(33, 88, 212) 92%,
+    rgb(29, 78, 192) 95%,
+    rgb(25, 65, 165) 98%
+  );
+  --tray-gradient: linear-gradient(
+    180deg,
+    rgb(12, 89, 185) 1%,
+    rgb(19, 158, 233) 6%,
+    rgb(24, 181, 242) 10%,
+    rgb(19, 155, 235) 14%,
+    rgb(18, 144, 232) 19%,
+    rgb(13, 141, 234) 63%,
+    rgb(13, 159, 241) 81%,
+    rgb(15, 158, 237) 88%,
+    rgb(17, 155, 233) 91%,
+    rgb(19, 146, 226) 94%,
+    rgb(19, 126, 215) 97%,
+    rgb(9, 91, 201) 100%
+  );
+  --menu-header-gradient: linear-gradient(
+    180deg,
+    rgb(24, 104, 206) 0%,
+    rgb(14, 96, 203) 12%,
+    rgb(14, 96, 203) 20%,
+    rgb(17, 100, 207) 32%,
+    rgb(22, 103, 207) 33%,
+    rgb(27, 108, 211) 47%,
+    rgb(30, 112, 217) 54%,
+    rgb(36, 118, 220) 60%,
+    rgb(41, 122, 224) 65%,
+    rgb(52, 130, 227) 77%,
+    rgb(55, 134, 229) 79%,
+    rgb(66, 142, 233) 90%,
+    rgb(71, 145, 235) 100%
+  );
+  --menu-footer-gradient: linear-gradient(
+    180deg,
+    rgb(66, 130, 214) 0%,
+    rgb(59, 133, 224) 3%,
+    rgb(65, 138, 227) 5%,
+    rgb(65, 138, 227) 17%,
+    rgb(60, 135, 226) 21%,
+    rgb(55, 134, 228) 26%,
+    rgb(52, 130, 227) 29%,
+    rgb(46, 126, 225) 39%,
+    rgb(35, 116, 223) 49%,
+    rgb(32, 114, 219) 57%,
+    rgb(25, 110, 219) 62%,
+    rgb(23, 107, 216) 72%,
+    rgb(20, 104, 213) 75%,
+    rgb(17, 101, 210) 83%,
+    rgb(15, 97, 203) 88%
+  );
+  --chrome-font: "Tahoma", "Segoe UI", "Geneva", sans-serif;
+  --xp-cursor: url("../assets/xp/cursor.cur"), default;
 }
 
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 html,
 body {
-    margin: 0;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 
 body {
-    font-family: var(--chrome-font);
-    font-size: 11px;
-    color: var(--xp-text);
-    background: #000;
-    user-select: none;
-    -webkit-user-select: none;
-    cursor: var(--xp-cursor);
+  font-family: var(--chrome-font);
+  font-size: 11px;
+  color: var(--xp-text);
+  background: #000;
+  user-select: none;
+  -webkit-user-select: none;
+  cursor: var(--xp-cursor);
 }
 
 button {
-    font-family: inherit;
+  font-family: inherit;
 }
 
 [hidden] {
-    display: none !important;
+  display: none !important;
 }
 
 iframe {
-    border: none;
+  border: none;
 }
 
 /* ============ Windows flag artwork ============ */
 
 .brand-flag {
-    display: block;
-    width: 36px;
-    height: 36px;
-    background: url("../assets/xp/flag.png") center / contain no-repeat;
-    filter: drop-shadow(1px 2px 2px rgba(0, 0, 0, 0.45));
+  display: block;
+  width: 36px;
+  height: 36px;
+  background: url("../assets/xp/flag.png") center / contain no-repeat;
+  filter: drop-shadow(1px 2px 2px rgba(0, 0, 0, 0.45));
 }
 
 .brand-flag i {
-    display: none;
+  display: none;
 }
 
 /* ============ Boot screen ============ */
 
 #boot-screen {
-    position: fixed;
-    inset: 0;
-    z-index: 9000;
-    background: #000;
-    overflow: hidden;
-    color: #f1f5f9;
-    cursor: var(--xp-cursor);
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  background: #000;
+  overflow: hidden;
+  color: #f1f5f9;
+  cursor: var(--xp-cursor);
 }
 
 #boot-screen:focus-visible {
-    outline: none;
+  outline: none;
 }
 
 .boot-center {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: min(400px, 88vw);
-    transform: translate(-50%, -50%);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(400px, 88vw);
+  transform: translate(-50%, -50%);
 }
 
 .boot-logo {
-    display: block;
-    width: 100%;
-    height: auto;
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 .boot-progress {
-    width: 150px;
-    height: 20px;
-    margin: 150px auto 0;
-    padding: 2px 1px;
-    overflow: hidden;
-    white-space: nowrap;
-    font-size: 0;
-    border: 2px solid #b2b2b2;
-    border-radius: 7px;
+  width: 150px;
+  height: 20px;
+  margin: 150px auto 0;
+  padding: 2px 1px;
+  overflow: hidden;
+  white-space: nowrap;
+  font-size: 0;
+  border: 2px solid #b2b2b2;
+  border-radius: 7px;
 }
 
 .boot-progress i {
-    display: inline-block;
-    width: 9px;
-    height: 100%;
-    margin-right: 2px;
-    background: linear-gradient(to bottom, #2838c7 0%, #5979ef 17%, #869ef3 32%, #869ef3 45%, #5979ef 59%, #2838c7 100%);
-    animation: boot-slide 2s linear infinite;
+  display: inline-block;
+  width: 9px;
+  height: 100%;
+  margin-right: 2px;
+  background: linear-gradient(
+    to bottom,
+    #2838c7 0%,
+    #5979ef 17%,
+    #869ef3 32%,
+    #869ef3 45%,
+    #5979ef 59%,
+    #2838c7 100%
+  );
+  animation: boot-slide 2s linear infinite;
 }
 
 .boot-footer {
-    position: absolute;
-    right: 16px;
-    bottom: 24px;
-    left: 16px;
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 8px;
+  position: absolute;
+  right: 16px;
+  bottom: 24px;
+  left: 16px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 8px;
 }
 
 .boot-footer p {
-    margin: 0;
-    font-family: Arial, sans-serif;
-    font-size: clamp(12px, 2vw, 16px);
+  margin: 0;
+  font-family: Arial, sans-serif;
+  font-size: clamp(12px, 2vw, 16px);
 }
 
 .boot-footer img {
-    width: min(120px, 30vw);
-    height: auto;
+  width: min(120px, 30vw);
+  height: auto;
 }
 
 @keyframes boot-slide {
-    from { transform: translateX(-30px); }
-    to { transform: translateX(150px); }
+  from {
+    transform: translateX(-30px);
+  }
+  to {
+    transform: translateX(150px);
+  }
 }
 
 /* ============ Welcome screen ============ */
 
 #welcome-screen {
-    position: fixed;
-    inset: 0;
-    z-index: 9000;
-    background:
-        linear-gradient(90deg,
-            transparent calc(50% - 1px),
-            rgba(126, 157, 229, 0.42) 50%,
-            transparent calc(50% + 1px)),
-        #5a7edc;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  background:
+    linear-gradient(
+      90deg,
+      transparent calc(50% - 1px),
+      rgba(126, 157, 229, 0.42) 50%,
+      transparent calc(50% + 1px)
+    ),
+    #5a7edc;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 #welcome-screen::before,
 #welcome-screen::after {
-    content: "";
-    position: absolute;
-    left: 0;
-    right: 0;
-    z-index: -1;
-    background: linear-gradient(180deg, #0643b8 0%, #003399 100%);
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: -1;
+  background: linear-gradient(180deg, #0643b8 0%, #003399 100%);
 }
 
 #welcome-screen::before {
-    top: 0;
-    height: 12.8%;
-    border-bottom: 2px solid #90a8e3;
+  top: 0;
+  height: 12.8%;
+  border-bottom: 2px solid #90a8e3;
 }
 
 #welcome-screen::after {
-    bottom: 0;
-    height: 16%;
-    border-top: 2px solid #e69232;
+  bottom: 0;
+  height: 16%;
+  border-top: 2px solid #e69232;
 }
 
 .welcome-wordmark {
-    position: absolute;
-    top: 43.5%;
-    left: 39%;
-    width: min(160px, 29vw);
-    height: auto;
-    transform: translate(-50%, -50%);
-    filter: none;
+  position: absolute;
+  top: 43.5%;
+  left: 39%;
+  width: min(160px, 29vw);
+  height: auto;
+  transform: translate(-50%, -50%);
+  filter: none;
 }
 
 .welcome-message {
-    display: none;
-    position: absolute;
-    top: 49%;
-    left: 57.5%;
-    margin: 0;
-    color: #fff;
-    font-family: "Franklin Gothic Medium", Arial, sans-serif;
-    font-size: clamp(34px, 5.75vw, 46px);
-    font-weight: 400;
-    font-style: italic;
-    letter-spacing: -1px;
-    text-shadow: 2px 2px 2px rgba(40, 67, 156, 0.45);
-    transform: translate(-50%, -50%);
+  display: none;
+  position: absolute;
+  top: 49%;
+  left: 57.5%;
+  margin: 0;
+  color: #fff;
+  font-family: "Franklin Gothic Medium", Arial, sans-serif;
+  font-size: clamp(34px, 5.75vw, 46px);
+  font-weight: 400;
+  font-style: italic;
+  letter-spacing: -1px;
+  text-shadow: 2px 2px 2px rgba(40, 67, 156, 0.45);
+  transform: translate(-50%, -50%);
 }
 
 #welcome-screen.auto-login .welcome-message {
-    display: block;
+  display: block;
 }
 
 #welcome-screen.auto-login {
-    background:
-        radial-gradient(ellipse 78% 100% at -5% 3%,
-            rgba(190, 216, 255, 0.82) 0%,
-            rgba(146, 181, 246, 0.62) 42%,
-            rgba(103, 139, 226, 0) 78%),
-        linear-gradient(180deg, #7da1ef 0%, #6689e1 100%);
+  background:
+    radial-gradient(
+      ellipse 78% 100% at -5% 3%,
+      rgba(190, 216, 255, 0.82) 0%,
+      rgba(146, 181, 246, 0.62) 42%,
+      rgba(103, 139, 226, 0) 78%
+    ),
+    linear-gradient(180deg, #7da1ef 0%, #6689e1 100%);
 }
 
 #welcome-screen.auto-login .welcome-wordmark {
-    display: none;
+  display: none;
 }
 
 #welcome-screen.auto-login .welcome-panel,
 #welcome-screen.auto-login #welcome-turn-off {
-    display: none;
+  display: none;
 }
 
 .welcome-panel {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-start;
-    width: 50%;
-    transform: translateY(-50%);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 50%;
+  transform: translateY(-50%);
 }
 
 .welcome-instruction {
-    position: absolute;
-    top: 70px;
-    right: calc(100% + 28px);
-    width: min(300px, 40vw);
-    margin: 0;
-    color: #fff;
-    font-size: 18px;
-    font-weight: 700;
-    line-height: 1.45;
-    text-align: right;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.45);
+  position: absolute;
+  top: 70px;
+  right: calc(100% + 28px);
+  width: min(300px, 40vw);
+  margin: 0;
+  color: #fff;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.45;
+  text-align: right;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.45);
 }
 
 #login-user {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    min-width: min(340px, 46vw);
-    padding: 9px 30px 9px 9px;
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid transparent;
-    border-radius: 5px;
-    cursor: var(--xp-cursor);
-    color: #fff;
-    transition: background 0.15s, border-color 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: min(340px, 46vw);
+  padding: 9px 30px 9px 9px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid transparent;
+  border-radius: 5px;
+  cursor: var(--xp-cursor);
+  color: #fff;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
 
 #login-user:hover {
-    background: rgba(255, 255, 255, 0.24);
-    border-color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.24);
+  border-color: rgba(255, 255, 255, 0.72);
 }
 
 .welcome-avatar {
-    width: 52px;
-    height: 52px;
-    border-radius: 5px;
-    box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.45);
+  width: 52px;
+  height: 52px;
+  border-radius: 5px;
+  box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.45);
 }
 
 .xp-user-tile {
-    position: relative;
-    display: inline-block;
-    overflow: hidden;
-    background:
-        radial-gradient(circle at 68% 24%, #fff6aa 0 7%, transparent 8%),
-        linear-gradient(155deg, transparent 0 53%, #34764b 54% 65%, transparent 66%),
-        linear-gradient(25deg, transparent 0 50%, #62a458 51% 67%, transparent 68%),
-        linear-gradient(180deg, #76c8f0 0 55%, #9bcf6b 56% 100%);
-    border: 2px solid #fff;
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 68% 24%, #fff6aa 0 7%, transparent 8%),
+    linear-gradient(
+      155deg,
+      transparent 0 53%,
+      #34764b 54% 65%,
+      transparent 66%
+    ),
+    linear-gradient(25deg, transparent 0 50%, #62a458 51% 67%, transparent 68%),
+    linear-gradient(180deg, #76c8f0 0 55%, #9bcf6b 56% 100%);
+  border: 2px solid #fff;
 }
 
 .xp-user-tile::after {
-    content: "";
-    position: absolute;
-    left: 8%;
-    right: 8%;
-    bottom: 17%;
-    height: 3px;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.9);
-    transform: rotate(-8deg);
+  content: "";
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  bottom: 17%;
+  height: 3px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  transform: rotate(-8deg);
 }
 
 .welcome-username {
-    font-size: 18px;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.45);
+  font-size: 18px;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.45);
 }
 
 #welcome-turn-off {
-    position: absolute;
-    left: 3.5%;
-    bottom: 4.4%;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 3px 6px 3px 3px;
-    background: none;
-    border: none;
-    color: #fff;
-    font-size: 12px;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
-    cursor: var(--xp-cursor);
+  position: absolute;
+  left: 3.5%;
+  bottom: 4.4%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 6px 3px 3px;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 12px;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+  cursor: var(--xp-cursor);
 }
 
 .welcome-help {
-    position: absolute;
-    right: 4%;
-    bottom: 4.3%;
-    margin: 0;
-    color: #fff;
-    font-size: 11px;
-    line-height: 1.25;
-    text-shadow: 1px 1px rgba(0, 0, 0, 0.35);
+  position: absolute;
+  right: 4%;
+  bottom: 4.3%;
+  margin: 0;
+  color: #fff;
+  font-size: 11px;
+  line-height: 1.25;
+  text-shadow: 1px 1px rgba(0, 0, 0, 0.35);
 }
 
 #welcome-screen.auto-login .welcome-help {
-    display: none;
+  display: none;
 }
 
 .welcome-turn-off-icon {
-    position: relative;
-    width: 24px;
-    height: 24px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 3px;
-    background: linear-gradient(180deg, #f4ad4b, #cf711f);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55),
-        1px 1px 3px rgba(0, 0, 0, 0.45);
+  position: relative;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #f4ad4b, #cf711f);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    1px 1px 3px rgba(0, 0, 0, 0.45);
 }
 
 .xp-power-icon::before {
-    content: "";
-    width: 8px;
-    height: 8px;
-    border: 2px solid #fff;
-    border-top-color: transparent;
-    border-radius: 50%;
+  content: "";
+  width: 8px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-top-color: transparent;
+  border-radius: 50%;
 }
 
 .xp-power-icon::after {
-    content: "";
-    position: absolute;
-    top: 5px;
-    left: 50%;
-    width: 2px;
-    height: 8px;
-    border-radius: 1px;
-    background: #fff;
-    transform: translateX(-50%);
+  content: "";
+  position: absolute;
+  top: 5px;
+  left: 50%;
+  width: 2px;
+  height: 8px;
+  border-radius: 1px;
+  background: #fff;
+  transform: translateX(-50%);
 }
 
 #welcome-turn-off:hover .welcome-turn-off-icon {
-    filter: brightness(1.12);
+  filter: brightness(1.12);
 }
 
 /* ============ Desktop ============ */
 
 #desktop {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 30px;
-    overflow: hidden;
-    background-color: var(--desktop-color, #3a6ea5);
-    background-image: var(--desktop-background, url("../assets/xp/bliss.jpg"));
-    background-position: center;
-    background-size: 100% 100%;
-    background-repeat: no-repeat;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 30px;
+  overflow: hidden;
+  background-color: var(--desktop-color, #3a6ea5);
+  background-image: var(--desktop-background, url("../assets/xp/bliss.jpg"));
+  background-position: center;
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
 }
 
 #desktop[data-monitor-resolution]:not([data-monitor-resolution="auto"]) {
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.7), 0 8px 26px rgba(0, 0, 0, 0.55);
+  box-shadow:
+    0 0 0 2px rgba(255, 255, 255, 0.7),
+    0 8px 26px rgba(0, 0, 0, 0.55);
 }
 
 #desktop[data-monitor-limited="true"] {
-    box-shadow: 0 0 0 2px #f2c94c, 0 8px 26px rgba(0, 0, 0, 0.55);
+  box-shadow:
+    0 0 0 2px #f2c94c,
+    0 8px 26px rgba(0, 0, 0, 0.55);
 }
 
 #desktop[data-wallpaper-position="center"] {
-    background-size: auto;
-    background-repeat: no-repeat;
+  background-size: auto;
+  background-repeat: no-repeat;
 }
 
 #desktop[data-wallpaper-position="tile"] {
-    background-size: auto;
-    background-repeat: repeat;
+  background-size: auto;
+  background-repeat: repeat;
 }
 
 #screen-saver-overlay {
-    position: absolute;
-    z-index: 20;
-    inset: 0;
-    background: #000;
+  position: absolute;
+  z-index: 20;
+  inset: 0;
+  background: #000;
 }
 
 #screen-saver-overlay[data-saver="marquee"]::after {
-    content: "Astro Flash";
-    position: absolute;
-    top: 45%;
-    left: 0;
-    width: 100%;
-    color: #0f0;
-    font: bold clamp(20px, 5vw, 48px) monospace;
-    text-align: center;
-    animation: saver-marquee 8s linear infinite;
+  content: "Astro Flash";
+  position: absolute;
+  top: 45%;
+  left: 0;
+  width: 100%;
+  color: #0f0;
+  font: bold clamp(20px, 5vw, 48px) monospace;
+  text-align: center;
+  animation: saver-marquee 8s linear infinite;
 }
 
 #screen-saver-overlay[data-saver="stars"] {
-    background-image: radial-gradient(circle at 20% 30%, #fff 0 1px, transparent 2px), radial-gradient(circle at 70% 60%, #fff 0 1px, transparent 2px), radial-gradient(circle at 45% 20%, #fff 0 1px, transparent 2px);
-    background-size: 130px 100px, 170px 140px, 210px 180px;
-    animation: saver-stars 12s linear infinite;
+  background-image:
+    radial-gradient(circle at 20% 30%, #fff 0 1px, transparent 2px),
+    radial-gradient(circle at 70% 60%, #fff 0 1px, transparent 2px),
+    radial-gradient(circle at 45% 20%, #fff 0 1px, transparent 2px);
+  background-size:
+    130px 100px,
+    170px 140px,
+    210px 180px;
+  animation: saver-stars 12s linear infinite;
 }
 
-@keyframes saver-marquee { from { transform: translateX(-35%); } to { transform: translateX(35%); } }
-@keyframes saver-stars { from { background-position: 0 0, 0 0, 0 0; } to { background-position: 130px 100px, -170px 140px, 210px -180px; } }
+@keyframes saver-marquee {
+  from {
+    transform: translateX(-35%);
+  }
+  to {
+    transform: translateX(35%);
+  }
+}
+@keyframes saver-stars {
+  from {
+    background-position:
+      0 0,
+      0 0,
+      0 0;
+  }
+  to {
+    background-position:
+      130px 100px,
+      -170px 140px,
+      210px -180px;
+  }
+}
 
 html[data-xp-appearance="olive"] {
-    --titlebar-active: linear-gradient(#8da64a, #526e20 55%, #3e5716);
-    --taskbar-gradient: linear-gradient(#6f8c35, #405817);
+  --titlebar-active: linear-gradient(#8da64a, #526e20 55%, #3e5716);
+  --taskbar-gradient: linear-gradient(#6f8c35, #405817);
 }
 
 html[data-xp-appearance="silver"] {
-    --titlebar-active: linear-gradient(#a7b0bf, #6d7788 55%, #535d6c);
-    --taskbar-gradient: linear-gradient(#8793a5, #596575);
+  --titlebar-active: linear-gradient(#a7b0bf, #6d7788 55%, #535d6c);
+  --taskbar-gradient: linear-gradient(#8793a5, #596575);
 }
 
 /* ---- Desktop icons ---- */
 
 #desktop-icons {
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    overflow: hidden;
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: hidden;
 }
 
 #desktop-icons.desktop-icons-overflow {
-    overflow-y: auto;
+  overflow-y: auto;
 }
 
 #desktop-icons::after {
-    content: "";
-    position: absolute;
-    top: var(--desktop-icon-overflow-height, 0);
-    left: 0;
-    width: 1px;
-    height: 1px;
+  content: "";
+  position: absolute;
+  top: var(--desktop-icon-overflow-height, 0);
+  left: 0;
+  width: 1px;
+  height: 1px;
 }
 
 .desktop-icon {
-    position: absolute;
-    width: 76px;
-    min-height: 70px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-    padding: 4px 1px 3px;
-    background: none;
-    border: 1px solid transparent;
-    cursor: var(--xp-cursor);
-    touch-action: none;
-    user-select: none;
+  position: absolute;
+  width: 76px;
+  min-height: 70px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 1px 3px;
+  background: none;
+  border: 1px solid transparent;
+  cursor: var(--xp-cursor);
+  touch-action: none;
+  user-select: none;
 }
 
 .desktop-icon .icon-glyph {
-    font-size: 32px;
-    line-height: 1;
-    filter: drop-shadow(1px 2px 2px rgba(0, 0, 0, 0.5));
+  font-size: 32px;
+  line-height: 1;
+  filter: drop-shadow(1px 2px 2px rgba(0, 0, 0, 0.5));
 }
 
 .desktop-icon .icon-glyph.has-image {
-    position: relative;
-    width: 38px;
-    height: 38px;
+  position: relative;
+  width: 38px;
+  height: 38px;
 }
 
 .desktop-icon .explorer-item-icon,
 .desktop-icon .explorer-item-icon img {
-    width: 38px;
-    height: 38px;
-    object-fit: contain;
+  width: 38px;
+  height: 38px;
+  object-fit: contain;
 }
 
 .desktop-icon .icon-glyph.has-image:not(.system-icon)::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: url("../assets/xp/icons/shortcut.png") center / contain no-repeat;
-    pointer-events: none;
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: url("../assets/xp/icons/shortcut.png") center / contain no-repeat;
+  pointer-events: none;
 }
 
 .recycle-full::before {
-    content: "";
-    position: absolute;
-    width: 21px;
-    height: 14px;
-    right: -3px;
-    bottom: 1px;
-    border: 1px solid #4d7f35;
-    background: repeating-linear-gradient(#fff 0 3px, #89c56e 3px 5px);
-    transform: rotate(-12deg);
+  content: "";
+  position: absolute;
+  width: 21px;
+  height: 14px;
+  right: -3px;
+  bottom: 1px;
+  border: 1px solid #4d7f35;
+  background: repeating-linear-gradient(#fff 0 3px, #89c56e 3px 5px);
+  transform: rotate(-12deg);
 }
 
 .game-icon-image {
-    display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .system-glyph-notepad {
-    position: relative;
-    width: 32px;
-    height: 32px;
-    border: 1px solid #334f72;
-    background:
-        repeating-linear-gradient(
-            to bottom,
-            transparent 0 5px,
-            #7999b8 5px 6px
-        ),
-        #f7f3dc;
-    box-shadow: inset 3px 0 #fff, 1px 1px 1px rgba(0, 0, 0, .35);
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border: 1px solid #334f72;
+  background:
+    repeating-linear-gradient(to bottom, transparent 0 5px, #7999b8 5px 6px),
+    #f7f3dc;
+  box-shadow:
+    inset 3px 0 #fff,
+    1px 1px 1px rgba(0, 0, 0, 0.35);
 }
 
 .system-glyph-notepad::before {
-    content: "";
-    position: absolute;
-    inset: -3px 3px auto;
-    height: 5px;
-    border: 1px solid #555;
-    background: repeating-linear-gradient(90deg, #777 0 2px, #ddd 2px 4px);
+  content: "";
+  position: absolute;
+  inset: -3px 3px auto;
+  height: 5px;
+  border: 1px solid #555;
+  background: repeating-linear-gradient(90deg, #777 0 2px, #ddd 2px 4px);
 }
 
 .title-icon.system-glyph-notepad,
 .task-icon.system-glyph-notepad {
-    width: 14px;
-    height: 14px;
+  width: 14px;
+  height: 14px;
 }
 
 .title-icon.system-glyph-notepad::before,
 .task-icon.system-glyph-notepad::before {
-    inset: -2px 1px auto;
-    height: 3px;
+  inset: -2px 1px auto;
+  height: 3px;
 }
 
 .desktop-icon .icon-label {
-    color: #fff;
-    font-size: 11px;
-    line-height: 1.15;
-    text-align: center;
-    text-shadow: 1px 1px 2px #000;
-    padding: 1px 3px;
-    max-width: 74px;
-    overflow: hidden;
-    overflow-wrap: break-word;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
+  color: #fff;
+  font-size: 11px;
+  line-height: 1.15;
+  text-align: center;
+  text-shadow: 1px 1px 2px #000;
+  padding: 1px 3px;
+  max-width: 74px;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .desktop-icon.selected .icon-glyph {
-    filter:
-        drop-shadow(1px 2px 2px rgba(0, 0, 0, 0.5))
-        sepia(0.2) saturate(2.2) hue-rotate(176deg) brightness(0.68);
+  filter: drop-shadow(1px 2px 2px rgba(0, 0, 0, 0.5)) sepia(0.2) saturate(2.2)
+    hue-rotate(176deg) brightness(0.68);
 }
 
 /* Like Windows XP, a selected icon reveals its full label text. */
 .desktop-icon.selected .icon-label {
-    background: #0b61ce;
-    outline: 1px dotted #fff;
-    text-shadow: none;
-    -webkit-line-clamp: unset;
+  background: #0b61ce;
+  outline: 1px dotted #fff;
+  text-shadow: none;
+  -webkit-line-clamp: unset;
 }
 
 .desktop-icon.selected:focus .icon-label {
-    outline: 1px dotted #fff;
+  outline: 1px dotted #fff;
 }
 
 #desktop-icons:not(:focus-within) .desktop-icon.selected .icon-label {
-    background: #7f7f7f;
-    outline-color: #fff;
+  background: #7f7f7f;
+  outline-color: #fff;
 }
 
 .desktop-rename {
-    width: 74px;
-    margin-top: 1px;
-    border: 1px solid #fff;
-    outline: 1px solid #0b61ce;
-    background: #fff;
-    color: #000;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
-    text-align: center;
+  width: 74px;
+  margin-top: 1px;
+  border: 1px solid #fff;
+  outline: 1px solid #0b61ce;
+  background: #fff;
+  color: #000;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
+  text-align: center;
 }
 
 #desktop-selection {
-    position: absolute;
-    z-index: 900;
-    border: 1px dotted #fff;
-    background: rgba(49, 106, 197, 0.2);
-    pointer-events: none;
+  position: absolute;
+  z-index: 900;
+  border: 1px dotted #fff;
+  background: rgba(49, 106, 197, 0.2);
+  pointer-events: none;
 }
 
 .xp-context-menu {
-    position: absolute;
-    z-index: 2500;
-    min-width: 178px;
-    padding: 2px;
-    background: #fff;
-    border: 1px solid #aca899;
-    box-shadow:
-        2px 2px 3px rgba(0, 0, 0, 0.35),
-        inset 1px 1px 0 #fff;
-    color: #000;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  position: absolute;
+  z-index: 2500;
+  min-width: 178px;
+  padding: 2px;
+  background: #fff;
+  border: 1px solid #aca899;
+  box-shadow:
+    2px 2px 3px rgba(0, 0, 0, 0.35),
+    inset 1px 1px 0 #fff;
+  color: #000;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
 .xp-context-menu button {
-    position: relative;
-    display: block;
-    width: 100%;
-    min-height: 22px;
-    padding: 3px 26px 3px 25px;
-    border: 0;
-    background: transparent;
-    color: inherit;
-    font: inherit;
-    text-align: left;
-    white-space: nowrap;
+  position: relative;
+  display: block;
+  width: 100%;
+  min-height: 22px;
+  padding: 3px 26px 3px 25px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  white-space: nowrap;
 }
 
 .xp-context-menu button:not(:disabled):hover,
 .xp-context-menu button:not(:disabled):focus-visible {
-    background: #316ac5;
-    color: #fff;
-    outline: 0;
+  background: #316ac5;
+  color: #fff;
+  outline: 0;
 }
 
 .xp-context-menu button:disabled {
-    color: #aca899;
-    text-shadow: 1px 1px #fff;
+  color: #aca899;
+  text-shadow: 1px 1px #fff;
 }
 
 .context-separator {
-    display: block;
-    height: 1px;
-    margin: 3px 2px 3px 24px;
-    background: #aca899;
-    box-shadow: 0 1px #fff;
+  display: block;
+  height: 1px;
+  margin: 3px 2px 3px 24px;
+  background: #aca899;
+  box-shadow: 0 1px #fff;
 }
 
 .context-arrow {
-    position: absolute;
-    right: 7px;
-    top: 8px;
-    width: 0;
-    height: 0;
-    border-top: 4px solid transparent;
-    border-bottom: 4px solid transparent;
-    border-left: 5px solid currentColor;
+  position: absolute;
+  right: 7px;
+  top: 8px;
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
 }
 
 .context-parent {
-    position: relative;
+  position: relative;
 }
 
 .context-submenu {
-    position: absolute;
-    display: none;
-    z-index: 2501;
+  position: absolute;
+  display: none;
+  z-index: 2501;
 }
 
 .context-parent.open > .context-submenu {
-    display: block;
+  display: block;
 }
 
 /* ============ Windows ============ */
 
 .xp-window {
-    position: absolute;
-    display: flex;
-    flex-direction: column;
-    background: var(--xp-beige);
-    padding: 0 3px 3px;
-    border-radius: 8px 8px 0 0;
-    box-shadow: 2px 2px 14px rgba(0, 0, 0, 0.45), var(--window-frame-inactive);
-    min-width: min(340px, calc(100% - 8px));
-    min-height: min(240px, calc(100% - 8px));
-    z-index: 10;
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  background: var(--xp-beige);
+  padding: 0 3px 3px;
+  border-radius: 8px 8px 0 0;
+  box-shadow:
+    2px 2px 14px rgba(0, 0, 0, 0.45),
+    var(--window-frame-inactive);
+  min-width: min(340px, calc(100% - 8px));
+  min-height: min(240px, calc(100% - 8px));
+  z-index: 10;
 }
 
 .xp-window.active {
-    box-shadow: 2px 2px 14px rgba(0, 0, 0, 0.45), var(--window-frame);
+  box-shadow:
+    2px 2px 14px rgba(0, 0, 0, 0.45),
+    var(--window-frame);
 }
 
 .xp-window.maximized {
-    left: 0 !important;
-    top: 0 !important;
-    width: 100% !important;
-    height: 100% !important;
-    padding: 0;
-    border-radius: 0;
+  left: 0 !important;
+  top: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+  padding: 0;
+  border-radius: 0;
 }
 
 .xp-window.maximized .resize-handle {
-    display: none;
+  display: none;
 }
 
 .title-bar {
-    height: 28px;
-    flex: none;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin: 0 -3px;
-    padding: 0 2px 0 8px;
-    border-radius: 8px 8px 0 0;
-    background: var(--titlebar-inactive);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
-    color: #fff;
-    font-family: "Trebuchet MS", var(--chrome-font);
-    font-size: 13px;
-    font-weight: 700;
-    letter-spacing: 0.2px;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.7);
-    touch-action: none;
-    cursor: var(--xp-cursor);
+  height: 28px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 -3px;
+  padding: 0 2px 0 8px;
+  border-radius: 8px 8px 0 0;
+  background: var(--titlebar-inactive);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  color: #fff;
+  font-family: "Trebuchet MS", var(--chrome-font);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.7);
+  touch-action: none;
+  cursor: var(--xp-cursor);
 }
 
 .xp-window.active .title-bar {
-    background: var(--titlebar-active);
+  background: var(--titlebar-active);
 }
 
 .xp-window:not(.active) .tb-btn {
-    filter: saturate(0.72) brightness(1.08);
+  filter: saturate(0.72) brightness(1.08);
 }
 
 .xp-window.maximized .title-bar {
-    margin: 0;
-    border-radius: 0;
+  margin: 0;
+  border-radius: 0;
 }
 
 .title-icon {
-    width: 16px;
-    height: 16px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex: none;
-    font-size: 15px;
-    line-height: 1;
-    text-shadow: none;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  font-size: 15px;
+  line-height: 1;
+  text-shadow: none;
 }
 
 .title-icon img {
-    width: 16px;
-    height: 16px;
-    object-fit: contain;
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
 }
 
 .title-text {
-    flex: 1;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .title-buttons {
-    display: flex;
-    align-items: center;
-    gap: 2px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
 }
 
 .tb-btn {
-    position: relative;
-    width: 21px;
-    height: 21px;
-    flex: none;
-    padding: 0;
-    border: 0;
-    border-radius: 3px;
-    background-color: transparent;
-    background-position: center;
-    background-size: contain;
-    background-repeat: no-repeat;
-    cursor: var(--xp-cursor);
+  position: relative;
+  width: 21px;
+  height: 21px;
+  flex: none;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background-color: transparent;
+  background-position: center;
+  background-size: contain;
+  background-repeat: no-repeat;
+  cursor: var(--xp-cursor);
 }
 
 .tb-btn:hover {
-    filter: brightness(1.12);
+  filter: brightness(1.12);
 }
 
 .tb-btn:active {
-    filter: brightness(0.92);
+  filter: brightness(0.92);
 }
 
 .minimize-btn {
-    background-image: url("../assets/xp/icons/Minimize.png");
+  background-image: url("../assets/xp/icons/Minimize.png");
 }
 
 .maximize-btn {
-    background-image: url("../assets/xp/icons/Maximize.png");
+  background-image: url("../assets/xp/icons/Maximize.png");
 }
 
 .restore-btn {
-    background-image: url("../assets/xp/icons/Restore.png");
+  background-image: url("../assets/xp/icons/Restore.png");
 }
 
 .close-btn {
-    background-image: url("../assets/xp/icons/Exit.png");
+  background-image: url("../assets/xp/icons/Exit.png");
 }
 
 /* ---- Game application menu bar ---- */
 
 .game-menu-bar {
-    position: relative;
-    z-index: 2;
-    flex: none;
-    display: flex;
-    align-items: center;
-    height: 22px;
-    padding: 0 2px;
-    background: var(--xp-beige);
-    border-bottom: 1px solid #aca899;
-    color: #111;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  position: relative;
+  z-index: 2;
+  flex: none;
+  display: flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 2px;
+  background: var(--xp-beige);
+  border-bottom: 1px solid #aca899;
+  color: #111;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
 .game-menu-items {
-    display: flex;
-    align-items: center;
-    height: 100%;
+  display: flex;
+  align-items: center;
+  height: 100%;
 }
 
 .game-menu-button {
-    height: 20px;
-    padding: 1px 7px 2px;
-    border: 1px solid transparent;
-    background: transparent;
-    color: inherit;
-    font: inherit;
-    cursor: var(--xp-cursor);
+  height: 20px;
+  padding: 1px 7px 2px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: var(--xp-cursor);
 }
 
 .game-menu-button:hover,
 .game-menu-button:focus-visible,
 .game-menu-button[aria-expanded="true"] {
-    border-color: #0a246a;
-    background: #316ac5;
-    color: #fff;
-    outline: 0;
+  border-color: #0a246a;
+  background: #316ac5;
+  color: #fff;
+  outline: 0;
 }
 
 .menu-accesskey {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .game-menu {
-    position: absolute;
-    top: 50px;
-    z-index: 20;
-    min-width: 164px;
-    padding: 2px;
-    background: var(--xp-beige);
-    border: 1px solid #7f7f7f;
-    box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.35), inset 1px 1px 0 #fff;
-    color: #111;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  position: absolute;
+  top: 50px;
+  z-index: 20;
+  min-width: 164px;
+  padding: 2px;
+  background: var(--xp-beige);
+  border: 1px solid #7f7f7f;
+  box-shadow:
+    2px 2px 3px rgba(0, 0, 0, 0.35),
+    inset 1px 1px 0 #fff;
+  color: #111;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
-.game-menu[data-game-menu="file"] { left: 3px; }
-.game-menu[data-game-menu="help"] { left: 38px; }
+.game-menu[data-game-menu="file"] {
+  left: 3px;
+}
+.game-menu[data-game-menu="help"] {
+  left: 38px;
+}
 
 .game-menu-item {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    min-height: 22px;
-    padding: 3px 18px 3px 22px;
-    border: 0;
-    background: transparent;
-    color: inherit;
-    font: inherit;
-    text-align: left;
-    white-space: nowrap;
-    cursor: var(--xp-cursor);
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 22px;
+  padding: 3px 18px 3px 22px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  white-space: nowrap;
+  cursor: var(--xp-cursor);
 }
 
 .game-menu-item:hover:not(:disabled),
 .game-menu-item:focus-visible:not(:disabled) {
-    background: #316ac5;
-    color: #fff;
-    outline: 0;
+  background: #316ac5;
+  color: #fff;
+  outline: 0;
 }
 
 .game-menu-item:disabled {
-    color: #aca899;
-    cursor: default;
-    text-shadow: 1px 1px #fff;
+  color: #aca899;
+  cursor: default;
+  text-shadow: 1px 1px #fff;
 }
 
 .menu-check {
-    width: 16px;
-    margin-left: -18px;
-    color: transparent;
-    font-weight: 700;
+  width: 16px;
+  margin-left: -18px;
+  color: transparent;
+  font-weight: 700;
 }
 
 .game-menu-item.checked .menu-check {
-    color: currentColor;
+  color: currentColor;
 }
 
 .menu-shortcut {
-    margin-left: auto;
-    padding-left: 22px;
-    color: inherit;
+  margin-left: auto;
+  padding-left: 22px;
+  color: inherit;
 }
 
 .game-menu-separator {
-    height: 1px;
-    margin: 3px 2px 3px 22px;
-    background: #aca899;
-    box-shadow: 0 1px #fff;
+  height: 1px;
+  margin: 3px 2px 3px 22px;
+  background: #aca899;
+  box-shadow: 0 1px #fff;
 }
 
 /* ---- Compact controls in the application menu row ---- */
 
 .game-quick-actions {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 1px;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1px;
 }
 
 .quick-access-btn {
-    width: 20px;
-    height: 20px;
-    padding: 0;
-    border: 1px solid transparent;
-    border-radius: 0;
-    background: transparent;
-    color: #111;
-    font: 13px/1 sans-serif;
-    cursor: var(--xp-cursor);
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: #111;
+  font: 13px/1 sans-serif;
+  cursor: var(--xp-cursor);
 }
 
 .quick-access-btn:hover,
 .quick-access-btn:focus-visible {
-    border-color: #0b4aa3;
-    background: #316ac5;
-    color: #fff;
-    outline: 0;
+  border-color: #0b4aa3;
+  background: #316ac5;
+  color: #fff;
+  outline: 0;
 }
 
 .favorite-btn.active,
 .volume-btn.active {
-    border-color: #7f9db9;
-    background: #d8e7f8;
+  border-color: #7f9db9;
+  background: #d8e7f8;
 }
 
 .game-volume-slider {
-    width: clamp(54px, 12vw, 92px);
-    height: 18px;
-    margin: 0;
-    accent-color: #316ac5;
+  width: clamp(54px, 12vw, 92px);
+  height: 18px;
+  margin: 0;
+  accent-color: #316ac5;
 }
 
 /* ---- Window content ---- */
 
 .window-content {
-    flex: 1;
-    position: relative;
-    background: #000;
-    --splash-screen-background: #000000;
-    overflow: hidden;
+  flex: 1;
+  position: relative;
+  background: #000;
+  --splash-screen-background: #000000;
+  overflow: hidden;
 }
 
 .window-content ruffle-player,
 .window-content iframe {
-    position: absolute;
-    inset: 0;
-    display: block;
-    width: 100%;
-    height: 100%;
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .notepad-window {
-    min-width: min(300px, calc(100% - 8px));
-    min-height: min(220px, calc(100% - 8px));
+  min-width: min(300px, calc(100% - 8px));
+  min-height: min(220px, calc(100% - 8px));
 }
 
 .notepad-content {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    background: var(--xp-beige);
-    color: #000;
-    overflow: hidden;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--xp-beige);
+  color: #000;
+  overflow: hidden;
 }
 
 .notepad-menu-bar {
-    position: relative;
-    z-index: 4;
-    flex: none;
-    display: flex;
-    height: 22px;
-    padding: 0 2px;
-    border-bottom: 1px solid #aca899;
-    background: var(--xp-beige);
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  position: relative;
+  z-index: 4;
+  flex: none;
+  display: flex;
+  height: 22px;
+  padding: 0 2px;
+  border-bottom: 1px solid #aca899;
+  background: var(--xp-beige);
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
 .notepad-menu-group {
-    position: relative;
+  position: relative;
 }
 
 .notepad-menu-button {
-    height: 21px;
-    padding: 1px 6px;
-    border: 1px solid transparent;
-    background: transparent;
-    color: #000;
-    font: inherit;
+  height: 21px;
+  padding: 1px 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #000;
+  font: inherit;
 }
 
 .notepad-menu-button:hover,
 .notepad-menu-button:focus-visible,
 .notepad-menu-button[aria-expanded="true"] {
-    border-color: #0a246a;
-    background: #316ac5;
-    color: #fff;
-    outline: 0;
+  border-color: #0a246a;
+  background: #316ac5;
+  color: #fff;
+  outline: 0;
 }
 
 .notepad-menu {
-    position: absolute;
-    top: 20px;
-    left: 0;
-    z-index: 5;
-    min-width: 178px;
-    padding: 2px;
-    border: 1px solid #7f7f7f;
-    background: var(--xp-beige);
-    box-shadow: 2px 2px 3px rgba(0, 0, 0, .35), inset 1px 1px #fff;
+  position: absolute;
+  top: 20px;
+  left: 0;
+  z-index: 5;
+  min-width: 178px;
+  padding: 2px;
+  border: 1px solid #7f7f7f;
+  background: var(--xp-beige);
+  box-shadow:
+    2px 2px 3px rgba(0, 0, 0, 0.35),
+    inset 1px 1px #fff;
 }
 
 .notepad-menu-item {
-    display: grid;
-    grid-template-columns: 18px 1fr auto;
-    align-items: center;
-    width: 100%;
-    min-height: 22px;
-    padding: 2px 5px 2px 2px;
-    border: 0;
-    background: transparent;
-    color: #000;
-    font: inherit;
-    text-align: left;
-    white-space: nowrap;
+  display: grid;
+  grid-template-columns: 18px 1fr auto;
+  align-items: center;
+  width: 100%;
+  min-height: 22px;
+  padding: 2px 5px 2px 2px;
+  border: 0;
+  background: transparent;
+  color: #000;
+  font: inherit;
+  text-align: left;
+  white-space: nowrap;
 }
 
 .notepad-menu-item:hover,
 .notepad-menu-item:focus-visible {
-    background: #316ac5;
-    color: #fff;
-    outline: 0;
+  background: #316ac5;
+  color: #fff;
+  outline: 0;
 }
 
 .notepad-menu-check {
-    color: transparent;
-    font-weight: 700;
+  color: transparent;
+  font-weight: 700;
 }
 
 .notepad-menu-item.checked .notepad-menu-check {
-    color: currentColor;
+  color: currentColor;
 }
 
 .notepad-menu-shortcut {
-    margin-left: 22px;
+  margin-left: 22px;
 }
 
 .notepad-menu-separator {
-    height: 1px;
-    margin: 3px 2px 3px 20px;
-    background: #aca899;
-    box-shadow: 0 1px #fff;
+  height: 1px;
+  margin: 3px 2px 3px 20px;
+  background: #aca899;
+  box-shadow: 0 1px #fff;
 }
 
 .notepad-editor {
-    flex: 1;
-    min-width: 0;
-    min-height: 0;
-    resize: none;
-    margin: 0;
-    padding: 2px;
-    border: 1px solid #7f9db9;
-    border-radius: 0;
-    outline: 0;
-    background: #fff;
-    color: #000;
-    font: 13px/1.25 "Lucida Console", "Courier New", monospace;
-    white-space: pre;
-    overflow: auto;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  resize: none;
+  margin: 0;
+  padding: 2px;
+  border: 1px solid #7f9db9;
+  border-radius: 0;
+  outline: 0;
+  background: #fff;
+  color: #000;
+  font:
+    13px/1.25 "Lucida Console",
+    "Courier New",
+    monospace;
+  white-space: pre;
+  overflow: auto;
 }
 
 .notepad-editor.word-wrap {
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 .notepad-status {
-    flex: none;
-    height: 19px;
-    padding: 2px 8px;
-    border-top: 1px solid #fff;
-    background: var(--xp-beige);
-    box-shadow: inset 0 1px #aca899;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
-    text-align: right;
+  flex: none;
+  height: 19px;
+  padding: 2px 8px;
+  border-top: 1px solid #fff;
+  background: var(--xp-beige);
+  box-shadow: inset 0 1px #aca899;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
+  text-align: right;
 }
 
 .explorer-window {
-    background: #fff;
+  background: #fff;
 }
 
 .explorer-content {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    background: #fff;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #fff;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
-.explorer-chrome { flex: none; background: #ece9d8; color: #000; }
-.explorer-menu-row { display: flex; min-height: 25px; border-bottom: 1px solid #d6d2c2; }
-.explorer-menu-bar, .explorer-toolbar { display: flex; align-items: center; gap: 2px; padding: 2px 5px; }
-.explorer-menu-bar { flex: 1; }
-.explorer-menu-bar button, .explorer-toolbar button { border: 1px solid transparent; background: transparent; font: inherit; padding: 2px 7px; }
-.explorer-brand { display: grid; width: 40px; place-items: center; background: #fff; }
-.explorer-brand img { width: 22px; height: 20px; object-fit: contain; }
-.explorer-toolbar { min-height: 51px; padding-block: 3px; border-bottom: 1px solid #aca899; }
-.explorer-toolbar button { display: inline-flex; align-items: center; gap: 4px; min-height: 43px; }
-.explorer-toolbar button img { width: 32px; height: 32px; object-fit: contain; }
-.explorer-toolbar button[data-explorer-action="up"] img { width: 28px; height: 28px; }
+.explorer-chrome {
+  flex: none;
+  background: #ece9d8;
+  color: #000;
+}
+.explorer-menu-row {
+  display: flex;
+  min-height: 25px;
+  border-bottom: 1px solid #d6d2c2;
+}
+.explorer-menu-bar,
+.explorer-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 5px;
+}
+.explorer-menu-bar {
+  flex: 1;
+}
+.explorer-menu-bar button,
+.explorer-toolbar button {
+  border: 1px solid transparent;
+  background: transparent;
+  font: inherit;
+  padding: 2px 7px;
+}
+.explorer-brand {
+  display: grid;
+  width: 40px;
+  place-items: center;
+  background: #fff;
+}
+.explorer-brand img {
+  width: 22px;
+  height: 20px;
+  object-fit: contain;
+}
+.explorer-toolbar {
+  min-height: 51px;
+  padding-block: 3px;
+  border-bottom: 1px solid #aca899;
+}
+.explorer-toolbar button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 43px;
+}
+.explorer-toolbar button img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+}
+.explorer-toolbar button[data-explorer-action="up"] img {
+  width: 28px;
+  height: 28px;
+}
 .explorer-toolbar button[data-explorer-action="search"] img,
-.explorer-toolbar button[data-explorer-action="folders"] img { width: 30px; height: 30px; }
-.explorer-toolbar button[data-explorer-action="view"] img { width: 28px; height: 28px; }
-.toolbar-drop-arrow { color: #7e8b98; font-size: 9px; line-height: 1; }
+.explorer-toolbar button[data-explorer-action="folders"] img {
+  width: 30px;
+  height: 30px;
+}
+.explorer-toolbar button[data-explorer-action="view"] img {
+  width: 28px;
+  height: 28px;
+}
+.toolbar-drop-arrow {
+  color: #7e8b98;
+  font-size: 9px;
+  line-height: 1;
+}
 .explorer-toolbar button:not(:disabled):hover,
-.explorer-toolbar button[aria-pressed="true"] { border-color: #aca899; background: linear-gradient(#fff, #ddd9c8); }
-.explorer-toolbar-separator { align-self: stretch; width: 1px; margin: 1px 4px; background: #aca899; border-right: 1px solid #fff; }
-.explorer-toolbar button:disabled { color: #888; }
-.explorer-toolbar button:disabled img { filter: grayscale(1); opacity: .48; }
-.explorer-address { display: flex; align-items: center; gap: 6px; min-height: 31px; padding: 3px 7px; border-bottom: 1px solid #aca899; }
-.explorer-address-field { display: flex; flex: 1; min-width: 0; align-items: center; background: #fff; border: 1px solid #7f9db9; }
-.explorer-address-field img { width: 18px; height: 18px; margin: 2px 4px; object-fit: contain; }
-.explorer-address input { flex: 1; min-width: 0; height: 23px; padding: 1px 3px; border: 0; outline: 0; font: inherit; }
-.explorer-address button { display: inline-flex; width: 28px; height: 24px; align-items: center; justify-content: center; padding: 0; border: 0; background: transparent; }
-.explorer-address button img { width: 23px; height: 23px; object-fit: contain; }
-.explorer-body { flex: 1; min-height: 0; display: grid; grid-template-columns: 220px minmax(0, 1fr); overflow: hidden; }
-.explorer-status { flex: none; min-height: 18px; padding: 2px 6px; border-top: 1px solid #aca899; background: #ece9d8; }
-.explorer-content:not(.folders-visible) .explorer-tree-section { display: none; }
-.explorer-content.folders-visible .explorer-sidebar > section:not(.explorer-tree-section) { display: none; }
+.explorer-toolbar button[aria-pressed="true"] {
+  border-color: #aca899;
+  background: linear-gradient(#fff, #ddd9c8);
+}
+.explorer-toolbar-separator {
+  align-self: stretch;
+  width: 1px;
+  margin: 1px 4px;
+  background: #aca899;
+  border-right: 1px solid #fff;
+}
+.explorer-toolbar button:disabled {
+  color: #888;
+}
+.explorer-toolbar button:disabled img {
+  filter: grayscale(1);
+  opacity: 0.48;
+}
+.explorer-address {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 31px;
+  padding: 3px 7px;
+  border-bottom: 1px solid #aca899;
+}
+.explorer-address-field {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #7f9db9;
+}
+.explorer-address-field img {
+  width: 18px;
+  height: 18px;
+  margin: 2px 4px;
+  object-fit: contain;
+}
+.explorer-address input {
+  flex: 1;
+  min-width: 0;
+  height: 23px;
+  padding: 1px 3px;
+  border: 0;
+  outline: 0;
+  font: inherit;
+}
+.explorer-address button {
+  display: inline-flex;
+  width: 28px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+.explorer-address button img {
+  width: 23px;
+  height: 23px;
+  object-fit: contain;
+}
+.explorer-body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  overflow: hidden;
+}
+.explorer-status {
+  flex: none;
+  min-height: 18px;
+  padding: 2px 6px;
+  border-top: 1px solid #aca899;
+  background: #ece9d8;
+}
+.explorer-content:not(.folders-visible) .explorer-tree-section {
+  display: none;
+}
+.explorer-content.folders-visible
+  .explorer-sidebar
+  > section:not(.explorer-tree-section) {
+  display: none;
+}
 
 .explorer-sidebar {
-    padding: 8px;
-    overflow: auto;
-    background: linear-gradient(#899bfd, #5468d4);
+  padding: 8px;
+  overflow: auto;
+  background: linear-gradient(#899bfd, #5468d4);
 }
 
 .explorer-sidebar section {
-    margin-bottom: 10px;
-    padding: 0 8px 8px;
-    overflow: hidden;
-    border-radius: 4px 4px 0 0;
-    background: linear-gradient(#f6f6f6, #d2d8fc);
+  margin-bottom: 10px;
+  padding: 0 8px 8px;
+  overflow: hidden;
+  border-radius: 4px 4px 0 0;
+  background: linear-gradient(#f6f6f6, #d2d8fc);
 }
 
 .explorer-sidebar h3 {
-    margin: 0 -8px 6px;
-    background: linear-gradient(90deg, #3064df, #2358d0);
-    color: #fff;
-    font-size: 12px;
+  margin: 0 -8px 6px;
+  background: linear-gradient(90deg, #3064df, #2358d0);
+  color: #fff;
+  font-size: 12px;
 }
 
 .explorer-sidebar h3 .explorer-section-toggle {
-    display: flex;
-    width: 100%;
-    align-items: center;
-    justify-content: space-between;
-    padding: 5px 5px 5px 8px;
-    border: 0;
-    background: transparent;
-    color: #fff;
-    font: inherit;
-    font-weight: 700;
-    text-align: left;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 5px 5px 8px;
+  border: 0;
+  background: transparent;
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  text-align: left;
 }
 
 .explorer-sidebar h3 .explorer-section-toggle span[aria-hidden="true"] {
-    display: inline-grid;
-    width: 15px;
-    height: 15px;
-    place-items: center;
-    border: 1px solid #fff;
-    border-radius: 50%;
-    background: #3769df;
-    color: #fff;
+  display: inline-grid;
+  width: 15px;
+  height: 15px;
+  place-items: center;
+  border: 1px solid #fff;
+  border-radius: 50%;
+  background: #3769df;
+  color: #fff;
 }
 
-.explorer-sidebar section.collapsed { padding-bottom: 0; border-radius: 4px; }
-.explorer-sidebar section.collapsed h3 { margin-bottom: 0; }
-.explorer-sidebar section.collapsed .explorer-section-body { display: none; }
+.explorer-sidebar section.collapsed {
+  padding-bottom: 0;
+  border-radius: 4px;
+}
+.explorer-sidebar section.collapsed h3 {
+  margin-bottom: 0;
+}
+.explorer-sidebar section.collapsed .explorer-section-body {
+  display: none;
+}
 
 .explorer-sidebar .explorer-section-body > button,
 .explorer-tree-item {
-    display: flex;
-    width: 100%;
-    align-items: center;
-    gap: 7px;
-    padding: 3px 2px;
-    border: 0;
-    background: transparent;
-    color: #215dc6;
-    font: inherit;
-    text-align: left;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 2px;
+  border: 0;
+  background: transparent;
+  color: #215dc6;
+  font: inherit;
+  text-align: left;
 }
 
-.explorer-sidebar .explorer-section-body > button img { width: 20px; height: 20px; flex: none; object-fit: contain; }
-.explorer-sidebar .explorer-section-body > button span { line-height: 1.2; }
+.explorer-sidebar .explorer-section-body > button img {
+  width: 20px;
+  height: 20px;
+  flex: none;
+  object-fit: contain;
+}
+.explorer-sidebar .explorer-section-body > button span {
+  line-height: 1.2;
+}
 
-.explorer-tree { max-height: 180px; overflow: auto; }
-.explorer-tree-item { padding-left: 6px !important; color: #000 !important; }
-.explorer-tree-item.active { background: #316ac5 !important; color: #fff !important; }
+.explorer-tree {
+  max-height: 180px;
+  overflow: auto;
+}
+.explorer-tree-item {
+  padding-left: 6px !important;
+  color: #000 !important;
+}
+.explorer-tree-item.active {
+  background: #316ac5 !important;
+  color: #fff !important;
+}
 
 .explorer-main {
-    min-width: 0;
-    padding: 6px 8px;
-    overflow: auto;
-    background: #f7faff;
+  min-width: 0;
+  padding: 6px 8px;
+  overflow: auto;
+  background: #f7faff;
 }
 
 .explorer-main h2 {
-    margin: 0 0 12px;
-    padding-bottom: 4px;
-    border-bottom: 1px solid #d6dff7;
-    color: #215dc6;
-    font-size: 13px;
-    font-weight: 400;
+  margin: 0 0 12px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #d6dff7;
+  color: #215dc6;
+  font-size: 13px;
+  font-weight: 400;
 }
 
 .explorer-items {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(185px, 1fr));
-    gap: 2px 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(185px, 1fr));
+  gap: 2px 16px;
 }
 
 .explorer-group-heading {
-    grid-column: 1 / -1;
-    max-width: 360px;
-    margin: 3px 0 7px;
-    padding: 0 0 3px 2px;
-    border-bottom: 2px solid;
-    border-image: linear-gradient(90deg, #4c8df6, transparent) 1;
-    color: #000;
-    font-size: 11px;
-    font-weight: 700;
+  grid-column: 1 / -1;
+  max-width: 360px;
+  margin: 3px 0 7px;
+  padding: 0 0 3px 2px;
+  border-bottom: 2px solid;
+  border-image: linear-gradient(90deg, #4c8df6, transparent) 1;
+  color: #000;
+  font-size: 11px;
+  font-weight: 700;
 }
 
 .my-computer-item {
-    max-width: 185px;
-    min-height: 58px;
-    padding: 2px 8px;
+  max-width: 185px;
+  min-height: 58px;
+  padding: 2px 8px;
 }
 
 .my-computer-item .explorer-item-icon,
 .my-computer-item .explorer-item-icon img {
-    width: 50px;
-    height: 50px;
+  width: 50px;
+  height: 50px;
 }
 
 .explorer-item {
-    display: flex;
-    align-items: center;
-    gap: 9px;
-    min-height: 52px;
-    padding: 5px;
-    border: 1px solid transparent;
-    background: transparent;
-    border-radius: 3px;
-    font: inherit;
-    color: inherit;
-    text-align: left;
-    cursor: var(--xp-cursor);
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 52px;
+  padding: 5px;
+  border: 1px solid transparent;
+  background: transparent;
+  border-radius: 3px;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: var(--xp-cursor);
 }
 
 .explorer-item:hover,
 .explorer-item:focus-visible {
-    border-color: #7f9db9;
-    background: #d8e7f8;
-    outline: 0;
+  border-color: #7f9db9;
+  background: #d8e7f8;
+  outline: 0;
 }
 
-.explorer-item.selected { border-color: #316ac5; background: #316ac5; color: #fff; }
-.drop-target { outline: 2px solid #316ac5 !important; background: #d8e7f8 !important; }
-#window-switcher { position: fixed; z-index: 9900; left: 50%; top: 50%; transform: translate(-50%, -50%); min-width: 210px; padding: 18px 24px; color: #fff; background: rgba(18, 54, 108, .92); border: 2px solid #d6e7ff; box-shadow: 3px 3px 10px #000; text-align: center; font-weight: 700; }
-.explorer-item.selected small { color: #fff; }
-.search-companion-content { display: grid; grid-template-columns: minmax(185px, 34%) 1fr; height: 100%; background: #fff; color: #111; }
-.search-companion-panel { display: flex; flex-direction: column; gap: 7px; padding: 14px; background: linear-gradient(#eff7ff, #cfe5fa); border-right: 1px solid #8aa9c5; }
-.search-companion-panel h2, .search-results-pane h2 { margin: 0 0 5px; font-size: 15px; color: #174a86; }
-.search-companion-panel .xp-btn { align-self: flex-start; margin-top: 6px; }
-.search-results-pane { min-width: 0; padding: 14px; overflow: auto; }
-.search-results-status { margin: 0 0 8px; }
-.search-results-list { display: grid; gap: 3px; }
-.search-results-list .explorer-item { width: 100%; text-align: left; }
+.explorer-item.selected {
+  border-color: #316ac5;
+  background: #316ac5;
+  color: #fff;
+}
+.drop-target {
+  outline: 2px solid #316ac5 !important;
+  background: #d8e7f8 !important;
+}
+#window-switcher {
+  position: fixed;
+  z-index: 9900;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  min-width: 210px;
+  padding: 18px 24px;
+  color: #fff;
+  background: rgba(18, 54, 108, 0.92);
+  border: 2px solid #d6e7ff;
+  box-shadow: 3px 3px 10px #000;
+  text-align: center;
+  font-weight: 700;
+}
+.explorer-item.selected small {
+  color: #fff;
+}
+.search-companion-content {
+  display: grid;
+  grid-template-columns: minmax(185px, 34%) 1fr;
+  height: 100%;
+  background: #fff;
+  color: #111;
+}
+.search-companion-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 14px;
+  background: linear-gradient(#eff7ff, #cfe5fa);
+  border-right: 1px solid #8aa9c5;
+}
+.search-companion-panel h2,
+.search-results-pane h2 {
+  margin: 0 0 5px;
+  font-size: 15px;
+  color: #174a86;
+}
+.search-companion-panel .xp-btn {
+  align-self: flex-start;
+  margin-top: 6px;
+}
+.search-results-pane {
+  min-width: 0;
+  padding: 14px;
+  overflow: auto;
+}
+.search-results-status {
+  margin: 0 0 8px;
+}
+.search-results-list {
+  display: grid;
+  gap: 3px;
+}
+.search-results-list .explorer-item {
+  width: 100%;
+  text-align: left;
+}
 
 .internet-games-content {
-    display: flex;
-    min-height: 0;
-    flex-direction: column;
-    overflow: hidden;
-    background: #fff;
-    color: #111;
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  background: #fff;
+  color: #111;
 }
 
 .internet-games-header {
-    display: flex;
-    min-height: 92px;
-    align-items: center;
-    justify-content: space-between;
-    padding: 13px 20px;
-    border-bottom: 1px solid #7f9db9;
-    background:
-        radial-gradient(circle at 74% 30%, rgb(255 255 255 / 65%), transparent 23%),
-        linear-gradient(115deg, #edf6ff, #bfdcff 58%, #f8fbff);
+  display: flex;
+  min-height: 92px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 13px 20px;
+  border-bottom: 1px solid #7f9db9;
+  background:
+    radial-gradient(circle at 74% 30%, rgb(255 255 255 / 65%), transparent 23%),
+    linear-gradient(115deg, #edf6ff, #bfdcff 58%, #f8fbff);
 }
 
 .internet-games-header h1 {
-    margin: 0 0 4px;
-    color: #174a86;
-    font-family: "Trebuchet MS", Tahoma, sans-serif;
-    font-size: 24px;
-    font-weight: normal;
+  margin: 0 0 4px;
+  color: #174a86;
+  font-family: "Trebuchet MS", Tahoma, sans-serif;
+  font-size: 24px;
+  font-weight: normal;
 }
 
-.internet-games-header p { margin: 0; color: #31567c; }
+.internet-games-header p {
+  margin: 0;
+  color: #31567c;
+}
 .internet-games-header img {
-    width: 58px;
-    height: 58px;
-    object-fit: contain;
-    filter: drop-shadow(2px 3px 2px rgb(30 70 120 / 25%));
+  width: 58px;
+  height: 58px;
+  object-fit: contain;
+  filter: drop-shadow(2px 3px 2px rgb(30 70 120 / 25%));
 }
 
 .internet-games-tabs {
-    display: flex;
-    gap: 2px;
-    padding: 6px 10px 0;
-    border-bottom: 1px solid #919b9c;
-    background: #ece9d8;
+  display: flex;
+  gap: 2px;
+  padding: 6px 10px 0;
+  border-bottom: 1px solid #919b9c;
+  background: #ece9d8;
 }
 
 .internet-games-tabs button {
-    min-width: 92px;
-    padding: 5px 12px 4px;
-    border: 1px solid #919b9c;
-    border-bottom: 0;
-    border-radius: 3px 3px 0 0;
-    background: linear-gradient(#fff, #ddd9c8);
-    font: inherit;
+  min-width: 92px;
+  padding: 5px 12px 4px;
+  border: 1px solid #919b9c;
+  border-bottom: 0;
+  border-radius: 3px 3px 0 0;
+  background: linear-gradient(#fff, #ddd9c8);
+  font: inherit;
 }
 
 .internet-games-tabs button[aria-selected="true"] {
-    position: relative;
-    bottom: -1px;
-    padding-top: 4px;
-    border-top: 2px solid #ffc73c;
-    background: #fff;
-    font-weight: bold;
+  position: relative;
+  bottom: -1px;
+  padding-top: 4px;
+  border-top: 2px solid #ffc73c;
+  background: #fff;
+  font-weight: bold;
 }
 
 .internet-games-panel {
-    min-height: 0;
-    flex: 1;
-    padding: 13px;
-    overflow: auto;
+  min-height: 0;
+  flex: 1;
+  padding: 13px;
+  overflow: auto;
 }
 
 .internet-games-search {
-    display: grid;
-    max-width: 560px;
-    gap: 5px;
+  display: grid;
+  max-width: 560px;
+  gap: 5px;
 }
 
 .internet-games-search > span {
-    display: flex;
-    gap: 6px;
+  display: flex;
+  gap: 6px;
 }
 
-.internet-games-search input { min-width: 0; flex: 1; }
+.internet-games-search input {
+  min-width: 0;
+  flex: 1;
+}
 .internet-games-status,
 .internet-games-installed-status {
-    min-height: 18px;
-    margin: 10px 0;
-    color: #454545;
+  min-height: 18px;
+  margin: 10px 0;
+  color: #454545;
 }
 
 .internet-games-results,
 .internet-games-installed {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 9px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 9px;
 }
 
 .internet-game-card {
-    display: grid;
-    min-height: 100px;
-    grid-template-columns: 76px minmax(0, 1fr);
-    gap: 9px;
-    padding: 8px;
-    border: 1px solid #b8c7d7;
-    background: linear-gradient(135deg, #fff, #f1f6fb);
-    box-shadow: inset 1px 1px #fff;
+  display: grid;
+  min-height: 100px;
+  grid-template-columns: 76px minmax(0, 1fr);
+  gap: 9px;
+  padding: 8px;
+  border: 1px solid #b8c7d7;
+  background: linear-gradient(135deg, #fff, #f1f6fb);
+  box-shadow: inset 1px 1px #fff;
 }
 
 .internet-game-artwork {
-    display: grid;
-    width: 76px;
-    height: 60px;
-    place-items: center;
-    overflow: hidden;
-    border: 1px solid #9aabbc;
-    background: #fff;
+  display: grid;
+  width: 76px;
+  height: 60px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid #9aabbc;
+  background: #fff;
 }
 
 .internet-game-artwork.missing::before {
-    content: "🎮";
-    font-size: 28px;
+  content: "🎮";
+  font-size: 28px;
 }
 
 .internet-game-artwork img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
-.internet-game-card-body { min-width: 0; }
+.internet-game-card-body {
+  min-width: 0;
+}
 .internet-game-card h2 {
-    margin: 0 0 2px;
-    overflow: hidden;
-    color: #174a86;
-    font-size: 14px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  margin: 0 0 2px;
+  overflow: hidden;
+  color: #174a86;
+  font-size: 14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .internet-game-developer,
 .internet-game-tags {
-    margin: 2px 0;
-    overflow: hidden;
-    color: #555;
-    font-size: 11px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  margin: 2px 0;
+  overflow: hidden;
+  color: #555;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.internet-game-tags { color: #32639a; }
+.internet-game-tags {
+  color: #32639a;
+}
 .internet-game-actions {
-    display: flex;
-    grid-column: 1 / -1;
-    justify-content: flex-end;
-    gap: 5px;
+  display: flex;
+  grid-column: 1 / -1;
+  justify-content: flex-end;
+  gap: 5px;
 }
 
-.internet-game-actions .xp-btn { min-width: 78px; }
-.explorer-items[data-view="icons"] { grid-template-columns: repeat(auto-fill, minmax(92px, 1fr)); }
-.explorer-items[data-view="thumbnails"] { grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); }
-.explorer-items[data-view="thumbnails"] .explorer-item { min-height: 110px; flex-direction: column; align-items: flex-start; }
-.explorer-items[data-view="list"] { display: block; }
-.explorer-items[data-view="list"] .explorer-item { min-height: 28px; }
-.explorer-items[data-view="details"] { display: block; }
-.explorer-details-header, .explorer-details-row { display: grid; grid-template-columns: minmax(180px, 1fr) 150px 80px; align-items: center; }
-.explorer-details-header { padding: 3px 6px; border-bottom: 1px solid #aaa; background: #ece9d8; font-weight: bold; }
-.explorer-items[data-view="details"] .explorer-item-icon { grid-row: 1; }
-.explorer-items[data-view="details"] .explorer-item > span:nth-child(2) { min-width: 0; }
-.explorer-items[data-view="details"] .explorer-item { min-height: 30px; border-bottom: 1px solid #eee; }
+.internet-game-actions .xp-btn {
+  min-width: 78px;
+}
+.explorer-items[data-view="icons"] {
+  grid-template-columns: repeat(auto-fill, minmax(92px, 1fr));
+}
+.explorer-items[data-view="thumbnails"] {
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+}
+.explorer-items[data-view="thumbnails"] .explorer-item {
+  min-height: 110px;
+  flex-direction: column;
+  align-items: flex-start;
+}
+.explorer-items[data-view="list"] {
+  display: block;
+}
+.explorer-items[data-view="list"] .explorer-item {
+  min-height: 28px;
+}
+.explorer-items[data-view="details"] {
+  display: block;
+}
+.explorer-details-header,
+.explorer-details-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) 150px 80px;
+  align-items: center;
+}
+.explorer-details-header {
+  padding: 3px 6px;
+  border-bottom: 1px solid #aaa;
+  background: #ece9d8;
+  font-weight: bold;
+}
+.explorer-items[data-view="details"] .explorer-item-icon {
+  grid-row: 1;
+}
+.explorer-items[data-view="details"] .explorer-item > span:nth-child(2) {
+  min-width: 0;
+}
+.explorer-items[data-view="details"] .explorer-item {
+  min-height: 30px;
+  border-bottom: 1px solid #eee;
+}
 
 .explorer-item-icon {
-    width: 42px;
-    height: 42px;
-    flex: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+  width: 42px;
+  height: 42px;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .explorer-item-emoji {
-    font-size: 30px;
+  font-size: 30px;
 }
 
 .explorer-item img,
 .drive-icon,
 .disc-icon {
-    width: 42px;
-    height: 42px;
-    flex: none;
-    object-fit: contain;
+  width: 42px;
+  height: 42px;
+  flex: none;
+  object-fit: contain;
 }
 
 .drive-icon {
-    border-radius: 3px;
-    background:
-        linear-gradient(#d6d6d6 0 58%, #777 59% 64%, #eee 65% 100%);
-    border: 1px solid #555;
-    box-shadow: inset 3px 3px 0 #f5f5f5;
+  border-radius: 3px;
+  background: linear-gradient(#d6d6d6 0 58%, #777 59% 64%, #eee 65% 100%);
+  border: 1px solid #555;
+  box-shadow: inset 3px 3px 0 #f5f5f5;
 }
 
 .disc-icon {
-    border-radius: 50%;
-    background:
-        radial-gradient(circle, #555 0 8%, #fff 9% 18%, transparent 19%),
-        conic-gradient(#b8e6ff, #fbd9ff, #fff8af, #aef0d1, #b8e6ff);
-    border: 1px solid #777;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, #555 0 8%, #fff 9% 18%, transparent 19%),
+    conic-gradient(#b8e6ff, #fbd9ff, #fff8af, #aef0d1, #b8e6ff);
+  border: 1px solid #777;
 }
 
 .explorer-item span:last-child {
-    display: flex;
-    min-width: 0;
-    flex-direction: column;
-    gap: 3px;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .explorer-item small {
-    color: #777;
+  color: #777;
 }
 
 .explorer-empty {
-    color: #777;
+  color: #777;
 }
 
 .display-properties-content {
-    flex: 1;
-    position: relative;
-    min-height: 0;
-    padding: 38px 14px 48px;
-    overflow: auto;
-    background: #ece9d8;
-    color: #111;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  flex: 1;
+  position: relative;
+  min-height: 0;
+  padding: 38px 14px 48px;
+  overflow: auto;
+  background: #ece9d8;
+  color: #111;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
 .display-tabs {
-    position: absolute;
-    top: 8px;
-    left: 8px;
-    right: 8px;
-    display: flex;
-    align-items: end;
-    gap: 1px;
-    border-bottom: 1px solid #919b9c;
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  display: flex;
+  align-items: end;
+  gap: 1px;
+  border-bottom: 1px solid #919b9c;
 }
 
 .display-tabs button {
-    height: 23px;
-    padding: 2px 8px;
-    border: 1px solid #919b9c;
-    border-bottom: 0;
-    border-radius: 3px 3px 0 0;
-    background: #ece9d8;
-    font: inherit;
+  height: 23px;
+  padding: 2px 8px;
+  border: 1px solid #919b9c;
+  border-bottom: 0;
+  border-radius: 3px 3px 0 0;
+  background: #ece9d8;
+  font: inherit;
 }
 
 .display-tabs button.active {
-    position: relative;
-    height: 26px;
-    margin-bottom: -1px;
-    background: #fff;
-    font-weight: 700;
+  position: relative;
+  height: 26px;
+  margin-bottom: -1px;
+  background: #fff;
+  font-weight: 700;
 }
 
 .display-panel {
-    min-height: 250px;
-    padding: 4px 0;
+  min-height: 250px;
+  padding: 4px 0;
 }
 
 .display-panel fieldset {
-    max-width: 420px;
-    margin: 12px auto;
-    padding: 12px;
-    border: 1px solid #919b9c;
+  max-width: 420px;
+  margin: 12px auto;
+  padding: 12px;
+  border: 1px solid #919b9c;
 }
 
 .display-panel legend {
-    padding: 0 4px;
+  padding: 0 4px;
 }
 
 .display-preview {
-    width: min(260px, 82%);
-    aspect-ratio: 4 / 3;
-    margin: 4px auto 14px;
-    padding: 16px 14px 25px;
-    border: 5px solid #333;
-    border-radius: 8px;
-    background: #1d1d1d;
-    box-shadow: inset 0 0 0 2px #777;
+  width: min(260px, 82%);
+  aspect-ratio: 4 / 3;
+  margin: 4px auto 14px;
+  padding: 16px 14px 25px;
+  border: 5px solid #333;
+  border-radius: 8px;
+  background: #1d1d1d;
+  box-shadow: inset 0 0 0 2px #777;
 }
 
 .display-preview > div {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    background-color: #3a6ea5;
-    background-image: url("../assets/xp/bliss.jpg");
-    background-position: center;
-    background-size: 100% 100%;
-    background-repeat: no-repeat;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: #3a6ea5;
+  background-image: url("../assets/xp/bliss.jpg");
+  background-position: center;
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
 }
 
-.display-preview > div[data-position="center"] { background-size: auto; }
-.display-preview > div[data-position="tile"] { background-size: auto; background-repeat: repeat; }
+.display-preview > div[data-position="center"] {
+  background-size: auto;
+}
+.display-preview > div[data-position="tile"] {
+  background-size: auto;
+  background-repeat: repeat;
+}
 
 .display-preview > div::after {
-    content: "";
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    height: 9px;
-    background: #245edb;
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 9px;
+  background: #245edb;
 }
 
 .display-preview span {
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    z-index: 1;
-    padding: 0 7px;
-    border-radius: 0 6px 6px 0;
-    background: #3c9b3c;
-    color: #fff;
-    font-size: 7px;
-    font-style: italic;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  z-index: 1;
+  padding: 0 7px;
+  border-radius: 0 6px 6px 0;
+  background: #3c9b3c;
+  color: #fff;
+  font-size: 7px;
+  font-style: italic;
 }
 
 .display-wallpaper-label,
 .display-properties-content select {
-    display: block;
-    width: min(260px, 82%);
-    margin: 0 auto 3px;
+  display: block;
+  width: min(260px, 82%);
+  margin: 0 auto 3px;
 }
 
 .display-form-row {
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    width: min(260px, 82%);
-    margin: 5px auto;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: min(260px, 82%);
+  margin: 5px auto;
 }
 
 .display-form-row select,
 .display-form-row input[type="number"] {
-    flex: 1;
-    min-width: 0;
-    height: 22px;
-    border: 1px solid #7f9db9;
-    background: #fff;
-    font: inherit;
+  flex: 1;
+  min-width: 0;
+  height: 22px;
+  border: 1px solid #7f9db9;
+  background: #fff;
+  font: inherit;
 }
 
-.display-form-row input[type="color"] { width: 35px; height: 22px; padding: 1px; }
+.display-form-row input[type="color"] {
+  width: 35px;
+  height: 22px;
+  padding: 1px;
+}
 
 .display-upload,
 .display-clear-image {
-    display: block;
-    width: min(260px, 82%);
-    margin: 6px auto;
-    color: #003c74;
-    cursor: var(--xp-cursor);
+  display: block;
+  width: min(260px, 82%);
+  margin: 6px auto;
+  color: #003c74;
+  cursor: var(--xp-cursor);
 }
 
 .display-clear-image {
-    border: 0;
-    background: transparent;
-    text-align: left;
-    text-decoration: underline;
-    font: inherit;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  text-decoration: underline;
+  font: inherit;
 }
 
 .display-status {
-    width: min(360px, 82%);
-    min-height: 14px;
-    margin: 6px auto;
-    color: #555;
+  width: min(360px, 82%);
+  min-height: 14px;
+  margin: 6px auto;
+  color: #555;
 }
 
 .screen-saver-preview {
-    width: min(260px, 82%);
-    height: 125px;
-    margin: 14px auto 0;
-    border: 4px solid #222;
-    background: #000;
+  width: min(260px, 82%);
+  height: 125px;
+  margin: 14px auto 0;
+  border: 4px solid #222;
+  background: #000;
 }
 
 .screen-saver-preview[data-saver="marquee"]::after {
-    content: "Astro Flash";
-    display: block;
-    padding: 48px 12px;
-    color: #0f0;
-    font: bold 18px monospace;
-    text-align: center;
+  content: "Astro Flash";
+  display: block;
+  padding: 48px 12px;
+  color: #0f0;
+  font: bold 18px monospace;
+  text-align: center;
 }
 
 .screen-saver-preview[data-saver="stars"] {
-    background-image: radial-gradient(circle at 20% 30%, #fff 0 1px, transparent 2px), radial-gradient(circle at 70% 60%, #fff 0 1px, transparent 2px), radial-gradient(circle at 45% 20%, #fff 0 1px, transparent 2px);
+  background-image:
+    radial-gradient(circle at 20% 30%, #fff 0 1px, transparent 2px),
+    radial-gradient(circle at 70% 60%, #fff 0 1px, transparent 2px),
+    radial-gradient(circle at 45% 20%, #fff 0 1px, transparent 2px);
 }
 
 .appearance-preview {
-    width: min(260px, 82%);
-    margin: 16px auto 0;
-    padding: 5px 7px;
-    border: 1px solid #003c74;
-    background: linear-gradient(#0997ff, #0053ee);
-    color: #fff;
-    font-weight: 700;
+  width: min(260px, 82%);
+  margin: 16px auto 0;
+  padding: 5px 7px;
+  border: 1px solid #003c74;
+  background: linear-gradient(#0997ff, #0053ee);
+  color: #fff;
+  font-weight: 700;
 }
 
-.appearance-preview button { float: right; border: 0; background: transparent; color: inherit; font-weight: 700; }
-.appearance-preview[data-appearance="olive"] { background: linear-gradient(#8da64a, #526e20); }
-.appearance-preview[data-appearance="silver"] { background: linear-gradient(#a7b0bf, #6d7788); }
-.display-settings-note { color: #555; }
+.appearance-preview button {
+  float: right;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-weight: 700;
+}
+.appearance-preview[data-appearance="olive"] {
+  background: linear-gradient(#8da64a, #526e20);
+}
+.appearance-preview[data-appearance="silver"] {
+  background: linear-gradient(#a7b0bf, #6d7788);
+}
+.display-settings-note {
+  color: #555;
+}
 
 .display-resolution-preview {
-    display: grid;
-    place-items: center;
-    width: 150px;
-    height: 105px;
-    margin: 10px auto 4px;
-    border: 8px solid #444;
-    border-radius: 8px;
-    background: #111;
+  display: grid;
+  place-items: center;
+  width: 150px;
+  height: 105px;
+  margin: 10px auto 4px;
+  border: 8px solid #444;
+  border-radius: 8px;
+  background: #111;
 }
 
 .display-resolution-preview span {
-    display: block;
-    border: 1px solid #9db9df;
-    background: linear-gradient(#245edb, #3a6ea5);
+  display: block;
+  border: 1px solid #9db9df;
+  background: linear-gradient(#245edb, #3a6ea5);
 }
 
 .display-resolution-preview[data-resolution="auto"] span {
-    width: 112px;
-    height: 70px;
+  width: 112px;
+  height: 70px;
 }
 
 .display-resolution-preview[data-resolution="800x600"] span {
-    width: 88px;
-    height: 66px;
+  width: 88px;
+  height: 66px;
 }
 
 .display-resolution-preview[data-resolution="1024x768"] span {
-    width: 112px;
-    height: 84px;
+  width: 112px;
+  height: 84px;
 }
 
 .display-resolution-value {
-    margin: 0;
-    text-align: center;
+  margin: 0;
+  text-align: center;
 }
 
 .display-properties-content select {
-    height: 22px;
-    border: 1px solid #7f9db9;
-    background: #fff;
-    font: inherit;
+  height: 22px;
+  border: 1px solid #7f9db9;
+  background: #fff;
+  font: inherit;
 }
 
 .display-dialog-buttons {
-    position: absolute;
-    right: 10px;
-    bottom: 10px;
-    display: flex;
-    gap: 7px;
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  display: flex;
+  gap: 7px;
 }
 
 .display-dialog-buttons button {
-    min-width: 72px;
-    height: 23px;
-    border: 1px solid #003c74;
-    border-radius: 3px;
-    background: linear-gradient(#fff, #ece9d8);
-    font: inherit;
+  min-width: 72px;
+  height: 23px;
+  border: 1px solid #003c74;
+  border-radius: 3px;
+  background: linear-gradient(#fff, #ece9d8);
+  font: inherit;
 }
 
 .display-dialog-buttons button:disabled {
-    color: #aca899;
-    border-color: #aaa;
+  color: #aca899;
+  border-color: #aaa;
 }
 
 /* Resize handles on every edge and corner, with XP resize cursors */
 .resize-handle {
-    position: absolute;
-    z-index: 2;
-    touch-action: none;
+  position: absolute;
+  z-index: 2;
+  touch-action: none;
 }
 
 .resize-n {
-    top: -3px;
-    left: 10px;
-    right: 10px;
-    height: 6px;
-    cursor: n-resize;
+  top: -3px;
+  left: 10px;
+  right: 10px;
+  height: 6px;
+  cursor: n-resize;
 }
 
 .resize-s {
-    bottom: -3px;
-    left: 10px;
-    right: 10px;
-    height: 6px;
-    cursor: s-resize;
+  bottom: -3px;
+  left: 10px;
+  right: 10px;
+  height: 6px;
+  cursor: s-resize;
 }
 
 .resize-e {
-    right: -3px;
-    top: 10px;
-    bottom: 10px;
-    width: 6px;
-    cursor: e-resize;
+  right: -3px;
+  top: 10px;
+  bottom: 10px;
+  width: 6px;
+  cursor: e-resize;
 }
 
 .resize-w {
-    left: -3px;
-    top: 10px;
-    bottom: 10px;
-    width: 6px;
-    cursor: w-resize;
+  left: -3px;
+  top: 10px;
+  bottom: 10px;
+  width: 6px;
+  cursor: w-resize;
 }
 
 .resize-ne {
-    top: -3px;
-    right: -3px;
-    width: 14px;
-    height: 14px;
-    cursor: ne-resize;
+  top: -3px;
+  right: -3px;
+  width: 14px;
+  height: 14px;
+  cursor: ne-resize;
 }
 
 .resize-nw {
-    top: -3px;
-    left: -3px;
-    width: 14px;
-    height: 14px;
-    cursor: nw-resize;
+  top: -3px;
+  left: -3px;
+  width: 14px;
+  height: 14px;
+  cursor: nw-resize;
 }
 
 .resize-sw {
-    bottom: -3px;
-    left: -3px;
-    width: 14px;
-    height: 14px;
-    cursor: sw-resize;
+  bottom: -3px;
+  left: -3px;
+  width: 14px;
+  height: 14px;
+  cursor: sw-resize;
 }
 
 .resize-se {
-    right: 0;
-    bottom: 0;
-    width: 18px;
-    height: 18px;
-    cursor: se-resize;
+  right: 0;
+  bottom: 0;
+  width: 18px;
+  height: 18px;
+  cursor: se-resize;
 }
 
 .xp-window.move-mode {
-    cursor: move;
+  cursor: move;
 }
 
 .xp-window.size-mode {
-    cursor: se-resize;
+  cursor: se-resize;
 }
 
 /* ============ Reusable dialogs ============ */
 
 /* Modal overlay: transparent (no XP dimming) but blocks interaction. */
 .xp-dialog-overlay {
-    position: fixed;
-    inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .xp-dialog {
-    position: relative;
-    width: min(400px, calc(100vw - 32px));
-    min-width: 0;
-    min-height: 0;
+  position: relative;
+  width: min(400px, calc(100vw - 32px));
+  min-width: 0;
+  min-height: 0;
 }
 
 .xp-dialog > .title-bar {
-    cursor: move;
-    touch-action: none;
+  cursor: move;
+  touch-action: none;
 }
 
 .xp-dialog-wide {
-    width: min(520px, calc(100vw - 32px));
+  width: min(520px, calc(100vw - 32px));
 }
 
 .dlg-body {
-    padding: 11px 12px;
-    color: #111;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  padding: 11px 12px;
+  color: #111;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
 /* Standard XP button, input, and dropdown controls */
 .xp-btn {
-    min-width: 70px;
-    height: 23px;
-    padding: 0 10px;
-    border: 1px solid #003c74;
-    border-radius: 3px;
-    background: linear-gradient(180deg, #fff, #ecebe5 86%, #d8d0c4);
-    color: #111;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
-    cursor: var(--xp-cursor);
+  min-width: 70px;
+  height: 23px;
+  padding: 0 10px;
+  border: 1px solid #003c74;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #fff, #ecebe5 86%, #d8d0c4);
+  color: #111;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
+  cursor: var(--xp-cursor);
 }
 
 .xp-btn:hover:not(:disabled) {
-    box-shadow: inset 0 0 0 1px rgba(0, 60, 116, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(0, 60, 116, 0.35);
 }
 
 .xp-btn.default {
-    box-shadow: inset 0 0 0 1px #003c74;
+  box-shadow: inset 0 0 0 1px #003c74;
 }
 
 .xp-btn:focus-visible {
-    outline: 1px dotted #000;
-    outline-offset: -4px;
+  outline: 1px dotted #000;
+  outline-offset: -4px;
 }
 
 .xp-btn:disabled {
-    border-color: #c9c7ba;
-    background: #f5f4ea;
-    color: #a1a192;
-    cursor: var(--xp-cursor);
+  border-color: #c9c7ba;
+  background: #f5f4ea;
+  color: #a1a192;
+  cursor: var(--xp-cursor);
 }
 
 .xp-input,
 .xp-select {
-    height: 22px;
-    padding: 0 4px;
-    border: 1px solid #7f9db9;
-    background: #fff;
-    color: #111;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  height: 22px;
+  padding: 0 4px;
+  border: 1px solid #7f9db9;
+  background: #fff;
+  color: #111;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
 .xp-input:focus-visible,
 .xp-select:focus-visible {
-    outline: 1px dotted #000;
-    outline-offset: -2px;
+  outline: 1px dotted #000;
+  outline-offset: -2px;
 }
 
 .xp-input:disabled,
 .xp-select:disabled {
-    background: #f5f4ea;
-    color: #a1a192;
+  background: #f5f4ea;
+  color: #a1a192;
 }
 
 /* Message boxes */
 .dlg-message {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    padding: 5px 4px 13px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 5px 4px 13px;
 }
 
 .dlg-text {
-    margin: 0;
-    white-space: pre-line;
+  margin: 0;
+  white-space: pre-line;
 }
 
 .dlg-icon {
-    position: relative;
-    width: 32px;
-    height: 32px;
-    flex: none;
+  position: relative;
+  width: 32px;
+  height: 32px;
+  flex: none;
 }
 
 .dlg-icon::before {
-    position: absolute;
-    inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #fff;
-    font-weight: 700;
-    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.4);
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 700;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.4);
 }
 
 .dlg-icon-info,
 .dlg-icon-question,
 .dlg-icon-error {
-    border-radius: 50%;
+  border-radius: 50%;
 }
 
 .dlg-icon-info {
-    background: radial-gradient(circle at 35% 30%, #7db3f4, #1e52b0 70%);
+  background: radial-gradient(circle at 35% 30%, #7db3f4, #1e52b0 70%);
 }
 
 .dlg-icon-info::before {
-    content: "i";
-    font: italic 700 22px Georgia, serif;
+  content: "i";
+  font:
+    italic 700 22px Georgia,
+    serif;
 }
 
 .dlg-icon-question {
-    background: radial-gradient(circle at 35% 30%, #7db3f4, #1e52b0 70%);
+  background: radial-gradient(circle at 35% 30%, #7db3f4, #1e52b0 70%);
 }
 
 .dlg-icon-question::before {
-    content: "?";
-    font-size: 20px;
+  content: "?";
+  font-size: 20px;
 }
 
 .dlg-icon-error {
-    background: radial-gradient(circle at 35% 30%, #f49a8c, #c13018 70%);
+  background: radial-gradient(circle at 35% 30%, #f49a8c, #c13018 70%);
 }
 
 .dlg-icon-error::before {
-    content: "×";
-    font-size: 24px;
+  content: "×";
+  font-size: 24px;
 }
 
 .dlg-icon-warning {
-    background: linear-gradient(180deg, #fdf17e, #e5b60f);
-    clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  background: linear-gradient(180deg, #fdf17e, #e5b60f);
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
 }
 
 .dlg-icon-warning::before {
-    content: "!";
-    top: 6px;
-    color: #111;
-    font-size: 18px;
-    text-shadow: none;
+  content: "!";
+  top: 6px;
+  color: #111;
+  font-size: 18px;
+  text-shadow: none;
 }
 
 .dlg-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 6px;
-    padding-top: 2px;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  padding-top: 2px;
 }
 
 .xp-dialog-wide .dlg-buttons {
-    justify-content: flex-end;
+  justify-content: flex-end;
 }
 
 /* Progress dialog */
 .dlg-progress-text {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
 
 .xp-progress {
-    height: 16px;
-    padding: 1px;
-    border: 1px solid #68635a;
-    background: #fff;
+  height: 16px;
+  padding: 1px;
+  border: 1px solid #68635a;
+  background: #fff;
 }
 
 .xp-progress-fill {
-    width: 0;
-    height: 100%;
-    background: repeating-linear-gradient(
-        90deg,
-        #37c837 0 8px,
-        transparent 8px 11px
-    );
-    transition: width 0.15s;
+  width: 0;
+  height: 100%;
+  background: repeating-linear-gradient(
+    90deg,
+    #37c837 0 8px,
+    transparent 8px 11px
+  );
+  transition: width 0.15s;
 }
 
 .dlg-progress-text + .xp-progress {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 /* Properties dialog */
 .dlg-props-header {
-    display: flex;
-    align-items: center;
-    gap: 9px;
-    padding-bottom: 9px;
-    margin-bottom: 9px;
-    border-bottom: 1px solid #d4d0c8;
-    box-shadow: 0 1px #fff;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding-bottom: 9px;
+  margin-bottom: 9px;
+  border-bottom: 1px solid #d4d0c8;
+  box-shadow: 0 1px #fff;
 }
 
 .dlg-props-name {
-    font-weight: 700;
+  font-weight: 700;
 }
 
 .dlg-props-table {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 4px 10px;
-    margin: 0 0 10px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 10px;
+  margin: 0 0 10px;
 }
 
 .dlg-props-table dt {
-    color: #444;
+  color: #444;
 }
 
 .dlg-props-table dd {
-    margin: 0;
+  margin: 0;
 }
 
 /* Network connection status */
 
 .dlg-network-icon {
-    width: 32px;
-    height: 32px;
-    object-fit: contain;
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
 }
 
 /* Astro Flash project settings */
 
 .project-settings-content {
-    flex: 1;
-    position: relative;
-    min-height: 0;
-    padding: 42px 14px 14px;
-    overflow: auto;
-    background: var(--xp-beige);
-    color: #111;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  flex: 1;
+  position: relative;
+  min-height: 0;
+  padding: 42px 14px 14px;
+  overflow: auto;
+  background: var(--xp-beige);
+  color: #111;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
 .project-settings-tabs {
-    position: absolute;
-    top: 8px;
-    left: 8px;
-    right: 8px;
-    display: flex;
-    align-items: end;
-    gap: 1px;
-    border-bottom: 1px solid #919b9c;
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  display: flex;
+  align-items: end;
+  gap: 1px;
+  border-bottom: 1px solid #919b9c;
 }
 
 .project-settings-tabs button {
-    height: 23px;
-    padding: 2px 11px;
-    border: 1px solid #919b9c;
-    border-bottom: 0;
-    border-radius: 3px 3px 0 0;
-    background: var(--xp-beige);
-    font: inherit;
+  height: 23px;
+  padding: 2px 11px;
+  border: 1px solid #919b9c;
+  border-bottom: 0;
+  border-radius: 3px 3px 0 0;
+  background: var(--xp-beige);
+  font: inherit;
 }
 
 .project-settings-tabs button.active {
-    position: relative;
-    height: 26px;
-    margin-bottom: -1px;
-    background: #fff;
-    font-weight: 700;
+  position: relative;
+  height: 26px;
+  margin-bottom: -1px;
+  background: #fff;
+  font-weight: 700;
 }
 
 .project-settings-panel {
-    min-height: 310px;
+  min-height: 310px;
 }
 
 .project-settings-panel > fieldset {
-    margin: 0 0 12px;
-    padding: 10px;
+  margin: 0 0 12px;
+  padding: 10px;
 }
 
 .project-settings-panel legend {
-    padding: 0 4px;
+  padding: 0 4px;
 }
 
 .project-settings-product {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin: 0 2px 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 2px 12px;
 }
 
 .project-settings-product img {
-    width: 40px;
-    height: 40px;
-    object-fit: contain;
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
 }
 
 .project-settings-product h2 {
-    margin: 0 0 3px;
-    font-size: 14px;
+  margin: 0 0 3px;
+  font-size: 14px;
 }
 
 .project-settings-product p,
 .project-settings-panel fieldset p {
-    margin: 0 0 9px;
-    color: #444;
+  margin: 0 0 9px;
+  color: #444;
 }
 
 .project-settings-details {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 .project-offline-setting {
-    display: block;
-    margin: 0 0 7px;
-    font-weight: 700;
+  display: block;
+  margin: 0 0 7px;
+  font-weight: 700;
 }
 
 .project-offline-game-list {
-    max-height: 156px;
-    margin: 0 0 10px;
-    overflow: auto;
-    border: 1px solid #7f9db9;
-    background: #fff;
+  max-height: 156px;
+  margin: 0 0 10px;
+  overflow: auto;
+  border: 1px solid #7f9db9;
+  background: #fff;
 }
 
 .project-offline-game {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
-    align-items: center;
-    gap: 6px;
-    min-height: 22px;
-    padding: 1px 5px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  min-height: 22px;
+  padding: 1px 5px;
 }
 
 .project-offline-game:nth-child(even) {
-    background: #f3f6fb;
+  background: #f3f6fb;
 }
 
 .project-offline-game-size {
-    color: #555;
-    white-space: nowrap;
+  color: #555;
+  white-space: nowrap;
 }
 
 .project-settings-description {
-    margin-left: 20px !important;
+  margin-left: 20px !important;
 }
 
 .project-settings-status {
-    min-height: 14px;
-    margin: 0 0 10px !important;
-    color: #444;
+  min-height: 14px;
+  margin: 0 0 10px !important;
+  color: #444;
 }
 
 .project-settings-progress {
-    box-sizing: border-box;
-    width: 100%;
-    margin: 0 0 10px;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 0 0 10px;
 }
 
 .project-settings-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    margin: 0 0 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 10px;
 }
 
 .project-recovery-group {
-    padding-bottom: 10px !important;
+  padding-bottom: 10px !important;
 }
 
 .project-recovery-group p {
-    margin: 0 0 10px;
-    color: #444;
+  margin: 0 0 10px;
+  color: #444;
 }
 
 .project-recovery-danger {
-    border-color: #b46a5d;
+  border-color: #b46a5d;
 }
 
 .project-suggestions-link {
-    color: #0000ee;
+  color: #0000ee;
 }
 
 /* Date and Time Properties */
 
 .dlg-datetime {
-    display: grid;
-    grid-template-columns: minmax(190px, 1fr) minmax(0, 1.2fr);
-    align-items: flex-start;
-    gap: 10px;
-    margin-bottom: 10px;
+  display: grid;
+  grid-template-columns: minmax(190px, 1fr) minmax(0, 1.2fr);
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 10px;
 }
 
 .dlg-group {
-    min-width: 0;
-    margin: 0;
-    padding: 8px 10px 10px;
-    border: 1px solid #d4d0c8;
-    box-shadow: inset 0 0 0 1px #fff;
+  min-width: 0;
+  margin: 0;
+  padding: 8px 10px 10px;
+  border: 1px solid #d4d0c8;
+  box-shadow: inset 0 0 0 1px #fff;
 }
 
 .dlg-group legend {
-    padding: 0 3px;
+  padding: 0 3px;
 }
 
 .dlg-month-year {
-    display: flex;
-    gap: 4px;
-    margin-bottom: 6px;
+  display: flex;
+  gap: 4px;
+  margin-bottom: 6px;
 }
 
 .dlg-month-select {
-    flex: 1;
-    min-width: 0;
+  flex: 1;
+  min-width: 0;
 }
 
 .dlg-year-input {
-    width: 56px;
+  width: 56px;
 }
 
 .dlg-calendar {
-    display: grid;
-    grid-template-columns: repeat(7, 22px);
-    gap: 1px;
+  display: grid;
+  grid-template-columns: repeat(7, 22px);
+  gap: 1px;
 }
 
 .dlg-calendar-head {
-    text-align: center;
-    color: #444;
+  text-align: center;
+  color: #444;
 }
 
 .dlg-calendar-day {
-    width: 22px;
-    height: 16px;
-    padding: 0;
-    border: 1px solid transparent;
-    background: none;
-    color: #111;
-    font: 11px Tahoma, "Segoe UI", sans-serif;
-    text-align: center;
-    cursor: var(--xp-cursor);
+  width: 22px;
+  height: 16px;
+  padding: 0;
+  border: 1px solid transparent;
+  background: none;
+  color: #111;
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
+  text-align: center;
+  cursor: var(--xp-cursor);
 }
 
 .dlg-calendar-day:hover {
-    border-color: #0b61ce;
+  border-color: #0b61ce;
 }
 
 .dlg-calendar-day.today {
-    font-weight: 700;
+  font-weight: 700;
 }
 
 .dlg-calendar-day.selected {
-    background: #0b61ce;
-    color: #fff;
+  background: #0b61ce;
+  color: #fff;
 }
 
 .dlg-calendar-day:focus-visible {
-    outline: 1px dotted #000;
-    outline-offset: -3px;
+  outline: 1px dotted #000;
+  outline-offset: -3px;
 }
 
 .dlg-time-row {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr) auto;
-    align-items: center;
-    gap: 3px;
+  display: grid;
+  grid-template-columns:
+    minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr)
+    auto;
+  align-items: center;
+  gap: 3px;
 }
 
 .dlg-time-input {
-    width: 100%;
-    min-width: 0;
+  width: 100%;
+  min-width: 0;
 }
 
 @media (max-width: 460px) {
-    .dlg-datetime {
-        grid-template-columns: 1fr;
-    }
+  .dlg-datetime {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Node icons (Properties + file dialogs) */
 .dlg-node-icon {
-    width: 32px;
-    height: 32px;
-    flex: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: center;
+  width: 32px;
+  height: 32px;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .dlg-node-icon img {
-    width: 32px;
-    height: 32px;
+  width: 32px;
+  height: 32px;
 }
 
 .dlg-node-icon-file {
-    font-size: 24px;
+  font-size: 24px;
 }
 
 /* Open / Save As dialogs */
 .dlg-file-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
 }
 
 .dlg-file-toolbar .xp-btn {
-    min-width: 44px;
+  min-width: 44px;
 }
 
 .dlg-file-path {
-    flex: 1;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    color: #444;
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: #444;
 }
 
 .dlg-file-list {
-    height: 150px;
-    padding: 2px;
-    overflow-y: auto;
-    border: 1px solid #7f9db9;
-    background: #fff;
+  height: 150px;
+  padding: 2px;
+  overflow-y: auto;
+  border: 1px solid #7f9db9;
+  background: #fff;
 }
 
 .dlg-file-item {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    width: 100%;
-    padding: 2px 4px;
-    border: 0;
-    background: none;
-    color: inherit;
-    font: inherit;
-    text-align: left;
-    cursor: var(--xp-cursor);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+  padding: 2px 4px;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: var(--xp-cursor);
 }
 
 .dlg-file-item .dlg-node-icon,
 .dlg-file-item .dlg-node-icon img {
-    width: 16px;
-    height: 16px;
+  width: 16px;
+  height: 16px;
 }
 
 .dlg-file-item .dlg-node-icon-file {
-    font-size: 13px;
+  font-size: 13px;
 }
 
 .dlg-file-item.selected {
-    background: #316ac5;
-    color: #fff;
+  background: #316ac5;
+  color: #fff;
 }
 
 .dlg-file-name-row {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin: 8px 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 0 10px;
 }
 
 .dlg-file-name-row label {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 .dlg-file-name-row .xp-input {
-    flex: 1;
+  flex: 1;
 }
 
 /* ============ Taskbar ============ */
 
 #taskbar {
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 30px;
-    z-index: 8000;
-    display: flex;
-    align-items: stretch;
-    background: var(--taskbar-gradient);
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 30px;
+  z-index: 8000;
+  display: flex;
+  align-items: stretch;
+  background: var(--taskbar-gradient);
 }
 
 #start-button {
-    flex: none;
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    width: 97px;
-    padding: 0;
-    margin: 0;
-    border: none;
-    border-radius: 0;
-    background: url("../assets/xp/start_btn_normal.png") left / 100% 100% no-repeat;
-    color: transparent;
-    cursor: var(--xp-cursor);
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 97px;
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background: url("../assets/xp/start_btn_normal.png") left / 100% 100%
+    no-repeat;
+  color: transparent;
+  cursor: var(--xp-cursor);
 }
 
 #start-button .start-flag,
 #start-button .start-text {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 #start-button:hover {
-    filter: brightness(1.1);
+  filter: brightness(1.1);
 }
 
 #start-button.active,
 #start-button:active {
-    filter: brightness(0.85) saturate(1.1);
+  filter: brightness(0.85) saturate(1.1);
 }
 
 .start-flag {
-    width: 17px;
-    height: 17px;
-    gap: 1px;
+  width: 17px;
+  height: 17px;
+  gap: 1px;
 }
 
 #task-buttons {
-    --task-button-min-width: 52px;
-    --task-overflow-min-width: 68px;
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 3px 8px;
-    overflow: hidden;
+  --task-button-min-width: 52px;
+  --task-overflow-min-width: 68px;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  overflow: hidden;
 }
 
 .task-button {
-    flex: 1 1 94px;
-    min-width: var(--task-button-min-width);
-    max-width: 158px;
-    height: 22px;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 0 8px;
-    border: 0;
-    border-radius: 2px;
-    background: rgb(60, 129, 243);
-    box-shadow: rgba(0, 0, 0, 0.3) -1px 0 inset,
-        rgba(255, 255, 255, 0.2) 1px 1px 1px inset;
-    color: #fff;
-    font-size: 11px;
-    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.4);
-    cursor: var(--xp-cursor);
-    overflow: hidden;
-    white-space: nowrap;
+  flex: 1 1 94px;
+  min-width: var(--task-button-min-width);
+  max-width: 158px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 2px;
+  background: rgb(60, 129, 243);
+  box-shadow:
+    rgba(0, 0, 0, 0.3) -1px 0 inset,
+    rgba(255, 255, 255, 0.2) 1px 1px 1px inset;
+  color: #fff;
+  font-size: 11px;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.4);
+  cursor: var(--xp-cursor);
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .task-button .task-icon {
-    flex: none;
-    font-size: 13px;
+  flex: none;
+  font-size: 13px;
 }
 
 .task-button .task-icon.has-image {
-    width: 16px;
-    height: 16px;
+  width: 16px;
+  height: 16px;
 }
 
 .task-button .task-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .task-button:hover {
-    filter: brightness(1.25);
+  filter: brightness(1.25);
 }
 
 .task-button:active,
 .task-button[aria-pressed="true"] {
-    transform: translateY(1px);
-    filter: brightness(0.86);
+  transform: translateY(1px);
+  filter: brightness(0.86);
 }
 
 .task-button:focus-visible {
-    outline: 1px dotted #fff;
-    outline-offset: -3px;
+  outline: 1px dotted #fff;
+  outline-offset: -3px;
 }
 
 .task-button-grouped {
-    flex: 0 1 82px;
-    min-width: var(--task-overflow-min-width);
-    justify-content: center;
+  flex: 0 1 82px;
+  min-width: var(--task-overflow-min-width);
+  justify-content: center;
 }
 
 #taskbar-context-menu,
 #taskbar-overflow-menu {
-    position: fixed;
-    z-index: 8200;
+  position: fixed;
+  z-index: 8200;
 }
 
 .task-button.active {
-    background: rgb(30, 82, 183);
-    box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px 1px inset,
-        rgba(0, 0, 0, 0.7) 1px 0 1px inset;
+  background: rgb(30, 82, 183);
+  box-shadow:
+    rgba(0, 0, 0, 0.2) 0 0 1px 1px inset,
+    rgba(0, 0, 0, 0.7) 1px 0 1px inset;
 }
 
 @keyframes task-button-attention {
-    50% { filter: brightness(1.55); background: #e39a12; }
+  50% {
+    filter: brightness(1.55);
+    background: #e39a12;
+  }
 }
 
 .task-button.needs-attention:not(.active) {
-    animation: task-button-attention 900ms step-end infinite;
+  animation: task-button-attention 900ms step-end infinite;
 }
 
 .taskbar-overflow-item.needs-attention {
-    background: #f7c85f;
-    color: #1b1b1b;
-    font-weight: 700;
+  background: #f7c85f;
+  color: #1b1b1b;
+  font-weight: 700;
 }
 
 .taskbar-group-heading {
-    display: block;
-    padding: 4px 7px 2px;
-    color: #1d4f91;
-    font-size: 11px;
-    font-weight: 700;
+  display: block;
+  padding: 4px 7px 2px;
+  color: #1d4f91;
+  font-size: 11px;
+  font-weight: 700;
 }
 
 #taskbar-tray {
-    flex: none;
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    padding: 0 10px 0 7px;
-    margin-left: 10px;
-    background: var(--tray-gradient);
-    border-left: 1px solid rgb(16, 66, 175);
-    box-shadow: inset 1px 0 1px rgb(24, 187, 255);
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 10px 0 7px;
+  margin-left: 10px;
+  background: var(--tray-gradient);
+  border-left: 1px solid rgb(16, 66, 175);
+  box-shadow: inset 1px 0 1px rgb(24, 187, 255);
 }
 
 .tray-icon {
-    position: relative;
-    display: inline-block;
-    flex: none;
-    width: 19px;
-    height: 19px;
-    padding: 1px;
-    border: 1px solid transparent;
-    border-radius: 2px;
-    background-color: transparent;
-    background-position: center;
-    background-size: 15px 15px;
-    background-repeat: no-repeat;
-    cursor: var(--xp-cursor);
+  position: relative;
+  display: inline-block;
+  flex: none;
+  width: 19px;
+  height: 19px;
+  padding: 1px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  background-color: transparent;
+  background-position: center;
+  background-size: 15px 15px;
+  background-repeat: no-repeat;
+  cursor: var(--xp-cursor);
 }
 
 .tray-icon:hover {
-    background-color: rgba(255, 255, 255, 0.14);
-    border-color: rgba(255, 255, 255, 0.35);
+  background-color: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.35);
 }
 
 .tray-icon:active,
 .tray-icon.pressed {
-    background-color: rgba(0, 0, 0, 0.18);
-    border-color: rgba(0, 0, 0, 0.45);
-    box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.4);
+  background-color: rgba(0, 0, 0, 0.18);
+  border-color: rgba(0, 0, 0, 0.45);
+  box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.4);
 }
 
 .tray-icon:focus-visible {
-    outline: 1px dotted #fff;
-    outline-offset: -4px;
+  outline: 1px dotted #fff;
+  outline-offset: -4px;
 }
 
 .tray-network {
-    background-image: url("../assets/xp/icons/NetworkConnection.png");
+  background-image: url("../assets/xp/icons/NetworkConnection.png");
 }
 
 .tray-volume {
-    background-image: url("../assets/xp/icons/Volume.png");
+  background-image: url("../assets/xp/icons/Volume.png");
 }
 
 .tray-volume.muted {
-    background-image: url("../assets/xp/icons/Mute.png");
+  background-image: url("../assets/xp/icons/Mute.png");
 }
 
 #taskbar-clock {
-    color: #fff;
-    font: inherit;
-    font-size: 11px;
-    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
-    background: none;
-    border: 1px solid transparent;
-    border-radius: 2px;
-    padding: 1px 3px;
-    cursor: var(--xp-cursor);
+  color: #fff;
+  font: inherit;
+  font-size: 11px;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  padding: 1px 3px;
+  cursor: var(--xp-cursor);
 }
 
 #taskbar-clock:focus-visible {
-    outline: 1px dotted #fff;
-    outline-offset: -4px;
+  outline: 1px dotted #fff;
+  outline-offset: -4px;
 }
 
 /* Quick volume popup (opens above the tray, like XP's sndvol control) */
 
 #tray-volume-popup {
-    position: fixed;
-    z-index: 8100;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 6px;
-    padding: 10px 9px 8px;
-    background: #ece9d8;
-    border: 1px solid #716f64;
-    box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.45);
-    font: 11px Tahoma, "Segoe UI", sans-serif;
+  position: fixed;
+  z-index: 8100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 9px 8px;
+  background: #ece9d8;
+  border: 1px solid #716f64;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.45);
+  font:
+    11px Tahoma,
+    "Segoe UI",
+    sans-serif;
 }
 
 .tray-volume-slider {
-    writing-mode: vertical-lr;
-    direction: rtl;
-    width: 24px;
-    height: 104px;
-    cursor: var(--xp-cursor);
+  writing-mode: vertical-lr;
+  direction: rtl;
+  width: 24px;
+  height: 104px;
+  cursor: var(--xp-cursor);
 }
 
 .tray-mute-row {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    color: #111;
-    cursor: var(--xp-cursor);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: #111;
+  cursor: var(--xp-cursor);
 }
 
 /* ============ Start menu ============ */
 
 #start-menu {
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    z-index: 7000;
-    width: min(380px, 96vw);
-    display: flex;
-    flex-direction: column;
-    background: rgb(66, 130, 214);
-    border: 0;
-    border-radius: 6px 6px 0 0;
-    box-shadow: 3px -3px 14px rgba(0, 0, 0, 0.45);
-    overflow: hidden;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  z-index: 7000;
+  width: min(380px, 96vw);
+  display: flex;
+  flex-direction: column;
+  background: rgb(66, 130, 214);
+  border: 0;
+  border-radius: 6px 6px 0 0;
+  box-shadow: 3px -3px 14px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
 }
 
 #start-menu::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 3px;
-    right: 3px;
-    height: 3px;
-    border-radius: 6px 6px 0 0;
-    background: linear-gradient(90deg,
-        transparent 0px, rgba(255, 255, 255, 0.3) 1%,
-        rgba(255, 255, 255, 0.5) 2%, rgba(255, 255, 255, 0.5) 95%,
-        rgba(255, 255, 255, 0.3) 98%, rgba(255, 255, 255, 0.2) 99%,
-        transparent 100%);
-    box-shadow: inset 0 -1px 1px rgb(14, 96, 203);
-    pointer-events: none;
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 3px;
+  right: 3px;
+  height: 3px;
+  border-radius: 6px 6px 0 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0px,
+    rgba(255, 255, 255, 0.3) 1%,
+    rgba(255, 255, 255, 0.5) 2%,
+    rgba(255, 255, 255, 0.5) 95%,
+    rgba(255, 255, 255, 0.3) 98%,
+    rgba(255, 255, 255, 0.2) 99%,
+    transparent 100%
+  );
+  box-shadow: inset 0 -1px 1px rgb(14, 96, 203);
+  pointer-events: none;
 }
 
 .start-menu-header {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 7px 8px;
-    background: var(--menu-header-gradient);
-    border-bottom: 2px solid;
-    border-image: linear-gradient(90deg,
-        rgba(0, 0, 0, 0) 0%, rgb(218, 136, 74) 50%,
-        rgba(0, 0, 0, 0) 100%) 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px;
+  background: var(--menu-header-gradient);
+  border-bottom: 2px solid;
+  border-image: linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0) 0%,
+      rgb(218, 136, 74) 50%,
+      rgba(0, 0, 0, 0) 100%
+    )
+    1;
 }
 
 .start-menu-avatar {
-    flex: none;
-    width: 42px;
-    height: 42px;
-    border: 2px solid rgba(255, 255, 255, 0.85);
-    border-radius: 5px;
-    box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.4);
+  flex: none;
+  width: 42px;
+  height: 42px;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  border-radius: 5px;
+  box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 .start-menu-user {
-    color: #fff;
-    font-family: "Tahoma", sans-serif;
-    font-size: 16px;
-    font-weight: 700;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-family: "Tahoma", sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
 }
 
 .start-menu-body {
-    display: flex;
-    margin: 0 2px;
-    min-height: 292px;
-    max-height: min(390px, 66vh);
+  display: flex;
+  margin: 0 2px;
+  min-height: 292px;
+  max-height: min(390px, 66vh);
 }
 
 .start-menu-left {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    background: #fff;
-    min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  min-width: 0;
 }
 
 #start-menu-pinned {
-    flex: 1;
-    padding: 5px 0;
-    overflow: hidden;
+  flex: 1;
+  padding: 5px 0;
+  overflow: hidden;
 }
 
 #start-menu-pinned .sm-game {
-    min-height: 38px;
+  min-height: 38px;
 }
 
 #start-menu-pinned .sm-game-icon.has-image {
-    width: 28px;
-    height: 28px;
+  width: 28px;
+  height: 28px;
 }
 
 #all-programs-button {
-    flex: none;
-    width: 100%;
-    height: 34px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 8px;
-    padding: 0 12px;
-    border: 0;
-    border-top: 1px solid #d7d7d7;
-    background: #fff;
-    color: #111;
-    font-size: 11px;
-    font-weight: 700;
-    cursor: var(--xp-cursor);
+  flex: none;
+  width: 100%;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 0 12px;
+  border: 0;
+  border-top: 1px solid #d7d7d7;
+  background: #fff;
+  color: #111;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: var(--xp-cursor);
 }
 
 #all-programs-button:hover,
 #all-programs-button.active {
-    background: #316ac5;
-    color: #fff;
+  background: #316ac5;
+  color: #fff;
 }
 
 .all-programs-arrow {
-    width: 0;
-    height: 0;
-    border-top: 7px solid transparent;
-    border-bottom: 7px solid transparent;
-    border-left: 9px solid #27933b;
-    filter: drop-shadow(1px 1px 0 #145f24);
+  width: 0;
+  height: 0;
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent;
+  border-left: 9px solid #27933b;
+  filter: drop-shadow(1px 1px 0 #145f24);
 }
 
 #all-programs-panel {
-    position: absolute;
-    left: calc(50% - 1px);
-    bottom: 40px;
-    z-index: 2;
-    width: min(260px, 58vw);
-    height: min(420px, 70vh);
-    display: flex;
-    flex-direction: column;
-    background: #fff;
-    border: 2px solid #1d58c7;
-    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.45);
+  position: absolute;
+  left: calc(50% - 1px);
+  bottom: 40px;
+  z-index: 2;
+  width: min(260px, 58vw);
+  height: min(420px, 70vh);
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 2px solid #1d58c7;
+  box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.45);
 }
 
 /* All Programs is a real adjacent XP flyout; Search lives in Search Companion. */
-#start-menu-flyouts { position: fixed; inset: 0; z-index: 7100; pointer-events: none; }
-.start-program-flyout { position: fixed; width: min(260px, 58vw); max-height: min(420px, 72vh); overflow: auto; padding: 3px; background: #fff; border: 2px solid #1d58c7; box-shadow: 2px 2px 8px rgba(0, 0, 0, .45); pointer-events: auto; }
-.start-program-flyout button { width: 100%; min-height: 28px; display: flex; align-items: center; gap: 5px; padding: 4px 7px; border: 0; background: #fff; color: #111; text-align: left; cursor: var(--xp-cursor); }
-.start-program-flyout button:hover, .start-program-flyout button:focus-visible { background: #316ac5; color: #fff; outline: none; }
-.start-program-folder { font-weight: 700; }
-.start-program-arrow { margin-left: auto; font-size: 10px; }
+#start-menu-flyouts {
+  position: fixed;
+  inset: 0;
+  z-index: 7100;
+  pointer-events: none;
+}
+.start-program-flyout {
+  position: fixed;
+  width: min(260px, 58vw);
+  max-height: min(420px, 72vh);
+  overflow: auto;
+  padding: 3px;
+  background: #fff;
+  border: 2px solid #1d58c7;
+  box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.45);
+  pointer-events: auto;
+}
+.start-program-flyout button {
+  width: 100%;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 7px;
+  border: 0;
+  background: #fff;
+  color: #111;
+  text-align: left;
+  cursor: var(--xp-cursor);
+}
+.start-program-flyout button:hover,
+.start-program-flyout button:focus-visible {
+  background: #316ac5;
+  color: #fff;
+  outline: none;
+}
+.start-program-folder {
+  font-weight: 700;
+}
+.start-program-arrow {
+  margin-left: auto;
+  font-size: 10px;
+}
 
 .start-menu-search {
-    flex: none;
-    padding: 6px;
-    border-bottom: 1px solid var(--xp-beige-dark);
+  flex: none;
+  padding: 6px;
+  border-bottom: 1px solid var(--xp-beige-dark);
 }
 
 #game-search {
-    width: 100%;
-    padding: 4px 6px;
-    border: 1px solid #7f9db9;
-    border-radius: 2px;
-    font-family: inherit;
-    font-size: 11px;
+  width: 100%;
+  padding: 4px 6px;
+  border: 1px solid #7f9db9;
+  border-radius: 2px;
+  font-family: inherit;
+  font-size: 11px;
 }
 
 #game-search:focus {
-    outline: none;
-    border-color: #316ac5;
-    box-shadow: 0 0 3px rgba(49, 106, 197, 0.6);
+  outline: none;
+  border-color: #316ac5;
+  box-shadow: 0 0 3px rgba(49, 106, 197, 0.6);
 }
 
 #start-menu-programs {
-    flex: 1;
-    overflow-y: auto;
-    padding: 4px 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
 }
 
 .sm-category-header {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 5px 10px;
-    background: none;
-    border: none;
-    font-size: 12px;
-    font-weight: 700;
-    color: var(--xp-text);
-    text-align: left;
-    cursor: var(--xp-cursor);
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  background: none;
+  border: none;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--xp-text);
+  text-align: left;
+  cursor: var(--xp-cursor);
 }
 
 .sm-category-header:hover {
-    background: #316ac5;
-    color: #fff;
+  background: #316ac5;
+  color: #fff;
 }
 
 .sm-cat-icon {
-    font-size: 15px;
+  font-size: 15px;
 }
 
 .sm-cat-count {
-    margin-left: auto;
-    font-size: 10px;
-    font-weight: 400;
-    color: #808080;
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 400;
+  color: #808080;
 }
 
 .sm-category-header:hover .sm-cat-count {
-    color: #cfe0ff;
+  color: #cfe0ff;
 }
 
 .sm-cat-count::before {
-    content: "▸ ";
+  content: "▸ ";
 }
 
 .sm-category.open .sm-cat-count::before {
-    content: "▾ ";
+  content: "▾ ";
 }
 
 .sm-games {
-    display: none;
-    padding: 2px 0 2px 14px;
-    background: #f4f8ff;
-    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.08);
+  display: none;
+  padding: 2px 0 2px 14px;
+  background: #f4f8ff;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 .sm-category.open .sm-games {
-    display: block;
+  display: block;
 }
 
 .sm-game {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 4px 10px;
-    background: none;
-    border: none;
-    font-size: 11px;
-    color: var(--xp-text);
-    text-align: left;
-    cursor: var(--xp-cursor);
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  background: none;
+  border: none;
+  font-size: 11px;
+  color: var(--xp-text);
+  text-align: left;
+  cursor: var(--xp-cursor);
 }
 
 .sm-game:hover {
-    background: #316ac5;
-    color: #fff;
+  background: #316ac5;
+  color: #fff;
 }
 
 .sm-game-icon {
-    font-size: 14px;
+  font-size: 14px;
 }
 
 .sm-game-icon.has-image {
-    flex: none;
-    width: 20px;
-    height: 20px;
+  flex: none;
+  width: 20px;
+  height: 20px;
 }
 
 .sm-game-title {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .play-count {
-    margin-left: auto;
-    font-size: 9px;
-    color: #909090;
-    white-space: nowrap;
+  margin-left: auto;
+  font-size: 9px;
+  color: #909090;
+  white-space: nowrap;
 }
 
 .sm-game:hover .play-count {
-    color: #cfe0ff;
+  color: #cfe0ff;
 }
 
 .sm-empty {
-    padding: 14px;
-    text-align: center;
-    color: #808080;
+  padding: 14px;
+  text-align: center;
+  color: #808080;
 }
 
 .start-menu-right {
-    flex: none;
-    width: 160px;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    padding: 8px 4px;
-    background: #d3e5fa;
-    border-left: 1px solid #95bdee;
-    overflow-y: auto;
+  flex: none;
+  width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 4px;
+  background: #d3e5fa;
+  border-left: 1px solid #95bdee;
+  overflow-y: auto;
 }
 
 .sm-place {
@@ -3149,330 +3649,331 @@ html[data-xp-appearance="silver"] {
   font-family: inherit;
   text-align: left;
   display: flex;
-    align-items: center;
-    gap: 7px;
-    min-height: 28px;
-    padding: 4px 7px;
-    border-radius: 3px;
-    font-size: 11px;
-    font-weight: 700;
-    color: #0b3d91;
-    text-decoration: none;
-    cursor: var(--xp-cursor);
+  align-items: center;
+  gap: 7px;
+  min-height: 28px;
+  padding: 4px 7px;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #0b3d91;
+  text-decoration: none;
+  cursor: var(--xp-cursor);
 }
 
 .sm-place-icon {
-    flex: none;
-    width: 24px;
-    height: 24px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: #174f9b;
-    font-size: 15px;
-    line-height: 1;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #174f9b;
+  font-size: 15px;
+  line-height: 1;
 }
 
 .sm-place-icon img {
-    width: 24px;
-    height: 24px;
-    object-fit: contain;
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
 }
 
 .sm-place-separator {
-    height: 1px;
-    margin: 3px 6px;
-    background: #9abfe8;
+  height: 1px;
+  margin: 3px 6px;
+  background: #9abfe8;
 }
 
 .sm-place:hover {
-    background: #b3d0f0;
+  background: #b3d0f0;
 }
 
 .shell-dialog-list {
-    display: grid;
-    gap: 3px;
-    max-height: 210px;
-    margin: 8px 0;
-    overflow-y: auto;
+  display: grid;
+  gap: 3px;
+  max-height: 210px;
+  margin: 8px 0;
+  overflow-y: auto;
 }
 
 .shell-dialog-list button {
-    padding: 4px 6px;
-    border: 1px solid transparent;
-    background: transparent;
-    color: var(--xp-text);
-    font: inherit;
-    text-align: left;
-    cursor: var(--xp-cursor);
+  padding: 4px 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--xp-text);
+  font: inherit;
+  text-align: left;
+  cursor: var(--xp-cursor);
 }
 
 .shell-dialog-list button:hover,
 .shell-dialog-list button:focus-visible {
-    border-color: #0b4aa3;
-    background: #316ac5;
-    color: #fff;
-    outline: 0;
+  border-color: #0b4aa3;
+  background: #316ac5;
+  color: #fff;
+  outline: 0;
 }
 
 .shell-dialog-input {
-    box-sizing: border-box;
-    width: 100%;
-    margin: 6px 0;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 6px 0;
 }
 
 .sm-place-info {
-    font-weight: 400;
-    color: #3a5a8c;
-    cursor: var(--xp-cursor);
+  font-weight: 400;
+  color: #3a5a8c;
+  cursor: var(--xp-cursor);
 }
 
 .sm-place-info:hover {
-    background: none;
+  background: none;
 }
 
 .sm-place input {
-    vertical-align: -1px;
+  vertical-align: -1px;
 }
 
 .start-menu-footer {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    justify-content: flex-end;
-    margin: 0 2px 2px;
-    padding: 8px 10px;
-    background: var(--menu-footer-gradient);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+  margin: 0 2px 2px;
+  padding: 8px 10px;
+  background: var(--menu-footer-gradient);
 }
 
 .start-menu-footer button {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 3px 6px;
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 3px;
-    color: #fff;
-    font-size: 11px;
-    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.4);
-    cursor: var(--xp-cursor);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  color: #fff;
+  font-size: 11px;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.4);
+  cursor: var(--xp-cursor);
 }
 
 .start-menu-footer .xp-power-icon,
 .start-menu-footer .xp-logoff-icon {
-    position: relative;
-    flex: none;
-    width: 24px;
-    height: 24px;
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
-    background-position: center;
-    background-size: contain;
-    background-repeat: no-repeat;
+  position: relative;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  background-position: center;
+  background-size: contain;
+  background-repeat: no-repeat;
 }
 
 .start-menu-footer .xp-power-icon {
-    background-image: url("../assets/xp/icons/Power.png");
+  background-image: url("../assets/xp/icons/Power.png");
 }
 
 .start-menu-footer .xp-power-icon::before,
 .start-menu-footer .xp-power-icon::after,
 .start-menu-footer .xp-logoff-icon::before,
 .start-menu-footer .xp-logoff-icon::after {
-    content: none;
+  content: none;
 }
 
 .start-menu-footer .xp-logoff-icon {
-    background-image: url("../assets/xp/icons/Logout.png");
+  background-image: url("../assets/xp/icons/Logout.png");
 }
 
 .xp-logoff-icon {
-    background: linear-gradient(180deg, #f4cf55, #d18c16);
+  background: linear-gradient(180deg, #f4cf55, #d18c16);
 }
 
 .xp-logoff-icon::before {
-    content: "";
-    position: absolute;
-    left: 4px;
-    top: 8px;
-    width: 10px;
-    height: 5px;
-    border: 2px solid #fff;
-    border-left: 0;
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 8px;
+  width: 10px;
+  height: 5px;
+  border: 2px solid #fff;
+  border-left: 0;
 }
 
 .xp-logoff-icon::after {
-    content: "";
-    position: absolute;
-    right: 3px;
-    top: 6px;
-    border: 4px solid transparent;
-    border-left-color: #fff;
+  content: "";
+  position: absolute;
+  right: 3px;
+  top: 6px;
+  border: 4px solid transparent;
+  border-left-color: #fff;
 }
 
 .start-menu-footer button:hover {
-    background: rgba(255, 255, 255, 0.25);
-    border-color: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.25);
+  border-color: rgba(255, 255, 255, 0.6);
 }
 
 .start-menu-footer h6 {
-    display: none;
+  display: none;
 }
 
 /* ============ Logoff and shutdown dialogs ============ */
 
 .system-dialog-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 9400;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(0, 36, 130, 0.38);
+  position: fixed;
+  inset: 0;
+  z-index: 9400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 36, 130, 0.38);
 }
 
 .system-dialog {
-    width: min(330px, calc(100vw - 24px));
-    color: #fff;
-    border: 1px solid #07379d;
-    box-shadow: 3px 4px 16px rgba(0, 0, 0, 0.55);
+  width: min(330px, calc(100vw - 24px));
+  color: #fff;
+  border: 1px solid #07379d;
+  box-shadow: 3px 4px 16px rgba(0, 0, 0, 0.55);
 }
 
 .system-dialog-title {
-    height: 46px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 10px;
-    background: linear-gradient(180deg, #0752c8, #003399);
-    border-bottom: 1px solid #8da7e4;
-    font-size: 18px;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  background: linear-gradient(180deg, #0752c8, #003399);
+  border-bottom: 1px solid #8da7e4;
+  font-size: 18px;
 }
 
 .dialog-flag {
-    width: 31px;
-    height: 31px;
-    filter: none;
+  width: 31px;
+  height: 31px;
+  filter: none;
 }
 
 .system-dialog-actions {
-    min-height: 110px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 48px;
-    padding: 16px;
-    background: linear-gradient(180deg, #85a7ed, #668bdc);
+  min-height: 110px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 48px;
+  padding: 16px;
+  background: linear-gradient(180deg, #85a7ed, #668bdc);
 }
 
 .shutdown-actions {
-    gap: 26px;
+  gap: 26px;
 }
 
 .system-dialog-actions button {
-    min-width: 58px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 6px;
-    padding: 0;
-    border: 0;
-    background: none;
-    color: #fff;
-    font-size: 11px;
-    cursor: var(--xp-cursor);
+  min-width: 58px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: #fff;
+  font-size: 11px;
+  cursor: var(--xp-cursor);
 }
 
 .dialog-action-icon {
-    position: relative;
-    width: 36px;
-    height: 36px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border: 2px solid rgba(255, 255, 255, 0.9);
-    border-radius: 5px;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5),
-        1px 2px 3px rgba(0, 0, 0, 0.4);
+  position: relative;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  border-radius: 5px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    1px 2px 3px rgba(0, 0, 0, 0.4);
 }
 
 .switch-user-icon,
 .restart-icon {
-    background: linear-gradient(180deg, #74d374, #15942c);
+  background: linear-gradient(180deg, #74d374, #15942c);
 }
 
 .switch-user-icon::before,
 .switch-user-icon::after {
-    content: "";
-    position: absolute;
-    left: 8px;
-    width: 18px;
-    height: 8px;
-    border: 2px solid #fff;
-    border-left: 0;
-    border-right: 0;
+  content: "";
+  position: absolute;
+  left: 8px;
+  width: 18px;
+  height: 8px;
+  border: 2px solid #fff;
+  border-left: 0;
+  border-right: 0;
 }
 
 .switch-user-icon::before {
-    top: 7px;
+  top: 7px;
 }
 
 .switch-user-icon::after {
-    bottom: 7px;
+  bottom: 7px;
 }
 
 .system-dialog .xp-logoff-icon {
-    width: 36px;
-    height: 36px;
+  width: 36px;
+  height: 36px;
 }
 
 .system-dialog .xp-logoff-icon::before {
-    left: 8px;
-    top: 14px;
-    width: 17px;
-    height: 7px;
+  left: 8px;
+  top: 14px;
+  width: 17px;
+  height: 7px;
 }
 
 .system-dialog .xp-logoff-icon::after {
-    right: 5px;
-    top: 11px;
-    border-width: 6px;
+  right: 5px;
+  top: 11px;
+  border-width: 6px;
 }
 
 .standby-icon {
-    background: linear-gradient(180deg, #ffd66b, #e79418);
+  background: linear-gradient(180deg, #ffd66b, #e79418);
 }
 
 .shutdown-icon {
-    background: linear-gradient(180deg, #ef9070, #c64127);
+  background: linear-gradient(180deg, #ef9070, #c64127);
 }
 
 .restart-icon::before {
-    content: "✣";
-    color: #fff;
-    font-size: 24px;
+  content: "✣";
+  color: #fff;
+  font-size: 24px;
 }
 
 .system-dialog-footer {
-    height: 38px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    padding: 0 8px;
-    background: linear-gradient(180deg, #0a4abb, #003399);
-    border-top: 1px solid #3759b4;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 8px;
+  background: linear-gradient(180deg, #0a4abb, #003399);
+  border-top: 1px solid #3759b4;
 }
 
 .system-dialog-footer button {
-    min-width: 62px;
-    height: 22px;
-    border: 1px solid #444;
-    background: linear-gradient(180deg, #fff, #e5e5e5);
-    color: #111;
-    font-size: 11px;
-    cursor: var(--xp-cursor);
+  min-width: 62px;
+  height: 22px;
+  border: 1px solid #444;
+  background: linear-gradient(180deg, #fff, #e5e5e5);
+  color: #111;
+  font-size: 11px;
+  cursor: var(--xp-cursor);
 }
 
 /* ============ Shutdown screens ============ */
@@ -3480,95 +3981,96 @@ html[data-xp-appearance="silver"] {
 #shutdown-screen,
 #turn-off-screen,
 #standby-screen {
-    position: fixed;
-    inset: 0;
-    z-index: 9500;
-    cursor: var(--xp-cursor);
+  position: fixed;
+  inset: 0;
+  z-index: 9500;
+  cursor: var(--xp-cursor);
 }
 
 #shutdown-screen {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 16px;
-    background:
-        linear-gradient(180deg,
-            #003399 0 13%,
-            #87a8ea 13.3%,
-            #5a7edc 13.6% 84%,
-            #e69232 84.2%,
-            #003399 84.5% 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: linear-gradient(
+    180deg,
+    #003399 0 13%,
+    #87a8ea 13.3%,
+    #5a7edc 13.6% 84%,
+    #e69232 84.2%,
+    #003399 84.5% 100%
+  );
 }
 
 #shutdown-screen img {
-    width: min(145px, 38vw);
+  width: min(145px, 38vw);
 }
 
 #shutdown-screen p {
-    margin: 0;
-    color: #fff;
-    font-size: 16px;
+  margin: 0;
+  color: #fff;
+  font-size: 16px;
 }
 
 #turn-off-screen {
-    background: #000;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
+  background: #000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 
 #standby-screen {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(0, 0, 0, 0.7);
-    color: #fff;
-    text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  text-align: center;
 }
 
 #standby-screen > div {
-    min-width: 240px;
-    padding: 22px 28px;
-    border: 2px solid #86aaf0;
-    border-radius: 5px;
-    background: linear-gradient(#3063b6, #123b83);
-    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.6);
+  min-width: 240px;
+  padding: 22px 28px;
+  border: 2px solid #86aaf0;
+  border-radius: 5px;
+  background: linear-gradient(#3063b6, #123b83);
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.6);
 }
 
 #standby-screen p {
-    margin: 0 0 16px;
-    font-size: 15px;
+  margin: 0 0 16px;
+  font-size: 15px;
 }
 
 #standby-screen button {
-    display: block;
-    min-width: 82px;
-    margin: 0 auto 12px;
+  display: block;
+  min-width: 82px;
+  margin: 0 auto 12px;
 }
 
 #standby-screen span {
-    font-size: 11px;
+  font-size: 11px;
 }
 
 #turn-off-screen img {
-    width: min(260px, 62vw);
+  width: min(260px, 62vw);
 }
 
 #turn-off-screen p {
-    margin: 0;
-    color: #fff;
-    font-size: 10px;
-    font-weight: 400;
-    text-align: center;
+  margin: 0;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 400;
+  text-align: center;
 }
 
 .turn-off-hint {
-    margin-top: 18px;
-    color: #202020;
-    font-size: 11px;
+  margin-top: 18px;
+  color: #202020;
+  font-size: 11px;
 }
 
 /* ============ Scrollbars (authentic XP) ============ */
@@ -3578,8 +4080,8 @@ html[data-xp-appearance="silver"] {
 #desktop-icons::-webkit-scrollbar,
 .explorer-sidebar::-webkit-scrollbar,
 .explorer-main::-webkit-scrollbar {
-    width: 17px;
-    height: 17px;
+  width: 17px;
+  height: 17px;
 }
 
 #start-menu-programs::-webkit-scrollbar-corner,
@@ -3587,7 +4089,7 @@ html[data-xp-appearance="silver"] {
 #desktop-icons::-webkit-scrollbar-corner,
 .explorer-sidebar::-webkit-scrollbar-corner,
 .explorer-main::-webkit-scrollbar-corner {
-    background: #dfdfdf;
+  background: #dfdfdf;
 }
 
 #start-menu-programs::-webkit-scrollbar-track,
@@ -3595,7 +4097,7 @@ html[data-xp-appearance="silver"] {
 #desktop-icons::-webkit-scrollbar-track,
 .explorer-sidebar::-webkit-scrollbar-track,
 .explorer-main::-webkit-scrollbar-track {
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -0.5 17 1' shape-rendering='crispEdges'%3E%3Cpath stroke='%23eeede5' d='M0 0h1m15 0h1'/%3E%3Cpath stroke='%23f3f1ec' d='M1 0h1'/%3E%3Cpath stroke='%23f4f1ec' d='M2 0h1'/%3E%3Cpath stroke='%23f4f3ee' d='M3 0h1'/%3E%3Cpath stroke='%23f5f4ef' d='M4 0h1'/%3E%3Cpath stroke='%23f6f5f0' d='M5 0h1'/%3E%3Cpath stroke='%23f7f7f3' d='M6 0h1'/%3E%3Cpath stroke='%23f9f8f4' d='M7 0h1'/%3E%3Cpath stroke='%23f9f9f7' d='M8 0h1'/%3E%3Cpath stroke='%23fbfbf8' d='M9 0h1'/%3E%3Cpath stroke='%23fbfbf9' d='M10 0h2'/%3E%3Cpath stroke='%23fdfdfa' d='M12 0h1'/%3E%3Cpath stroke='%23fefefb' d='M13 0h3'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -0.5 17 1' shape-rendering='crispEdges'%3E%3Cpath stroke='%23eeede5' d='M0 0h1m15 0h1'/%3E%3Cpath stroke='%23f3f1ec' d='M1 0h1'/%3E%3Cpath stroke='%23f4f1ec' d='M2 0h1'/%3E%3Cpath stroke='%23f4f3ee' d='M3 0h1'/%3E%3Cpath stroke='%23f5f4ef' d='M4 0h1'/%3E%3Cpath stroke='%23f6f5f0' d='M5 0h1'/%3E%3Cpath stroke='%23f7f7f3' d='M6 0h1'/%3E%3Cpath stroke='%23f9f8f4' d='M7 0h1'/%3E%3Cpath stroke='%23f9f9f7' d='M8 0h1'/%3E%3Cpath stroke='%23fbfbf8' d='M9 0h1'/%3E%3Cpath stroke='%23fbfbf9' d='M10 0h2'/%3E%3Cpath stroke='%23fdfdfa' d='M12 0h1'/%3E%3Cpath stroke='%23fefefb' d='M13 0h3'/%3E%3C/svg%3E");
 }
 
 #start-menu-programs::-webkit-scrollbar-thumb,
@@ -3603,95 +4105,116 @@ html[data-xp-appearance="silver"] {
 #desktop-icons::-webkit-scrollbar-thumb,
 .explorer-sidebar::-webkit-scrollbar-thumb,
 .explorer-main::-webkit-scrollbar-thumb {
-    background-position: 50%;
-    background-repeat: no-repeat;
-    background-color: #c8d6fb;
-    background-size: 7px;
-    border: 1px solid #fff;
-    border-radius: 2px;
-    box-shadow: inset -3px 0 #bad1fc, inset 1px 1px #b7caf5;
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -0.5 7 8' shape-rendering='crispEdges'%3E%3Cpath stroke='%23eef4fe' d='M0 0h6M0 2h6M0 4h6M0 6h6'/%3E%3Cpath stroke='%23bad1fc' d='M6 0h1M6 2h1M6 4h1'/%3E%3Cpath stroke='%23c8d6fb' d='M0 1h1M0 3h1M0 5h1M0 7h1'/%3E%3Cpath stroke='%238cb0f8' d='M1 1h6M1 3h6M1 5h6M1 7h6'/%3E%3Cpath stroke='%23bad3fc' d='M6 6h1'/%3E%3C/svg%3E");
+  background-position: 50%;
+  background-repeat: no-repeat;
+  background-color: #c8d6fb;
+  background-size: 7px;
+  border: 1px solid #fff;
+  border-radius: 2px;
+  box-shadow:
+    inset -3px 0 #bad1fc,
+    inset 1px 1px #b7caf5;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -0.5 7 8' shape-rendering='crispEdges'%3E%3Cpath stroke='%23eef4fe' d='M0 0h6M0 2h6M0 4h6M0 6h6'/%3E%3Cpath stroke='%23bad1fc' d='M6 0h1M6 2h1M6 4h1'/%3E%3Cpath stroke='%23c8d6fb' d='M0 1h1M0 3h1M0 5h1M0 7h1'/%3E%3Cpath stroke='%238cb0f8' d='M1 1h6M1 3h6M1 5h6M1 7h6'/%3E%3Cpath stroke='%23bad3fc' d='M6 6h1'/%3E%3C/svg%3E");
 }
 
 /* ============ Small screens ============ */
 
 @media (max-width: 560px) {
-    .welcome-panel {
-        flex-direction: column;
-        gap: 22px;
-        margin-top: 110px;
-    }
+  .welcome-panel {
+    flex-direction: column;
+    gap: 22px;
+    margin-top: 110px;
+  }
 
-    .welcome-instruction {
-        text-align: center;
-    }
+  .welcome-instruction {
+    text-align: center;
+  }
 
-    .start-menu-right {
-        width: 128px;
-    }
+  .start-menu-right {
+    width: 128px;
+  }
 
-    #all-programs-panel {
-        left: 0;
-        bottom: 38px;
-        width: 100%;
-    }
+  #all-programs-panel {
+    left: 0;
+    bottom: 38px;
+    width: 100%;
+  }
 
-    #start-button {
-        width: 78px;
-    }
+  #start-button {
+    width: 78px;
+  }
 
-    #task-buttons {
-        padding-left: 4px;
-        padding-right: 4px;
-    }
+  #task-buttons {
+    padding-left: 4px;
+    padding-right: 4px;
+  }
 
-    #taskbar-tray {
-        gap: 3px;
-        margin-left: 3px;
-        padding: 0 4px;
-    }
+  #taskbar-tray {
+    gap: 3px;
+    margin-left: 3px;
+    padding: 0 4px;
+  }
 
-    .task-button {
-        --task-button-min-width: 48px;
-    }
+  .task-button {
+    --task-button-min-width: 48px;
+  }
 
-    #task-buttons {
-        --task-overflow-min-width: 58px;
-    }
+  #task-buttons {
+    --task-overflow-min-width: 58px;
+  }
 
-    .explorer-content {
-        grid-template-columns: 1fr;
-    }
+  .explorer-content {
+    grid-template-columns: 1fr;
+  }
 
-    .explorer-sidebar {
-        display: none;
-    }
+  .explorer-sidebar {
+    display: none;
+  }
 
-    .explorer-main {
-        padding: 12px;
-    }
+  .explorer-main {
+    padding: 12px;
+  }
 
-    .explorer-items {
-        grid-template-columns: 1fr;
-    }
+  .explorer-items {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 480px) {
-    .desktop-icon {
-        width: 60px;
-        min-height: 58px;
-        gap: 2px;
-        padding: 2px 0;
-    }
+  .desktop-icon {
+    width: 60px;
+    min-height: 58px;
+    gap: 2px;
+    padding: 2px 0;
+  }
 
-    .desktop-icon .icon-glyph { font-size: 26px; }
-    .desktop-icon .icon-glyph.has-image { width: 30px; height: 30px; }
-    .desktop-icon .icon-label { max-width: 58px; font-size: 10px; line-height: 1.05; }
+  .desktop-icon .icon-glyph {
+    font-size: 26px;
+  }
+  .desktop-icon .icon-glyph.has-image {
+    width: 30px;
+    height: 30px;
+  }
+  .desktop-icon .icon-label {
+    max-width: 58px;
+    font-size: 10px;
+    line-height: 1.05;
+  }
 }
 
 @media (max-width: 360px) {
-    #start-button { width: 66px; }
-    #tray-network-button { display: none; }
-    #taskbar-tray { margin-left: 1px; padding: 0 2px; }
-    #taskbar-clock { font-size: 10px; padding: 1px; }
+  #start-button {
+    width: 66px;
+  }
+  #tray-network-button {
+    display: none;
+  }
+  #taskbar-tray {
+    margin-left: 1px;
+    padding: 0 2px;
+  }
+  #taskbar-clock {
+    font-size: 10px;
+    padding: 1px;
+  }
 }

--- a/site/iframe/doom/index.html
+++ b/site/iframe/doom/index.html
@@ -1,69 +1,71 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
-        />
-        <title>Doom</title>
-        <link
-            rel="stylesheet"
-            href="../../vendor/js-dos/8.4.1/js-dos.css"
-        />
-        <style>
-            html,
-            body,
-            #jsdos {
-                width: 100%;
-                height: 100%;
-                margin: 0;
-                overflow: hidden;
-                background: #000;
-            }
-        </style>
-        <script src="../../vendor/js-dos/8.4.1/js-dos.js"></script>
-    </head>
-    <body>
-        <div id="jsdos"></div>
-        <script>
-            "use strict";
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
+    />
+    <title>Doom</title>
+    <link rel="stylesheet" href="../../vendor/js-dos/8.4.1/js-dos.css" />
+    <style>
+      html,
+      body,
+      #jsdos {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: #000;
+      }
+    </style>
+    <script src="../../vendor/js-dos/8.4.1/js-dos.js"></script>
+  </head>
+  <body>
+    <div id="jsdos"></div>
+    <script>
+      "use strict";
 
-            let pendingVolume = 1;
-            let player = null;
+      let pendingVolume = 1;
+      let player = null;
 
-            window.addEventListener("message", (event) => {
-                if (
-                    event.source !== window.parent
-                    || event.origin !== window.location.origin
-                ) return;
-                if (event.data?.type !== "setVolume") return;
+      window.addEventListener("message", (event) => {
+        if (
+          event.source !== window.parent ||
+          event.origin !== window.location.origin
+        )
+          return;
+        if (event.data?.type !== "setVolume") return;
 
-                const volume = Number(event.data.volume);
-                pendingVolume = Number.isFinite(volume)
-                    ? Math.min(Math.max(volume, 0), 1)
-                    : 0;
-                player?.setVolume(pendingVolume);
-            });
+        const volume = Number(event.data.volume);
+        pendingVolume = Number.isFinite(volume)
+          ? Math.min(Math.max(volume, 0), 1)
+          : 0;
+        player?.setVolume(pendingVolume);
+      });
 
-            player = Dos(document.getElementById("jsdos"), {
-                url: "../../dos/doom/doom.jsdos",
-                pathPrefix: "../../vendor/js-dos/8.4.1/emulators/",
-                backend: "dosbox",
-                backendLocked: true,
-                autoStart: true,
-                countDownStart: 0,
-                kiosk: true,
-                mouseCapture: true,
-                noCursor: true,
-                renderAspect: "4/3",
-                volume: pendingVolume
-            });
-            player.setNoCloud(true);
+      player = Dos(document.getElementById("jsdos"), {
+        url: "../../dos/doom/doom.jsdos",
+        pathPrefix: "../../vendor/js-dos/8.4.1/emulators/",
+        backend: "dosbox",
+        backendLocked: true,
+        autoStart: true,
+        countDownStart: 0,
+        kiosk: true,
+        mouseCapture: true,
+        noCursor: true,
+        renderAspect: "4/3",
+        volume: pendingVolume,
+      });
+      player.setNoCloud(true);
 
-            window.addEventListener("pagehide", () => {
-                player?.stop();
-            }, { once: true });
-        </script>
-    </body>
+      window.addEventListener(
+        "pagehide",
+        () => {
+          player?.stop();
+        },
+        { once: true },
+      );
+    </script>
+  </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,321 +1,322 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link rel="icon" href="favicon.ico" type="image/x-icon" />
-        <title>Astro Flash Collection</title>
-        <script src="js/ruffle.js?v=bf02ea2d"></script>
-        <script src="vendor/fflate/0.8.3/index.js?v=dev"></script>
-        <script src="js/games.js?v=a5b45b42"></script>
-        <script src="js/game-installer.js?v=dev"></script>
-        <script src="js/game-library.js?v=dev"></script>
-        <script src="js/filesystem.js?v=750917fa"></script>
-        <script src="js/file-operations.js?v=f2bf59d7"></script>
-        <script src="js/dialogs.js?v=63482d98"></script>
-        <script src="js/offline.js?v=1"></script>
-        <script src="js/main.js?v=2b29c40f"></script>
-        <link rel="stylesheet" href="css/main.css?v=6194f8c9">
-    </head>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="favicon.ico" type="image/x-icon" />
+    <title>Astro Flash Collection</title>
+    <script src="js/ruffle.js?v=bf02ea2d"></script>
+    <script src="vendor/fflate/0.8.3/index.js?v=dev"></script>
+    <script src="js/games.js?v=a5b45b42"></script>
+    <script src="js/game-installer.js?v=dev"></script>
+    <script src="js/game-library.js?v=dev"></script>
+    <script src="js/filesystem.js?v=750917fa"></script>
+    <script src="js/file-operations.js?v=f2bf59d7"></script>
+    <script src="js/dialogs.js?v=63482d98"></script>
+    <script src="js/offline.js?v=1"></script>
+    <script src="js/main.js?v=2b29c40f"></script>
+    <link rel="stylesheet" href="css/main.css?v=6194f8c9" />
+  </head>
 
-    <body>
-        <!-- Boot screen -->
-        <div
-            id="boot-screen"
-            role="button"
-            tabindex="0"
-            aria-label="Continue to the welcome screen"
+  <body>
+    <!-- Boot screen -->
+    <div
+      id="boot-screen"
+      role="button"
+      tabindex="0"
+      aria-label="Continue to the welcome screen"
+    >
+      <div class="boot-center">
+        <img
+          class="boot-logo"
+          src="assets/xp/loading-logo.jpg"
+          alt="Microsoft Windows XP"
+        />
+        <div class="boot-progress" aria-hidden="true">
+          <i></i><i></i><i></i>
+        </div>
+      </div>
+      <div class="boot-footer">
+        <p>Copyright © Microsoft Corporation</p>
+        <img src="assets/xp/loading-microsoft.jpg" alt="Microsoft" />
+      </div>
+    </div>
+
+    <!-- Welcome screen -->
+    <div id="welcome-screen" hidden>
+      <img
+        class="welcome-wordmark"
+        src="assets/xp/wordmark.png"
+        alt="Microsoft Windows XP"
+      />
+      <p class="welcome-message">welcome</p>
+      <div class="welcome-panel">
+        <p class="welcome-instruction">To begin, click your user name</p>
+        <button id="login-user" type="button">
+          <span class="welcome-avatar xp-user-tile" aria-hidden="true"></span>
+          <span class="welcome-username">astro</span>
+        </button>
+      </div>
+      <button id="welcome-turn-off" type="button">
+        <span
+          class="welcome-turn-off-icon xp-power-icon"
+          aria-hidden="true"
+        ></span>
+        <span>Turn off computer</span>
+      </button>
+      <p class="welcome-help">
+        After you log on, you can add or change accounts.<br />
+        Just go to Control Panel and click User Accounts.
+      </p>
+    </div>
+
+    <!-- Desktop -->
+    <div id="desktop" hidden>
+      <div id="desktop-icons"></div>
+      <div id="desktop-selection" aria-hidden="true" hidden></div>
+
+      <div
+        id="desktop-context-menu"
+        class="xp-context-menu"
+        role="menu"
+        hidden
+      ></div>
+
+      <div id="window-system-menu" class="xp-context-menu" role="menu" hidden>
+        <button type="button" role="menuitem" data-command="restore">
+          Restore
+        </button>
+        <button type="button" role="menuitem" data-command="move">Move</button>
+        <button type="button" role="menuitem" data-command="size">Size</button>
+        <span class="context-separator" aria-hidden="true"></span>
+        <button type="button" role="menuitem" data-command="minimize">
+          Minimize
+        </button>
+        <button type="button" role="menuitem" data-command="maximize">
+          Maximize
+        </button>
+        <span class="context-separator" aria-hidden="true"></span>
+        <button type="button" role="menuitem" data-command="close">
+          Close
+        </button>
+      </div>
+
+      <!-- Start menu -->
+      <div id="start-menu" hidden>
+        <div class="start-menu-header">
+          <span
+            class="start-menu-avatar xp-user-tile"
+            aria-hidden="true"
+          ></span>
+          <span class="start-menu-user">astro</span>
+        </div>
+        <div class="start-menu-body">
+          <div class="start-menu-left">
+            <div id="start-menu-pinned"></div>
+            <button id="all-programs-button" type="button">
+              <span>All Programs</span>
+              <span class="all-programs-arrow" aria-hidden="true"></span>
+            </button>
+          </div>
+          <div class="start-menu-right" id="start-menu-places"></div>
+        </div>
+        <div class="start-menu-footer">
+          <button id="log-off-button" type="button">
+            <span class="xp-logoff-icon" aria-hidden="true"></span>
+            Log Off
+          </button>
+          <button id="turn-off-button" type="button">
+            <span class="xp-power-icon" aria-hidden="true"></span>
+            Turn Off Computer
+          </button>
+        </div>
+      </div>
+      <div id="start-menu-flyouts" aria-label="All Programs" hidden></div>
+    </div>
+
+    <!-- Taskbar -->
+    <div id="taskbar" hidden>
+      <button id="start-button" type="button">
+        <span class="brand-flag start-flag" aria-hidden="true"
+          ><i></i><i></i><i></i><i></i
+        ></span>
+        <span class="start-text">start</span>
+      </button>
+      <div id="task-buttons"></div>
+      <div id="taskbar-tray">
+        <button
+          id="tray-network-button"
+          class="tray-icon tray-network"
+          type="button"
+          title="Local Area Connection"
+          aria-label="Local Area Connection Status"
+        ></button>
+        <button
+          id="tray-volume-button"
+          class="tray-icon tray-volume"
+          type="button"
+          title="Volume"
+          aria-label="Volume"
+          aria-haspopup="dialog"
+        ></button>
+        <button id="taskbar-clock" type="button"></button>
+      </div>
+      <div id="tray-volume-popup" role="dialog" aria-label="Volume" hidden>
+        <input
+          type="range"
+          id="tray-volume-slider"
+          class="tray-volume-slider"
+          min="0"
+          max="100"
+          step="1"
+          aria-label="Volume"
+        />
+        <label class="tray-mute-row" for="tray-mute-checkbox">
+          <input type="checkbox" id="tray-mute-checkbox" />
+          Mute
+        </label>
+      </div>
+    </div>
+
+    <div id="taskbar-context-menu" class="xp-context-menu" role="menu" hidden>
+      <button
+        type="button"
+        role="menuitem"
+        data-taskbar-action="toolbars"
+        disabled
+      >
+        Toolbars
+      </button>
+      <span class="context-separator" aria-hidden="true"></span>
+      <button type="button" role="menuitem" data-taskbar-action="cascade">
+        Cascade Windows
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        data-taskbar-action="tile-horizontal"
+      >
+        Tile Windows Horizontally
+      </button>
+      <button type="button" role="menuitem" data-taskbar-action="tile-vertical">
+        Tile Windows Vertically
+      </button>
+      <button type="button" role="menuitem" data-taskbar-action="show-desktop">
+        Show the Desktop
+      </button>
+      <button type="button" role="menuitem" data-taskbar-action="task-manager">
+        Task Manager
+      </button>
+      <span class="context-separator" aria-hidden="true"></span>
+      <button
+        type="button"
+        role="menuitemcheckbox"
+        aria-checked="true"
+        data-taskbar-action="lock"
+        disabled
+        title="The taskbar position is fixed"
+      >
+        Lock the Taskbar
+      </button>
+      <button type="button" role="menuitem" data-taskbar-action="properties">
+        Properties
+      </button>
+    </div>
+    <div
+      id="taskbar-overflow-menu"
+      class="xp-context-menu"
+      role="menu"
+      hidden
+    ></div>
+
+    <!-- Log Off Windows -->
+    <div id="logoff-dialog" class="system-dialog-overlay" hidden>
+      <div class="system-dialog" role="dialog" aria-labelledby="logoff-title">
+        <div class="system-dialog-title">
+          <span id="logoff-title">Log Off Windows</span>
+          <span class="dialog-flag brand-flag" aria-hidden="true"></span>
+        </div>
+        <div class="system-dialog-actions">
+          <button id="switch-user-confirm" type="button">
+            <span
+              class="dialog-action-icon switch-user-icon"
+              aria-hidden="true"
+            ></span>
+            <span>Switch User</span>
+          </button>
+          <button id="logoff-confirm" type="button">
+            <span
+              class="dialog-action-icon xp-logoff-icon"
+              aria-hidden="true"
+            ></span>
+            <span>Log Off</span>
+          </button>
+        </div>
+        <div class="system-dialog-footer">
+          <button id="logoff-cancel" type="button">Cancel</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Turn off computer -->
+    <div id="shutdown-dialog" class="system-dialog-overlay" hidden>
+      <div class="system-dialog" role="dialog" aria-labelledby="shutdown-title">
+        <div class="system-dialog-title">
+          <span id="shutdown-title">Turn off computer</span>
+          <span class="dialog-flag brand-flag" aria-hidden="true"></span>
+        </div>
+        <div class="system-dialog-actions shutdown-actions">
+          <button id="standby-confirm" type="button">
+            <span
+              class="dialog-action-icon standby-icon xp-power-icon"
+              aria-hidden="true"
+            ></span>
+            <span>Stand By</span>
+          </button>
+          <button id="shutdown-confirm" type="button">
+            <span
+              class="dialog-action-icon shutdown-icon xp-power-icon"
+              aria-hidden="true"
+            ></span>
+            <span>Turn Off</span>
+          </button>
+          <button id="restart-confirm" type="button">
+            <span
+              class="dialog-action-icon restart-icon"
+              aria-hidden="true"
+            ></span>
+            <span>Restart</span>
+          </button>
+        </div>
+        <div class="system-dialog-footer">
+          <button id="shutdown-cancel" type="button">Cancel</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Shutting down -->
+    <div id="shutdown-screen" hidden>
+      <img src="assets/xp/wordmark.png" alt="Microsoft Windows XP" />
+      <p>Windows is shutting down...</p>
+    </div>
+
+    <!-- Safe to turn off -->
+    <div id="turn-off-screen" hidden>
+      <img src="assets/xp/wordmark.png" alt="Microsoft Windows" />
+      <p>It is now safe to turn off your computer.</p>
+      <span class="turn-off-hint">Click anywhere to restart</span>
+    </div>
+
+    <!-- Stand By blocks the shell without ending the current session. -->
+    <div id="standby-screen" hidden>
+      <div role="dialog" aria-modal="true" aria-labelledby="standby-title">
+        <p id="standby-title">Windows is standing by.</p>
+        <button id="standby-resume" type="button">Resume</button>
+        <span
+          >Move the pointer, click, or press a key to return to your
+          session.</span
         >
-            <div class="boot-center">
-                <img
-                    class="boot-logo"
-                    src="assets/xp/loading-logo.jpg"
-                    alt="Microsoft Windows XP"
-                />
-                <div class="boot-progress" aria-hidden="true">
-                    <i></i><i></i><i></i>
-                </div>
-            </div>
-            <div class="boot-footer">
-                <p>Copyright © Microsoft Corporation</p>
-                <img
-                    src="assets/xp/loading-microsoft.jpg"
-                    alt="Microsoft"
-                />
-            </div>
-        </div>
-
-        <!-- Welcome screen -->
-        <div id="welcome-screen" hidden>
-            <img
-                class="welcome-wordmark"
-                src="assets/xp/wordmark.png"
-                alt="Microsoft Windows XP"
-            />
-            <p class="welcome-message">welcome</p>
-            <div class="welcome-panel">
-                <p class="welcome-instruction">
-                    To begin, click your user name
-                </p>
-                <button id="login-user" type="button">
-                    <span
-                        class="welcome-avatar xp-user-tile"
-                        aria-hidden="true"
-                    ></span>
-                    <span class="welcome-username">astro</span>
-                </button>
-            </div>
-            <button id="welcome-turn-off" type="button">
-                <span
-                    class="welcome-turn-off-icon xp-power-icon"
-                    aria-hidden="true"
-                ></span>
-                <span>Turn off computer</span>
-            </button>
-            <p class="welcome-help">
-                After you log on, you can add or change accounts.<br />
-                Just go to Control Panel and click User Accounts.
-            </p>
-        </div>
-
-        <!-- Desktop -->
-        <div id="desktop" hidden>
-            <div id="desktop-icons"></div>
-            <div id="desktop-selection" aria-hidden="true" hidden></div>
-
-            <div
-                id="desktop-context-menu"
-                class="xp-context-menu"
-                role="menu"
-                hidden
-            ></div>
-
-            <div
-                id="window-system-menu"
-                class="xp-context-menu"
-                role="menu"
-                hidden
-            >
-                <button type="button" role="menuitem" data-command="restore">
-                    Restore
-                </button>
-                <button type="button" role="menuitem" data-command="move">
-                    Move
-                </button>
-                <button type="button" role="menuitem" data-command="size">
-                    Size
-                </button>
-                <span class="context-separator" aria-hidden="true"></span>
-                <button type="button" role="menuitem" data-command="minimize">
-                    Minimize
-                </button>
-                <button type="button" role="menuitem" data-command="maximize">
-                    Maximize
-                </button>
-                <span class="context-separator" aria-hidden="true"></span>
-                <button type="button" role="menuitem" data-command="close">
-                    Close
-                </button>
-            </div>
-
-            <!-- Start menu -->
-            <div id="start-menu" hidden>
-                <div class="start-menu-header">
-                    <span
-                        class="start-menu-avatar xp-user-tile"
-                        aria-hidden="true"
-                    ></span>
-                    <span class="start-menu-user">astro</span>
-                </div>
-                <div class="start-menu-body">
-                    <div class="start-menu-left">
-                        <div id="start-menu-pinned"></div>
-                        <button id="all-programs-button" type="button">
-                            <span>All Programs</span>
-                            <span
-                                class="all-programs-arrow"
-                                aria-hidden="true"
-                            ></span>
-                        </button>
-                    </div>
-                    <div class="start-menu-right" id="start-menu-places"></div>
-                </div>
-                <div class="start-menu-footer">
-                    <button id="log-off-button" type="button">
-                        <span class="xp-logoff-icon" aria-hidden="true"></span>
-                        Log Off
-                    </button>
-                    <button id="turn-off-button" type="button">
-                        <span class="xp-power-icon" aria-hidden="true"></span>
-                        Turn Off Computer
-                    </button>
-                </div>
-            </div>
-            <div id="start-menu-flyouts" aria-label="All Programs" hidden></div>
-        </div>
-
-        <!-- Taskbar -->
-        <div id="taskbar" hidden>
-            <button id="start-button" type="button">
-                <span class="brand-flag start-flag" aria-hidden="true"
-                    ><i></i><i></i><i></i><i></i
-                ></span>
-                <span class="start-text">start</span>
-            </button>
-            <div id="task-buttons"></div>
-            <div id="taskbar-tray">
-                <button
-                    id="tray-network-button"
-                    class="tray-icon tray-network"
-                    type="button"
-                    title="Local Area Connection"
-                    aria-label="Local Area Connection Status"
-                ></button>
-                <button
-                    id="tray-volume-button"
-                    class="tray-icon tray-volume"
-                    type="button"
-                    title="Volume"
-                    aria-label="Volume"
-                    aria-haspopup="dialog"
-                ></button>
-                <button id="taskbar-clock" type="button"></button>
-            </div>
-            <div
-                id="tray-volume-popup"
-                role="dialog"
-                aria-label="Volume"
-                hidden
-            >
-                <input
-                    type="range"
-                    id="tray-volume-slider"
-                    class="tray-volume-slider"
-                    min="0"
-                    max="100"
-                    step="1"
-                    aria-label="Volume"
-                />
-                <label class="tray-mute-row" for="tray-mute-checkbox">
-                    <input type="checkbox" id="tray-mute-checkbox" />
-                    Mute
-                </label>
-            </div>
-        </div>
-
-        <div id="taskbar-context-menu" class="xp-context-menu" role="menu" hidden>
-            <button type="button" role="menuitem" data-taskbar-action="toolbars" disabled>Toolbars</button>
-            <span class="context-separator" aria-hidden="true"></span>
-            <button type="button" role="menuitem" data-taskbar-action="cascade">Cascade Windows</button>
-            <button type="button" role="menuitem" data-taskbar-action="tile-horizontal">Tile Windows Horizontally</button>
-            <button type="button" role="menuitem" data-taskbar-action="tile-vertical">Tile Windows Vertically</button>
-            <button type="button" role="menuitem" data-taskbar-action="show-desktop">Show the Desktop</button>
-            <button type="button" role="menuitem" data-taskbar-action="task-manager">Task Manager</button>
-            <span class="context-separator" aria-hidden="true"></span>
-            <button type="button" role="menuitemcheckbox" aria-checked="true" data-taskbar-action="lock" disabled title="The taskbar position is fixed">Lock the Taskbar</button>
-            <button type="button" role="menuitem" data-taskbar-action="properties">Properties</button>
-        </div>
-        <div id="taskbar-overflow-menu" class="xp-context-menu" role="menu" hidden></div>
-
-        <!-- Log Off Windows -->
-        <div id="logoff-dialog" class="system-dialog-overlay" hidden>
-            <div
-                class="system-dialog"
-                role="dialog"
-                aria-labelledby="logoff-title"
-            >
-                <div class="system-dialog-title">
-                    <span id="logoff-title">Log Off Windows</span>
-                    <span
-                        class="dialog-flag brand-flag"
-                        aria-hidden="true"
-                    ></span>
-                </div>
-                <div class="system-dialog-actions">
-                    <button id="switch-user-confirm" type="button">
-                        <span
-                            class="dialog-action-icon switch-user-icon"
-                            aria-hidden="true"
-                        ></span>
-                        <span>Switch User</span>
-                    </button>
-                    <button id="logoff-confirm" type="button">
-                        <span
-                            class="dialog-action-icon xp-logoff-icon"
-                            aria-hidden="true"
-                        ></span>
-                        <span>Log Off</span>
-                    </button>
-                </div>
-                <div class="system-dialog-footer">
-                    <button id="logoff-cancel" type="button">Cancel</button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Turn off computer -->
-        <div id="shutdown-dialog" class="system-dialog-overlay" hidden>
-            <div
-                class="system-dialog"
-                role="dialog"
-                aria-labelledby="shutdown-title"
-            >
-                <div class="system-dialog-title">
-                    <span id="shutdown-title">Turn off computer</span>
-                    <span
-                        class="dialog-flag brand-flag"
-                        aria-hidden="true"
-                    ></span>
-                </div>
-                <div class="system-dialog-actions shutdown-actions">
-                    <button id="standby-confirm" type="button">
-                        <span
-                            class="dialog-action-icon standby-icon xp-power-icon"
-                            aria-hidden="true"
-                        ></span>
-                        <span>Stand By</span>
-                    </button>
-                    <button id="shutdown-confirm" type="button">
-                        <span
-                            class="dialog-action-icon shutdown-icon xp-power-icon"
-                            aria-hidden="true"
-                        ></span>
-                        <span>Turn Off</span>
-                    </button>
-                    <button id="restart-confirm" type="button">
-                        <span
-                            class="dialog-action-icon restart-icon"
-                            aria-hidden="true"
-                        ></span>
-                        <span>Restart</span>
-                    </button>
-                </div>
-                <div class="system-dialog-footer">
-                    <button id="shutdown-cancel" type="button">Cancel</button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Shutting down -->
-        <div id="shutdown-screen" hidden>
-            <img src="assets/xp/wordmark.png" alt="Microsoft Windows XP" />
-            <p>Windows is shutting down...</p>
-        </div>
-
-        <!-- Safe to turn off -->
-        <div id="turn-off-screen" hidden>
-            <img src="assets/xp/wordmark.png" alt="Microsoft Windows" />
-            <p>It is now safe to turn off your computer.</p>
-            <span class="turn-off-hint">Click anywhere to restart</span>
-        </div>
-
-        <!-- Stand By blocks the shell without ending the current session. -->
-        <div id="standby-screen" hidden>
-            <div role="dialog" aria-modal="true" aria-labelledby="standby-title">
-                <p id="standby-title">Windows is standing by.</p>
-                <button id="standby-resume" type="button">Resume</button>
-                <span>Move the pointer, click, or press a key to return to your session.</span>
-            </div>
-        </div>
-    </body>
+      </div>
+    </div>
+  </body>
 </html>

--- a/site/js/filesystem.js
+++ b/site/js/filesystem.js
@@ -76,6 +76,7 @@
   // Windows disallows these characters in file and folder names, along
   // with DOS device names (even when they have an extension). Keep this
   // check in the filesystem rather than duplicating it in each shell view.
+  // eslint-disable-next-line no-control-regex -- Windows rejects ASCII control characters.
   const INVALID_NAME_CHARACTERS = /[<>:"/\\\\|?*\u0000-\u001f]/;
   const RESERVED_DEVICE_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
 
@@ -461,7 +462,7 @@
 
   const copy = (id, targetParentId) => {
     const node = requireNode(id);
-    const target = requireFolder(targetParentId);
+    requireFolder(targetParentId);
     if (id === targetParentId || isDescendantOf(id, targetParentId)) {
       throw new Error(`Cannot copy "${node.name}" into itself`);
     }

--- a/site/js/game-installer.js
+++ b/site/js/game-installer.js
@@ -1,4 +1,3 @@
-/* global window */
 "use strict";
 
 // This module deliberately knows nothing about the UI.  Supplying the ZIP reader,
@@ -9,45 +8,70 @@
   if (root) root.AstroGameInstaller = api;
 })(typeof window !== "undefined" ? window : globalThis, function () {
   // Flashpoint UUIDs are not necessarily RFC 4122 version 1-5 UUIDs.
-  const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const UUID =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const DEFAULT_LIMITS = Object.freeze({
     maxFiles: 2000,
     maxFileBytes: 64 * 1024 * 1024,
     maxTotalBytes: 512 * 1024 * 1024,
   });
 
-  function fail(message) { throw new Error(message); }
+  function fail(message) {
+    throw new Error(message);
+  }
   function field(record, ...names) {
-    for (const name of names) if (record[name] !== undefined) return record[name];
+    for (const name of names)
+      if (record[name] !== undefined) return record[name];
     return undefined;
   }
-  function text(value) { return Array.isArray(value) ? value.join(" ") : String(value || ""); }
+  function text(value) {
+    return Array.isArray(value) ? value.join(" ") : String(value || "");
+  }
 
   function validateCatalogRecord(record, options = {}) {
-    if (!record || typeof record !== "object") fail("A game record is required");
+    if (!record || typeof record !== "object")
+      fail("A game record is required");
     const uuid = field(record, "uuid", "id");
     if (typeof uuid !== "string" || !UUID.test(uuid)) fail("Invalid game UUID");
-    if (text(field(record, "library", "libraryName")).toLowerCase() !== "games") fail("Only Games library records are supported");
-    if (text(field(record, "platform", "platformName")).toLowerCase() !== "flash") fail("Only Flash games are supported");
-    if (text(field(record, "status")).toLowerCase() !== "playable") fail("Only playable games are supported");
-    const applicationPath = text(field(record, "applicationPath", "application", "applicationPaths"));
+    if (text(field(record, "library", "libraryName")).toLowerCase() !== "games")
+      fail("Only Games library records are supported");
+    if (
+      text(field(record, "platform", "platformName")).toLowerCase() !== "flash"
+    )
+      fail("Only Flash games are supported");
+    if (text(field(record, "status")).toLowerCase() !== "playable")
+      fail("Only playable games are supported");
+    const applicationPath = text(
+      field(record, "applicationPath", "application", "applicationPaths"),
+    );
     if (!/(?:flash\s*player|flashplayer)/i.test(applicationPath))
       fail("Game does not use the Flash player");
     const downloadUrl = field(record, "downloadUrl", "gameZipUrl", "gameZIP");
     const launchCommand = field(record, "launchCommand", "launch", "command");
-    const packageType = text(field(record, "packageType") || "gamezip").toLowerCase();
+    const packageType = text(
+      field(record, "packageType") || "gamezip",
+    ).toLowerCase();
     if (!["gamezip", "legacy"].includes(packageType))
       fail("Unsupported game package type");
     let download, launch;
-    try { download = new URL(downloadUrl, options.origin || "https://astro.local"); } catch (_) { fail("Invalid download URL"); }
-    try { launch = new URL(launchCommand); } catch (_) { fail("Invalid launch command"); }
+    try {
+      download = new URL(downloadUrl, options.origin || "https://astro.local");
+    } catch (_) {
+      fail("Invalid download URL");
+    }
+    try {
+      launch = new URL(launchCommand);
+    } catch (_) {
+      fail("Invalid launch command");
+    }
     const ownOrigin = new URL(options.origin || "https://astro.local").origin;
     const trustedUpstream =
       download.protocol === "https:" &&
       download.host === "download.unstable.life";
     if (!trustedUpstream && download.origin !== ownOrigin)
       fail("Download URL is not allowed");
-    if (!/^https?:$/.test(launch.protocol) || !/\.swf$/i.test(launch.pathname)) fail("Launch command must point to an SWF");
+    if (!/^https?:$/.test(launch.protocol) || !/\.swf$/i.test(launch.pathname))
+      fail("Launch command must point to an SWF");
     return Object.assign({}, record, {
       uuid: uuid.toLowerCase(),
       downloadUrl: download.href,
@@ -64,7 +88,15 @@
   }
 
   function safeArchivePath(name) {
-    if (typeof name !== "string" || !name || name.indexOf("\0") !== -1 || name.includes("\\") || name.startsWith("/") || /^[a-zA-Z]:/.test(name)) fail("Unsafe ZIP entry name");
+    if (
+      typeof name !== "string" ||
+      !name ||
+      name.indexOf("\0") !== -1 ||
+      name.includes("\\") ||
+      name.startsWith("/") ||
+      /^[a-zA-Z]:/.test(name)
+    )
+      fail("Unsafe ZIP entry name");
     const isDirectory = name.endsWith("/");
     const parts = (isDirectory ? name.slice(0, -1) : name).split("/");
     if (
@@ -76,11 +108,7 @@
         } catch (_) {
           return true;
         }
-        return (
-          decoded === "." ||
-          decoded === ".." ||
-          /[\\/?#]/.test(decoded)
-        );
+        return decoded === "." || decoded === ".." || /[\\/?#]/.test(decoded);
       })
     )
       fail("Unsafe ZIP entry name");
@@ -138,10 +166,7 @@
     let offset = directoryOffset;
     let total = 0;
     for (let index = 0; index < entryCount; index += 1) {
-      if (
-        offset + 46 > eocd ||
-        view.getUint32(offset, true) !== 0x02014b50
-      ) {
+      if (offset + 46 > eocd || view.getUint32(offset, true) !== 0x02014b50) {
         fail("ZIP metadata is invalid");
       }
       const fileBytes = view.getUint32(offset + 24, true);
@@ -174,7 +199,10 @@
 
   function validateZipEntries(entries, limits = {}) {
     const max = Object.assign({}, DEFAULT_LIMITS, limits);
-    const pairs = entries instanceof Map ? Array.from(entries.entries()) : Object.entries(entries || {});
+    const pairs =
+      entries instanceof Map
+        ? Array.from(entries.entries())
+        : Object.entries(entries || {});
     if (pairs.length > max.maxFiles) fail("ZIP has too many files");
     let total = 0;
     return pairs.flatMap(([name, entry]) => {
@@ -210,7 +238,8 @@
   }
   async function putMetadata(store, metadata) {
     if (typeof store.put === "function") return store.put(metadata);
-    if (typeof store.set === "function") return store.set(metadata.id, metadata);
+    if (typeof store.set === "function")
+      return store.set(metadata.id, metadata);
     fail("Metadata store dependency is required");
   }
   async function deleteMetadata(store, id) {
@@ -220,11 +249,27 @@
   }
 
   async function install(record, zipBytes, dependencies = {}) {
-    if (!(zipBytes instanceof Uint8Array)) fail("Game archive must be a Uint8Array");
-    if (typeof dependencies.unzipSync !== "function") fail("unzipSync dependency is required");
-    if (!dependencies.cache || typeof dependencies.cache.put !== "function" || typeof dependencies.cache.delete !== "function") fail("Cache dependency is required");
-    if (!dependencies.store || (typeof dependencies.store.put !== "function" && typeof dependencies.store.set !== "function")) fail("Metadata store dependency is required");
-    const origin = dependencies.origin || (typeof location !== "undefined" ? location.origin : "https://astro.local");
+    if (!(zipBytes instanceof Uint8Array))
+      fail("Game archive must be a Uint8Array");
+    if (typeof dependencies.unzipSync !== "function")
+      fail("unzipSync dependency is required");
+    if (
+      !dependencies.cache ||
+      typeof dependencies.cache.put !== "function" ||
+      typeof dependencies.cache.delete !== "function"
+    )
+      fail("Cache dependency is required");
+    if (
+      !dependencies.store ||
+      (typeof dependencies.store.put !== "function" &&
+        typeof dependencies.store.set !== "function")
+    )
+      fail("Metadata store dependency is required");
+    const origin =
+      dependencies.origin ||
+      (typeof location !== "undefined"
+        ? location.origin
+        : "https://astro.local");
     const game = validateCatalogRecord(record, { origin });
     if (game.packageType !== "gamezip")
       fail("Legacy games must be installed from their launch SWF");
@@ -248,22 +293,23 @@
         );
         written.push(key);
       }
-      const resolvedLaunchPath = cacheKey(
-        origin,
-        game.uuid,
-        launchFile.path,
-      );
+      const resolvedLaunchPath = cacheKey(origin, game.uuid, launchFile.path);
       const metadata = Object.assign({}, game, {
         id: "flashpoint:" + game.uuid,
         type: "swf",
         source: "Flashpoint Archive",
         launchPath: resolvedLaunchPath,
-        basePath: resolvedLaunchPath.slice(0, resolvedLaunchPath.lastIndexOf("/") + 1),
+        basePath: resolvedLaunchPath.slice(
+          0,
+          resolvedLaunchPath.lastIndexOf("/") + 1,
+        ),
       });
       await putMetadata(dependencies.store, metadata);
       return metadata;
     } catch (error) {
-      await Promise.all(written.map((key) => dependencies.cache.delete(key).catch(() => {})));
+      await Promise.all(
+        written.map((key) => dependencies.cache.delete(key).catch(() => {})),
+      );
       throw error;
     }
   }
@@ -271,17 +317,27 @@
   async function installLegacy(record, swfBytes, dependencies = {}) {
     if (!(swfBytes instanceof Uint8Array))
       fail("Game file must be a Uint8Array");
-    if (swfBytes.byteLength === 0)
-      fail("Game file is empty");
+    if (swfBytes.byteLength === 0) fail("Game file is empty");
     const maxFileBytes =
       dependencies.limits?.maxFileBytes || DEFAULT_LIMITS.maxFileBytes;
-    if (swfBytes.byteLength > maxFileBytes)
-      fail("Game file is too large");
-    if (!dependencies.cache || typeof dependencies.cache.put !== "function" || typeof dependencies.cache.delete !== "function")
+    if (swfBytes.byteLength > maxFileBytes) fail("Game file is too large");
+    if (
+      !dependencies.cache ||
+      typeof dependencies.cache.put !== "function" ||
+      typeof dependencies.cache.delete !== "function"
+    )
       fail("Cache dependency is required");
-    if (!dependencies.store || (typeof dependencies.store.put !== "function" && typeof dependencies.store.set !== "function"))
+    if (
+      !dependencies.store ||
+      (typeof dependencies.store.put !== "function" &&
+        typeof dependencies.store.set !== "function")
+    )
       fail("Metadata store dependency is required");
-    const origin = dependencies.origin || (typeof location !== "undefined" ? location.origin : "https://astro.local");
+    const origin =
+      dependencies.origin ||
+      (typeof location !== "undefined"
+        ? location.origin
+        : "https://astro.local");
     const game = validateCatalogRecord(record, { origin });
     if (game.packageType !== "legacy")
       fail("Only Legacy games can be installed from a launch SWF");
@@ -297,7 +353,10 @@
         type: "swf",
         source: "Flashpoint Archive",
         launchPath: resolvedLaunchPath,
-        basePath: resolvedLaunchPath.slice(0, resolvedLaunchPath.lastIndexOf("/") + 1),
+        basePath: resolvedLaunchPath.slice(
+          0,
+          resolvedLaunchPath.lastIndexOf("/") + 1,
+        ),
       });
       await putMetadata(dependencies.store, metadata);
       return metadata;
@@ -309,14 +368,45 @@
 
   async function uninstall(uuid, dependencies = {}) {
     if (typeof uuid !== "string" || !UUID.test(uuid)) fail("Invalid game UUID");
-    if (!dependencies.cache || typeof dependencies.cache.keys !== "function" || typeof dependencies.cache.delete !== "function") fail("Cache dependency is required");
-    if (!dependencies.store || (typeof dependencies.store.delete !== "function" && typeof dependencies.store.remove !== "function")) fail("Metadata store dependency is required");
-    const origin = dependencies.origin || (typeof location !== "undefined" ? location.origin : "https://astro.local");
+    if (
+      !dependencies.cache ||
+      typeof dependencies.cache.keys !== "function" ||
+      typeof dependencies.cache.delete !== "function"
+    )
+      fail("Cache dependency is required");
+    if (
+      !dependencies.store ||
+      (typeof dependencies.store.delete !== "function" &&
+        typeof dependencies.store.remove !== "function")
+    )
+      fail("Metadata store dependency is required");
+    const origin =
+      dependencies.origin ||
+      (typeof location !== "undefined"
+        ? location.origin
+        : "https://astro.local");
     const prefix = cacheKey(origin, uuid.toLowerCase(), "");
     const keys = await dependencies.cache.keys();
-    await Promise.all(keys.filter((key) => String(key.url || key).startsWith(prefix)).map((key) => dependencies.cache.delete(key)));
-    await deleteMetadata(dependencies.store, "flashpoint:" + uuid.toLowerCase());
+    await Promise.all(
+      keys
+        .filter((key) => String(key.url || key).startsWith(prefix))
+        .map((key) => dependencies.cache.delete(key)),
+    );
+    await deleteMetadata(
+      dependencies.store,
+      "flashpoint:" + uuid.toLowerCase(),
+    );
   }
 
-  return { DEFAULT_LIMITS, validateCatalogRecord, archiveLaunchPath, safeArchivePath, validateZipMetadata, validateZipEntries, install, installLegacy, uninstall };
+  return {
+    DEFAULT_LIMITS,
+    validateCatalogRecord,
+    archiveLaunchPath,
+    safeArchivePath,
+    validateZipMetadata,
+    validateZipEntries,
+    install,
+    installLegacy,
+    uninstall,
+  };
 });

--- a/site/js/game-library.js
+++ b/site/js/game-library.js
@@ -1,4 +1,3 @@
-/* global window */
 "use strict";
 
 (function exposeGameLibrary(root, factory) {
@@ -59,10 +58,8 @@
       return result;
     };
     return {
-      list: () =>
-        run("readonly", (store) => requestResult(store.getAll())),
-      get: (id) =>
-        run("readonly", (store) => requestResult(store.get(id))),
+      list: () => run("readonly", (store) => requestResult(store.getAll())),
+      get: (id) => run("readonly", (store) => requestResult(store.get(id))),
       put: (record) =>
         run("readwrite", (store) => requestResult(store.put(record))),
       delete: (id) =>
@@ -106,7 +103,9 @@
     if (!response.body?.getReader) {
       const bytes = new Uint8Array(await response.arrayBuffer());
       if (bytes.byteLength > maxBytes) {
-        throw new Error("This game is larger than the supported download limit.");
+        throw new Error(
+          "This game is larger than the supported download limit.",
+        );
       }
       onProgress?.({ loaded: bytes.byteLength, total: expected });
       return bytes;
@@ -121,7 +120,9 @@
       loaded += value.byteLength;
       if (loaded > maxBytes) {
         await reader.cancel();
-        throw new Error("This game is larger than the supported download limit.");
+        throw new Error(
+          "This game is larger than the supported download limit.",
+        );
       }
       chunks.push(value);
       onProgress?.({ loaded, total: expected });
@@ -147,7 +148,9 @@
       } catch {
         // Upstream failure pages are not necessarily JSON.
       }
-      throw new Error(message || `The game catalog returned ${response.status}.`);
+      throw new Error(
+        message || `The game catalog returned ${response.status}.`,
+      );
     }
     return response.json();
   };
@@ -281,7 +284,9 @@
               ? estimate.quota - estimate.usage
               : null;
           if (available !== null && contentLength > available) {
-            throw new Error("There is not enough browser storage for this game.");
+            throw new Error(
+              "There is not enough browser storage for this game.",
+            );
           }
         }
         const bytes = await readDownload(response, { onProgress });

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -108,7 +108,7 @@ const systemShortcuts = {
     icon: "assets/xp/icons/mycomputer.png",
     desktop: false,
   },
-  "__notepad": {
+  __notepad: {
     title: "Notepad",
     glyph: "notepad",
     desktop: false,
@@ -925,9 +925,7 @@ const loadRuffleSWF = (gameId, win) => {
     url:
       game.url ||
       (game.spoofUrl ? `${game.spoofUrl}/main.swf` : `swf/${gameId}/main.swf`),
-    base:
-      game.base ||
-      (game.spoofUrl ? `${game.spoofUrl}/` : `swf/${gameId}/`),
+    base: game.base || (game.spoofUrl ? `${game.spoofUrl}/` : `swf/${gameId}/`),
     letterbox: "on",
     scale: "showAll",
     forceScale: true,
@@ -2275,7 +2273,6 @@ const createSystemWindowContent = (shortcutId, win) => {
       }
       return;
     }
-    const item = explorerMenu.querySelector("button:not(:disabled)");
     const menuItems = [
       ...explorerMenu.querySelectorAll("button:not(:disabled)"),
     ];
@@ -2838,7 +2835,9 @@ const wireSearchCompanion = (win) => {
 };
 
 const findBundledGameByTitle = (title) => {
-  const wanted = String(title || "").trim().toLowerCase();
+  const wanted = String(title || "")
+    .trim()
+    .toLowerCase();
   if (!wanted) return null;
   return (
     Object.keys(window.FLASH_GAMES).find(
@@ -2917,9 +2916,7 @@ const createInternetGameCard = (game, win, { installed = false } = {}) => {
   } else {
     const gameId = `flashpoint:${game.uuid}`;
     const includedGameId = findBundledGameByTitle(game.title);
-    let availableGameId = gamesList[gameId]
-      ? gameId
-      : includedGameId;
+    let availableGameId = gamesList[gameId] ? gameId : includedGameId;
     action.textContent = availableGameId
       ? "Play"
       : game.potentiallyCompatible === false
@@ -3038,7 +3035,8 @@ const wireInternetGames = (win) => {
     }
     if (!gameLibrary || gameLibraryError) {
       status.textContent =
-        gameLibraryError?.message || "The Internet Games service is unavailable.";
+        gameLibraryError?.message ||
+        "The Internet Games service is unavailable.";
       return;
     }
     const submit = form.querySelector("button");
@@ -3262,11 +3260,7 @@ const importDroppedFiles = async (destinationId, dataTransfer) => {
     progress.close();
   }
 };
-const wireFolderDropTarget = (
-  element,
-  destinationId,
-  selectedIds = () => [],
-) => {
+const wireFolderDropTarget = (element, destinationId) => {
   element.addEventListener("dragover", (event) => {
     const internal = event.dataTransfer?.types?.includes(
       "application/x-astro-vfs-ids",
@@ -3823,8 +3817,7 @@ const renderExplorerItems = (win, contentRoot = win.el) => {
       item.click();
       openExplorerContextMenu(win, event.clientX, event.clientY);
     });
-    if (node.type === "folder")
-      wireFolderDropTarget(item, node.id, () => selectedExplorerNodes(win));
+    if (node.type === "folder") wireFolderDropTarget(item, node.id);
     items.appendChild(item);
   });
   const status = explorerContent?.querySelector(".explorer-status");
@@ -3841,6 +3834,7 @@ const renderExplorerItems = (win, contentRoot = win.el) => {
 // opened through the registered file association.
 const gameFileName = (gameId) =>
   `${formatGameTitle(gameId)
+    // eslint-disable-next-line no-control-regex -- Windows rejects ASCII control characters.
     .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "")
     .replace(/\s+/g, " ")
     .trim()}.game`;
@@ -4105,11 +4099,7 @@ const openNotepad = (file = null) => {
       item.setAttribute("aria-checked", String(!status.hidden));
     },
     about: () =>
-      XPDialogs.alert(
-        "Microsoft Windows XP\nNotepad",
-        "About Notepad",
-        "info",
-      ),
+      XPDialogs.alert("Microsoft Windows XP\nNotepad", "About Notepad", "info"),
   };
 
   const menuDefinitions = [
@@ -4177,10 +4167,7 @@ const openNotepad = (file = null) => {
       item.type = "button";
       item.className = "notepad-menu-item";
       item.dataset.command = command;
-      item.setAttribute(
-        "role",
-        checked ? "menuitemcheckbox" : "menuitem",
-      );
+      item.setAttribute("role", checked ? "menuitemcheckbox" : "menuitem");
       if (checked) {
         item.classList.add("checked");
         item.setAttribute("aria-checked", "true");
@@ -5086,12 +5073,8 @@ const wireProjectSettings = (win) => {
   const offlineGamesList = content.querySelector(
     "[data-project-offline-games]",
   );
-  const updateStatus = content.querySelector(
-    '[data-project-status="updates"]',
-  );
-  const downloadProgress = content.querySelector(
-    ".project-settings-progress",
-  );
+  const updateStatus = content.querySelector('[data-project-status="updates"]');
+  const downloadProgress = content.querySelector(".project-settings-progress");
   const gameDownloadProgress = content.querySelector(
     "[data-project-game-progress]",
   );
@@ -5189,8 +5172,7 @@ const wireProjectSettings = (win) => {
       checkbox.disabled = busy;
       checkbox.dataset.offlineGame = game.id;
       const title = document.createElement("span");
-      title.textContent =
-        gamesList[game.id]?.title || formatGameTitle(game.id);
+      title.textContent = gamesList[game.id]?.title || formatGameTitle(game.id);
       const size = document.createElement("span");
       size.className = "project-offline-game-size";
       size.textContent = formatProjectBytes(game.bytes);
@@ -5238,9 +5220,7 @@ const wireProjectSettings = (win) => {
       state.downloadedGameBytes,
     );
     value("storage").textContent = projectStorageText(state);
-    value("lastChecked").textContent = formatUpdateCheckTime(
-      state.lastChecked,
-    );
+    value("lastChecked").textContent = formatUpdateCheckTime(state.lastChecked);
     offlineStatus.textContent = offlineStatusText(state);
     const activeGameTitle = state.activeGameId
       ? gamesList[state.activeGameId]?.title ||
@@ -5281,13 +5261,12 @@ const wireProjectSettings = (win) => {
     } else {
       gameDownloadProgress.removeAttribute("value");
     }
-    checkButton.disabled =
-      !state.online || transientPhases.has(state.phase);
+    checkButton.disabled = !state.online || transientPhases.has(state.phase);
     applyButton.hidden = !state.availableVersion;
-    applyButton.disabled =
-      state.enabled ? !state.updateReady : transientPhases.has(state.phase);
-    repairButton.disabled =
-      !state.online || transientPhases.has(state.phase);
+    applyButton.disabled = state.enabled
+      ? !state.updateReady
+      : transientPhases.has(state.phase);
+    repairButton.disabled = !state.online || transientPhases.has(state.phase);
     const gameBusy = ["downloading", "removing"].includes(state.gamePhase);
     downloadAllGamesButton.disabled =
       !state.online ||
@@ -5373,7 +5352,6 @@ const wireProjectSettings = (win) => {
     resetAstroFlash();
     window.location.reload();
   });
-
 };
 
 const openProjectSettings = () => openSystemWindow("__astro-settings");
@@ -5834,6 +5812,7 @@ const wireDesktopIconDrag = (icon) => {
       left: item.offsetLeft,
       top: item.offsetTop,
     }));
+    const container = document.getElementById("desktop-icons");
     desktopDragged = false;
 
     const onMove = (moveEvent) => {
@@ -5842,7 +5821,6 @@ const wireDesktopIconDrag = (icon) => {
       if (!desktopDragged && Math.hypot(deltaX, deltaY) < 4) return;
 
       desktopDragged = true;
-      const container = document.getElementById("desktop-icons");
       const groupLeft = Math.min(...selected.map(({ left }) => left));
       const groupTop = Math.min(...selected.map(({ top }) => top));
       const groupRight = Math.max(
@@ -6092,8 +6070,7 @@ const buildDesktopIcons = () => {
   });
 
   if (!wasBuilt) wireDesktopSelectionRectangle();
-  if (!wasBuilt)
-    wireFolderDropTarget(container, fs.DESKTOP, getSelectedFilesystemIds);
+  if (!wasBuilt) wireFolderDropTarget(container, fs.DESKTOP);
   requestAnimationFrame(() =>
     layoutDesktopIcons(getDesktopLayoutSettings().autoArrange),
   );
@@ -6227,13 +6204,6 @@ const addDesktopSeparator = (menu) => {
 };
 
 const renderDesktopContextMenu = (menu, itemId = null) => {
-  const selectedIds =
-    itemId &&
-    document
-      .querySelector(`.desktop-icon[data-desktop-id="${CSS.escape(itemId)}"]`)
-      ?.classList.contains("selected")
-      ? getSelectedDesktopIds()
-      : [];
   const {
     filesystemIds: selectedFsIds,
     allFilesystem,

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -53,7 +53,9 @@
     typeof file.url === "string" &&
     !file.url.startsWith("/") &&
     !file.url.includes("\\") &&
-    !file.url.split("/").some((part) => !part || part === "." || part === "..") &&
+    !file.url
+      .split("/")
+      .some((part) => !part || part === "." || part === "..") &&
     Number.isInteger(file.bytes) &&
     file.bytes >= 0;
 
@@ -131,7 +133,9 @@
       quota: null,
       error: null,
       bundledGames: [],
-      downloadedGameIds: Object.keys(records).filter((id) => id !== "__runtime__"),
+      downloadedGameIds: Object.keys(records).filter(
+        (id) => id !== "__runtime__",
+      ),
       downloadedGameBytes: Object.values(records).reduce(
         (total, record) => total + (Number(record.bytes) || 0),
         0,
@@ -269,7 +273,9 @@
 
     const registerAndWait = async () => {
       if (!navigatorObject.serviceWorker) {
-        throw new Error("Offline system files are not supported by this browser.");
+        throw new Error(
+          "Offline system files are not supported by this browser.",
+        );
       }
       const nextRegistration = await navigatorObject.serviceWorker.register(
         serviceWorkerUrl,
@@ -287,7 +293,11 @@
       }
       const worker = nextRegistration.installing || nextRegistration.waiting;
       if (worker) {
-        setState({ phase: "downloading", workerState: worker.state, error: null });
+        setState({
+          phase: "downloading",
+          workerState: worker.state,
+          error: null,
+        });
         await waitForWorker(worker);
       } else {
         await navigatorObject.serviceWorker.ready;
@@ -367,7 +377,9 @@
       const cache = await environment.caches.open(bundledCacheName);
       let loaded = 0;
       for (const file of entry.files) {
-        const response = await environment.fetch(file.url, { cache: "no-store" });
+        const response = await environment.fetch(file.url, {
+          cache: "no-store",
+        });
         if (!response.ok) {
           throw new Error(`Offline download failed (${response.status}).`);
         }
@@ -393,7 +405,9 @@
         Number.isFinite(estimate.usage) &&
         requiredBytes > estimate.quota - estimate.usage
       ) {
-        throw new Error("There is not enough browser storage for this download.");
+        throw new Error(
+          "There is not enough browser storage for this download.",
+        );
       }
     };
 
@@ -529,7 +543,9 @@
       for (const id of selectedIds) {
         if (!currentManifest.games[id]) {
           await deleteRecordFiles(id);
-        } else if (records[id].revision !== currentManifest.games[id].revision) {
+        } else if (
+          records[id].revision !== currentManifest.games[id].revision
+        ) {
           await downloadGame(id);
         }
       }
@@ -649,7 +665,8 @@
         setState({ online: false });
       });
       environment.document?.addEventListener("visibilitychange", () => {
-        if (environment.document.visibilityState === "visible") automaticCheck();
+        if (environment.document.visibilityState === "visible")
+          automaticCheck();
       });
     };
 

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-	handleCatalogRequest,
-	legacyAssetUrl,
-	parseGameDetails,
-	parseSearchResults,
+  handleCatalogRequest,
+  legacyAssetUrl,
+  parseGameDetails,
+  parseSearchResults,
 } from "../catalog/catalog";
 import catalogWorker from "../worker/catalog-worker";
 
@@ -35,120 +35,126 @@ const detailsHtml = `
 <div class="row"><div class="field">Application Path:</div><div class="value">FPSoftware\\Flash\\flashplayer_32_sa.exe</div></div>`;
 
 describe("Flashpoint catalog parsing", () => {
-	test("parses search results and safely decodes text", () => {
-		const results = parseSearchResults(searchHtml);
-		expect(results).toHaveLength(1);
-		expect(results[0]).toMatchObject({
-			uuid,
-			title: "Bike Mania Arena",
-			developer: "Flash Games 247",
-			platform: "Flash",
-			tags: ["Sports", "Motocross", "Auto-zipped"],
-		});
-		expect(
-			parseSearchResults(
-				searchHtml.replace(
-					"Bike Mania Arena",
-					"&lt;b&gt;Bike Mania Arena&lt;/b&gt;",
-				),
-			)[0].title,
-		).toBe("Bike Mania Arena");
-		expect(
-			parseSearchResults(
-				searchHtml.replace(
-					"Bike Mania Arena",
-					"&amp;lt;b&amp;gt;Bike Mania Arena&amp;lt;/b&amp;gt;",
-				),
-			)[0].title,
-		).toBe("&lt;b&gt;Bike Mania Arena&lt;/b&gt;");
-	});
+  test("parses search results and safely decodes text", () => {
+    const results = parseSearchResults(searchHtml);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      uuid,
+      title: "Bike Mania Arena",
+      developer: "Flash Games 247",
+      platform: "Flash",
+      tags: ["Sports", "Motocross", "Auto-zipped"],
+    });
+    expect(
+      parseSearchResults(
+        searchHtml.replace(
+          "Bike Mania Arena",
+          "&lt;b&gt;Bike Mania Arena&lt;/b&gt;",
+        ),
+      )[0].title,
+    ).toBe("Bike Mania Arena");
+    expect(
+      parseSearchResults(
+        searchHtml.replace(
+          "Bike Mania Arena",
+          "&amp;lt;b&amp;gt;Bike Mania Arena&amp;lt;/b&amp;gt;",
+        ),
+      )[0].title,
+    ).toBe("&lt;b&gt;Bike Mania Arena&lt;/b&gt;");
+  });
 
-	test("parses GameZIP and Legacy compatibility", () => {
-		const details = parseGameDetails(detailsHtml, "https://flash.example", uuid);
-		expect(details).toMatchObject({
-			compatible: true,
-			packageType: "gamezip",
-			legacyFallback: true,
-			downloadUrl: `https://flash.example/api/games/${uuid}/download`,
-			tags: ["Sports", "Motocross"],
-		});
+  test("parses GameZIP and Legacy compatibility", () => {
+    const details = parseGameDetails(
+      detailsHtml,
+      "https://flash.example",
+      uuid,
+    );
+    expect(details).toMatchObject({
+      compatible: true,
+      packageType: "gamezip",
+      legacyFallback: true,
+      downloadUrl: `https://flash.example/api/games/${uuid}/download`,
+      tags: ["Sports", "Motocross"],
+    });
 
-		const unsupported = parseGameDetails(
-			detailsHtml
-				.replace(/data-game-zip="[^"]+"/, 'data-game-zip=""')
-				.replace(/data-legacy-server="[^"]+"/, 'data-legacy-server=""'),
-			"https://flash.example",
-			uuid,
-		);
-		expect(unsupported.compatible).toBeFalse();
-		const legacy = parseGameDetails(
-			detailsHtml.replace(/data-game-zip="[^"]+"/, 'data-game-zip=""'),
-			"https://flash.example",
-			uuid,
-		);
-		expect(legacy.compatible).toBeTrue();
-		expect(legacy.packageType).toBe("legacy");
-	});
+    const unsupported = parseGameDetails(
+      detailsHtml
+        .replace(/data-game-zip="[^"]+"/, 'data-game-zip=""')
+        .replace(/data-legacy-server="[^"]+"/, 'data-legacy-server=""'),
+      "https://flash.example",
+      uuid,
+    );
+    expect(unsupported.compatible).toBeFalse();
+    const legacy = parseGameDetails(
+      detailsHtml.replace(/data-game-zip="[^"]+"/, 'data-game-zip=""'),
+      "https://flash.example",
+      uuid,
+    );
+    expect(legacy.compatible).toBeTrue();
+    expect(legacy.packageType).toBe("legacy");
+  });
 
-	test("accepts safe Legacy paths and rejects traversal", () => {
-		expect(legacyAssetUrl("content/localflash/game/main.swf")).toBe(
-			"https://infinity.unstable.life/Flashpoint/Legacy/htdocs/localflash/game/main.swf",
-		);
-		expect(() => legacyAssetUrl("content/localflash/../secret")).toThrow(
-			"Invalid Legacy",
-		);
-	});
+  test("accepts safe Legacy paths and rejects traversal", () => {
+    expect(legacyAssetUrl("content/localflash/game/main.swf")).toBe(
+      "https://infinity.unstable.life/Flashpoint/Legacy/htdocs/localflash/game/main.swf",
+    );
+    expect(() => legacyAssetUrl("content/localflash/../secret")).toThrow(
+      "Invalid Legacy",
+    );
+  });
 });
 
 describe("shared catalog request handler", () => {
-	test("serves search results in both local and Worker entrypoints", async () => {
-		const fetcher = async () =>
-			new Response(searchHtml, {
-				headers: { "Content-Type": "text/html; charset=utf-8" },
-			});
-		const request = new Request(
-			"https://flash.example/api/games?q=bike%20mania",
-		);
-		const localResponse = await handleCatalogRequest(request, fetcher);
-		expect(localResponse.status).toBe(200);
-		expect((await localResponse.json()).games[0].title).toBe("Bike Mania Arena");
+  test("serves search results in both local and Worker entrypoints", async () => {
+    const fetcher = async () =>
+      new Response(searchHtml, {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    const request = new Request(
+      "https://flash.example/api/games?q=bike%20mania",
+    );
+    const localResponse = await handleCatalogRequest(request, fetcher);
+    expect(localResponse.status).toBe(200);
+    expect((await localResponse.json()).games[0].title).toBe(
+      "Bike Mania Arena",
+    );
 
-		const originalFetch = globalThis.fetch;
-		try {
-			globalThis.fetch = fetcher as unknown as typeof fetch;
-			const workerResponse = await catalogWorker.fetch(request);
-			expect(workerResponse.status).toBe(200);
-			expect((await workerResponse.json()).games[0].title).toBe(
-				"Bike Mania Arena",
-			);
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = fetcher as unknown as typeof fetch;
+      const workerResponse = await catalogWorker.fetch(request);
+      expect(workerResponse.status).toBe(200);
+      expect((await workerResponse.json()).games[0].title).toBe(
+        "Bike Mania Arena",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-	test("validates methods, queries, and UUID routes", async () => {
-		expect(
-			(
-				await handleCatalogRequest(
-					new Request("https://flash.example/api/games", {
-						method: "POST",
-					}),
-				)
-			).status,
-		).toBe(405);
-		expect(
-			(
-				await handleCatalogRequest(
-					new Request("https://flash.example/api/games?q="),
-				)
-			).status,
-		).toBe(400);
-		expect(
-			(
-				await handleCatalogRequest(
-					new Request("https://flash.example/api/games/not-a-uuid"),
-				)
-			).status,
-		).toBe(404);
-	});
+  test("validates methods, queries, and UUID routes", async () => {
+    expect(
+      (
+        await handleCatalogRequest(
+          new Request("https://flash.example/api/games", {
+            method: "POST",
+          }),
+        )
+      ).status,
+    ).toBe(405);
+    expect(
+      (
+        await handleCatalogRequest(
+          new Request("https://flash.example/api/games?q="),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await handleCatalogRequest(
+          new Request("https://flash.example/api/games/not-a-uuid"),
+        )
+      ).status,
+    ).toBe(404);
+  });
 });

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import {
-	mkdir,
-	mkdtemp,
-	readFile,
-	readdir,
-	rm,
-	unlink,
-	writeFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  unlink,
+  writeFile,
 } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { tmpdir } from "node:os";
@@ -15,383 +15,387 @@ import { tmpdir } from "node:os";
 import { zipSync } from "fflate";
 
 import {
-	BuildPaths,
-	PRECACHE_FILE_SUFFIXES,
-	build,
-	downloadRuffle,
-	generateServiceWorker,
-	getDeploymentVersion,
-	getShortHash,
-	loadRuffleRelease,
-	updateHtml,
-	validateOutput,
-	writeOfflineGameManifest,
-	writeVersionMetadata,
+  BuildPaths,
+  PRECACHE_FILE_SUFFIXES,
+  build,
+  downloadRuffle,
+  generateServiceWorker,
+  getDeploymentVersion,
+  getShortHash,
+  loadRuffleRelease,
+  updateHtml,
+  validateOutput,
+  writeOfflineGameManifest,
+  writeVersionMetadata,
 } from "../tools/deploy";
 
 const temporaryDirectories: string[] = [];
 
 async function makeTemporaryDirectory(): Promise<string> {
-	const path = await mkdtemp(join(tmpdir(), "astro-flash-deploy-test-"));
-	temporaryDirectories.push(path);
-	return path;
+  const path = await mkdtemp(join(tmpdir(), "astro-flash-deploy-test-"));
+  temporaryDirectories.push(path);
+  return path;
 }
 
 afterEach(async () => {
-	await Promise.all(
-		temporaryDirectories.splice(0).map((path) =>
-			rm(path, { force: true, recursive: true }),
-		),
-	);
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { force: true, recursive: true })),
+  );
 });
 
 function makeRuffleArchive({
-	includeCore = true,
-	includeWasm = true,
+  includeCore = true,
+  includeWasm = true,
 }: {
-	includeCore?: boolean;
-	includeWasm?: boolean;
+  includeCore?: boolean;
+  includeWasm?: boolean;
 } = {}): Uint8Array {
-	return zipSync({
-		"ruffle.js": new TextEncoder().encode("ruffle"),
-		"ruffle.js.map": new TextEncoder().encode("map"),
-		...(includeCore
-			? { "core.ruffle.abc123.js": new TextEncoder().encode("core") }
-			: {}),
-		...(includeWasm ? { "abc123.wasm": new TextEncoder().encode("wasm") } : {}),
-		"nested/ignored.js": new TextEncoder().encode("ignored"),
-	});
+  return zipSync({
+    "ruffle.js": new TextEncoder().encode("ruffle"),
+    "ruffle.js.map": new TextEncoder().encode("map"),
+    ...(includeCore
+      ? { "core.ruffle.abc123.js": new TextEncoder().encode("core") }
+      : {}),
+    ...(includeWasm ? { "abc123.wasm": new TextEncoder().encode("wasm") } : {}),
+    "nested/ignored.js": new TextEncoder().encode("ignored"),
+  });
 }
 
 function archiveResponse(archive: Uint8Array): Response {
-	return new Response(archive.slice().buffer as ArrayBuffer);
+  return new Response(archive.slice().buffer as ArrayBuffer);
 }
 
 async function writeFiles(
-	root: string,
-	files: Record<string, string | Uint8Array>,
+  root: string,
+  files: Record<string, string | Uint8Array>,
 ): Promise<void> {
-	for (const [relativePath, content] of Object.entries(files)) {
-		const path = join(root, relativePath);
-		await mkdir(join(path, ".."), { recursive: true });
-		await writeFile(path, content);
-	}
+  for (const [relativePath, content] of Object.entries(files)) {
+    const path = join(root, relativePath);
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, content);
+  }
 }
 
 async function makeSource(root: string): Promise<void> {
-	await writeFiles(root, {
-		"index.html": [
-			'<script src="js/ruffle.js?v=old"></script>',
-			'<script src="vendor/fflate/0.8.3/index.js?v=old"></script>',
-			'<script src="js/games.js?v=old"></script>',
-			'<script src="js/game-installer.js?v=old"></script>',
-			'<script src="js/game-library.js?v=old"></script>',
-			'<script src="js/filesystem.js?v=old"></script>',
-			'<script src="js/file-operations.js?v=old"></script>',
-			'<script src="js/dialogs.js?v=old"></script>',
-			'<script src="js/offline.js?v=old"></script>',
-			'<script src="js/main.js?v=old"></script>',
-			'<link rel="stylesheet" href="css/main.css?v=old">',
-		].join("\n"),
-		"js/games.js": "games",
-		"js/game-installer.js": "game installer",
-		"js/game-library.js": "game library",
-		"js/filesystem.js": "filesystem",
-		"js/file-operations.js": "file operations",
-		"js/dialogs.js": "dialogs",
-		"js/offline.js": "offline",
-		"js/offline-worker.js": "offline worker",
-		"js/main.js": 'const APP_VERSION = "old";\n',
-		"css/main.css": "css",
-		"css/fonts/test.ttf": "font",
-		"vendor/fflate/0.8.3/index.js": "fflate",
-		"swf/bike-mania/main.swf": "swf",
-		"iframe/doom/index.html": "doom",
-		"iframe/inside-the-firewall/index.html": "firewall",
-		"dos/doom/doom.jsdos": "jsdos",
-	});
+  await writeFiles(root, {
+    "index.html": [
+      '<script src="js/ruffle.js?v=old"></script>',
+      '<script src="vendor/fflate/0.8.3/index.js?v=old"></script>',
+      '<script src="js/games.js?v=old"></script>',
+      '<script src="js/game-installer.js?v=old"></script>',
+      '<script src="js/game-library.js?v=old"></script>',
+      '<script src="js/filesystem.js?v=old"></script>',
+      '<script src="js/file-operations.js?v=old"></script>',
+      '<script src="js/dialogs.js?v=old"></script>',
+      '<script src="js/offline.js?v=old"></script>',
+      '<script src="js/main.js?v=old"></script>',
+      '<link rel="stylesheet" href="css/main.css?v=old">',
+    ].join("\n"),
+    "js/games.js": "games",
+    "js/game-installer.js": "game installer",
+    "js/game-library.js": "game library",
+    "js/filesystem.js": "filesystem",
+    "js/file-operations.js": "file operations",
+    "js/dialogs.js": "dialogs",
+    "js/offline.js": "offline",
+    "js/offline-worker.js": "offline worker",
+    "js/main.js": 'const APP_VERSION = "old";\n',
+    "css/main.css": "css",
+    "css/fonts/test.ttf": "font",
+    "vendor/fflate/0.8.3/index.js": "fflate",
+    "swf/bike-mania/main.swf": "swf",
+    "iframe/doom/index.html": "doom",
+    "iframe/inside-the-firewall/index.html": "firewall",
+    "dos/doom/doom.jsdos": "jsdos",
+  });
 }
 
 async function addGeneratedRuntime(root: string): Promise<void> {
-	await writeFiles(root, {
-		"js/ruffle.js": "ruffle",
-		"js/core.ruffle.abc123.js": "core",
-		"js/abc123.wasm": "wasm",
-		"sw.js": 's("workbox-f9030226", import.meta.url)',
-		"workbox-f9030226.js": "workbox",
-	});
+  await writeFiles(root, {
+    "js/ruffle.js": "ruffle",
+    "js/core.ruffle.abc123.js": "core",
+    "js/abc123.wasm": "wasm",
+    "sw.js": 's("workbox-f9030226", import.meta.url)',
+    "workbox-f9030226.js": "workbox",
+  });
 }
 
 async function fileSnapshot(root: string): Promise<Map<string, Uint8Array>> {
-	const snapshot = new Map<string, Uint8Array>();
-	async function visit(directory: string): Promise<void> {
-		for (const entry of await readdir(directory, { withFileTypes: true })) {
-			const path = join(directory, entry.name);
-			if (entry.isDirectory()) await visit(path);
-			else if (entry.isFile()) snapshot.set(relative(root, path), await readFile(path));
-		}
-	}
-	await visit(root);
-	return snapshot;
+  const snapshot = new Map<string, Uint8Array>();
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile())
+        snapshot.set(relative(root, path), await readFile(path));
+    }
+  }
+  await visit(root);
+  return snapshot;
 }
 
 describe("Ruffle release handling", () => {
-	test("accepts complete pinned metadata", async () => {
-		const root = await makeTemporaryDirectory();
-		const metadata = join(root, "ruffle.json");
-		await writeFile(
-			metadata,
-			JSON.stringify({
-				tag: "v0.4.1",
-				asset: "ruffle-0.4.1-web-selfhosted.zip",
-				sha256: "a".repeat(64),
-			}),
-		);
-		expect((await loadRuffleRelease(metadata)).tag).toBe("v0.4.1");
-	});
+  test("accepts complete pinned metadata", async () => {
+    const root = await makeTemporaryDirectory();
+    const metadata = join(root, "ruffle.json");
+    await writeFile(
+      metadata,
+      JSON.stringify({
+        tag: "v0.4.1",
+        asset: "ruffle-0.4.1-web-selfhosted.zip",
+        sha256: "a".repeat(64),
+      }),
+    );
+    expect((await loadRuffleRelease(metadata)).tag).toBe("v0.4.1");
+  });
 
-	test("rejects invalid metadata", async () => {
-		const root = await makeTemporaryDirectory();
-		const metadata = join(root, "ruffle.json");
-		await writeFile(metadata, '{"tag":"nightly"}');
-		expect(loadRuffleRelease(metadata)).rejects.toThrow(
-			"tag, asset, and sha256",
-		);
-	});
+  test("rejects invalid metadata", async () => {
+    const root = await makeTemporaryDirectory();
+    const metadata = join(root, "ruffle.json");
+    await writeFile(metadata, '{"tag":"nightly"}');
+    expect(loadRuffleRelease(metadata)).rejects.toThrow(
+      "tag, asset, and sha256",
+    );
+  });
 
-	test("verifies checksum and extracts only root runtime files", async () => {
-		const root = await makeTemporaryDirectory();
-		const archive = makeRuffleArchive();
-		const release = {
-			tag: "v0.4.1",
-			asset: "ruffle-0.4.1-web-selfhosted.zip",
-			sha256: createHash("sha256").update(archive).digest("hex"),
-		};
-		const fetcher = async () => archiveResponse(archive);
-		await downloadRuffle(join(root, "js"), release, fetcher);
+  test("verifies checksum and extracts only root runtime files", async () => {
+    const root = await makeTemporaryDirectory();
+    const archive = makeRuffleArchive();
+    const release = {
+      tag: "v0.4.1",
+      asset: "ruffle-0.4.1-web-selfhosted.zip",
+      sha256: createHash("sha256").update(archive).digest("hex"),
+    };
+    const fetcher = async () => archiveResponse(archive);
+    await downloadRuffle(join(root, "js"), release, fetcher);
 
-		expect(await Bun.file(join(root, "js", "ruffle.js")).exists()).toBeTrue();
-		expect(await Bun.file(join(root, "js", "abc123.wasm")).exists()).toBeTrue();
-		expect(await Bun.file(join(root, "js", "ignored.js")).exists()).toBeFalse();
-	});
+    expect(await Bun.file(join(root, "js", "ruffle.js")).exists()).toBeTrue();
+    expect(await Bun.file(join(root, "js", "abc123.wasm")).exists()).toBeTrue();
+    expect(await Bun.file(join(root, "js", "ignored.js")).exists()).toBeFalse();
+  });
 
-	test("rejects checksum mismatches and incomplete runtimes", async () => {
-		const root = await makeTemporaryDirectory();
-		const completeArchive = makeRuffleArchive();
-		const incompleteArchive = makeRuffleArchive({ includeWasm: false });
-		const baseRelease = {
-			tag: "v0.4.1",
-			asset: "ruffle-0.4.1-web-selfhosted.zip",
-		};
-		await expect(
-			downloadRuffle(
-				join(root, "mismatch"),
-				{ ...baseRelease, sha256: "0".repeat(64) },
-				async () => archiveResponse(completeArchive),
-			),
-		).rejects.toThrow("checksum mismatch");
-		await expect(
-			downloadRuffle(
-				join(root, "incomplete"),
-				{
-					...baseRelease,
-					sha256: createHash("sha256").update(incompleteArchive).digest("hex"),
-				},
-				async () => archiveResponse(incompleteArchive),
-			),
-		).rejects.toThrow("missing required runtime");
-	});
+  test("rejects checksum mismatches and incomplete runtimes", async () => {
+    const root = await makeTemporaryDirectory();
+    const completeArchive = makeRuffleArchive();
+    const incompleteArchive = makeRuffleArchive({ includeWasm: false });
+    const baseRelease = {
+      tag: "v0.4.1",
+      asset: "ruffle-0.4.1-web-selfhosted.zip",
+    };
+    await expect(
+      downloadRuffle(
+        join(root, "mismatch"),
+        { ...baseRelease, sha256: "0".repeat(64) },
+        async () => archiveResponse(completeArchive),
+      ),
+    ).rejects.toThrow("checksum mismatch");
+    await expect(
+      downloadRuffle(
+        join(root, "incomplete"),
+        {
+          ...baseRelease,
+          sha256: createHash("sha256").update(incompleteArchive).digest("hex"),
+        },
+        async () => archiveResponse(incompleteArchive),
+      ),
+    ).rejects.toThrow("missing required runtime");
+  });
 });
 
 describe("build metadata", () => {
-	test("uses the commit date and short revision", () => {
-		const outputs = ["2026-07-28", "abcdef123456"];
-		const git = () => outputs.shift() ?? "";
-		expect(getDeploymentVersion("main", "/tmp", git)).toBe("26.07.28-abcdef1");
-	});
+  test("uses the commit date and short revision", () => {
+    const outputs = ["2026-07-28", "abcdef123456"];
+    const git = () => outputs.shift() ?? "";
+    expect(getDeploymentVersion("main", "/tmp", git)).toBe("26.07.28-abcdef1");
+  });
 
-	test("rejects invalid git output", () => {
-		const outputs = ["not-a-date", "abcdef1"];
-		const git = () => outputs.shift() ?? "";
-		expect(() => getDeploymentVersion("HEAD", "/tmp", git)).toThrow(
-			"invalid commit date",
-		);
-	});
+  test("rejects invalid git output", () => {
+    const outputs = ["not-a-date", "abcdef1"];
+    const git = () => outputs.shift() ?? "";
+    expect(() => getDeploymentVersion("HEAD", "/tmp", git)).toThrow(
+      "invalid commit date",
+    );
+  });
 
-	test("versions main before hashing and writes matching manifests", async () => {
-		const root = await makeTemporaryDirectory();
-		await makeSource(root);
-		await addGeneratedRuntime(root);
-		const paths = new BuildPaths(root);
+  test("versions main before hashing and writes matching manifests", async () => {
+    const root = await makeTemporaryDirectory();
+    await makeSource(root);
+    await addGeneratedRuntime(root);
+    const paths = new BuildPaths(root);
 
-		await updateHtml(paths, "26.07.28-abcdef1");
-		await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
-		await writeVersionMetadata(paths, "26.07.28-abcdef1");
+    await updateHtml(paths, "26.07.28-abcdef1");
+    await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
+    await writeVersionMetadata(paths, "26.07.28-abcdef1");
 
-		const main = await readFile(paths.mainJs, "utf8");
-		const html = await readFile(paths.html, "utf8");
-		expect(main).toContain('const APP_VERSION = "26.07.28-abcdef1";');
-		expect(html).toContain(`js/main.js?v=${await getShortHash(paths.mainJs)}"`);
-		expect(html).toContain(
-			`js/game-installer.js?v=${await getShortHash(join(paths.js, "game-installer.js"))}"`,
-		);
-		expect(html).toContain(
-			`js/game-library.js?v=${await getShortHash(join(paths.js, "game-library.js"))}"`,
-		);
-		expect(html).toContain(
-			`js/file-operations.js?v=${await getShortHash(join(paths.js, "file-operations.js"))}"`,
-		);
-		expect(PRECACHE_FILE_SUFFIXES.has(".ttf")).toBeTrue();
+    const main = await readFile(paths.mainJs, "utf8");
+    const html = await readFile(paths.html, "utf8");
+    expect(main).toContain('const APP_VERSION = "26.07.28-abcdef1";');
+    expect(html).toContain(`js/main.js?v=${await getShortHash(paths.mainJs)}"`);
+    expect(html).toContain(
+      `js/game-installer.js?v=${await getShortHash(join(paths.js, "game-installer.js"))}"`,
+    );
+    expect(html).toContain(
+      `js/game-library.js?v=${await getShortHash(join(paths.js, "game-library.js"))}"`,
+    );
+    expect(html).toContain(
+      `js/file-operations.js?v=${await getShortHash(join(paths.js, "file-operations.js"))}"`,
+    );
+    expect(PRECACHE_FILE_SUFFIXES.has(".ttf")).toBeTrue();
 
-		const metadata = JSON.parse(await readFile(paths.versionJson, "utf8"));
-		const manifest = JSON.parse(await readFile(paths.offlineGamesJson, "utf8"));
-		expect(metadata.offlineBytes).toBeGreaterThan(0);
-		expect(metadata.bundledGameBytes).toBeGreaterThan(0);
-		expect(manifest.version).toBe("26.07.28-abcdef1");
-		expect(manifest.games["bike-mania"].type).toBe("swf");
-		expect(manifest.games.doom.type).toBe("iframe");
-		expect(manifest.games.doom.files.map(({ url }: { url: string }) => url)).toEqual([
-			"dos/doom/doom.jsdos",
-			"iframe/doom/index.html",
-		]);
-		expect(manifest.runtime.files.length).toBeGreaterThan(0);
-		expect(metadata.bundledGameBytes).toBe(
-			manifest.runtime.bytes +
-				Object.values(manifest.games).reduce(
-					(total: number, game: any) => total + game.bytes,
-					0,
-				),
-		);
-		expect({
-			revision: metadata.revision,
-			version: metadata.version,
-		}).toEqual({
-			revision: "abcdef1",
-			version: "26.07.28-abcdef1",
-		});
-	});
+    const metadata = JSON.parse(await readFile(paths.versionJson, "utf8"));
+    const manifest = JSON.parse(await readFile(paths.offlineGamesJson, "utf8"));
+    expect(metadata.offlineBytes).toBeGreaterThan(0);
+    expect(metadata.bundledGameBytes).toBeGreaterThan(0);
+    expect(manifest.version).toBe("26.07.28-abcdef1");
+    expect(manifest.games["bike-mania"].type).toBe("swf");
+    expect(manifest.games.doom.type).toBe("iframe");
+    expect(
+      manifest.games.doom.files.map(({ url }: { url: string }) => url),
+    ).toEqual(["dos/doom/doom.jsdos", "iframe/doom/index.html"]);
+    expect(manifest.runtime.files.length).toBeGreaterThan(0);
+    expect(metadata.bundledGameBytes).toBe(
+      manifest.runtime.bytes +
+        Object.values(manifest.games).reduce(
+          (total: number, game: any) => total + game.bytes,
+          0,
+        ),
+    );
+    expect({
+      revision: metadata.revision,
+      version: metadata.version,
+    }).toEqual({
+      revision: "abcdef1",
+      version: "26.07.28-abcdef1",
+    });
+  });
 
-	test("fails when an asset reference is missing", async () => {
-		const root = await makeTemporaryDirectory();
-		await makeSource(root);
-		await addGeneratedRuntime(root);
-		const html = join(root, "index.html");
-		await writeFile(
-			html,
-			(await readFile(html, "utf8")).replace(
-				'<script src="js/dialogs.js?v=old"></script>',
-				"",
-			),
-		);
-		expect(updateHtml(new BuildPaths(root), "26.07.28-abcdef1")).rejects.toThrow(
-			"Could not update asset reference",
-		);
-	});
+  test("fails when an asset reference is missing", async () => {
+    const root = await makeTemporaryDirectory();
+    await makeSource(root);
+    await addGeneratedRuntime(root);
+    const html = join(root, "index.html");
+    await writeFile(
+      html,
+      (await readFile(html, "utf8")).replace(
+        '<script src="js/dialogs.js?v=old"></script>',
+        "",
+      ),
+    );
+    expect(
+      updateHtml(new BuildPaths(root), "26.07.28-abcdef1"),
+    ).rejects.toThrow("Could not update asset reference");
+  });
 });
 
 describe("Workbox and artifact validation", () => {
-	test("accepts a generated worker with its runtime", async () => {
-		const root = await makeTemporaryDirectory();
-		const generator = async () => {
-			await addGeneratedRuntime(root);
-			return { count: 1, size: 1, warnings: [], filePaths: [] };
-		};
-		await generateServiceWorker(root, generator as any);
-		expect(await Bun.file(join(root, "workbox-f9030226.js")).exists()).toBeTrue();
-	});
+  test("accepts a generated worker with its runtime", async () => {
+    const root = await makeTemporaryDirectory();
+    const generator = async () => {
+      await addGeneratedRuntime(root);
+      return { count: 1, size: 1, warnings: [], filePaths: [] };
+    };
+    await generateServiceWorker(root, generator as any);
+    expect(
+      await Bun.file(join(root, "workbox-f9030226.js")).exists(),
+    ).toBeTrue();
+  });
 
-	test("rejects a generated worker with a missing runtime", async () => {
-		const root = await makeTemporaryDirectory();
-		const generator = async () => {
-			await writeFile(
-				join(root, "sw.js"),
-				's("workbox-deadbeef", import.meta.url)',
-			);
-			return { count: 1, size: 1, warnings: [], filePaths: [] };
-		};
-		expect(generateServiceWorker(root, generator as any)).rejects.toThrow(
-			"missing Workbox runtime",
-		);
-	});
+  test("rejects a generated worker with a missing runtime", async () => {
+    const root = await makeTemporaryDirectory();
+    const generator = async () => {
+      await writeFile(
+        join(root, "sw.js"),
+        's("workbox-deadbeef", import.meta.url)',
+      );
+      return { count: 1, size: 1, warnings: [], filePaths: [] };
+    };
+    expect(generateServiceWorker(root, generator as any)).rejects.toThrow(
+      "missing Workbox runtime",
+    );
+  });
 
-	test("accepts a complete artifact and rejects a missing representative game", async () => {
-		const root = await makeTemporaryDirectory();
-		await makeSource(root);
-		await addGeneratedRuntime(root);
-		const paths = new BuildPaths(root);
-		await updateHtml(paths, "26.07.28-abcdef1");
-		await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
-		await writeVersionMetadata(paths, "26.07.28-abcdef1");
-		await validateOutput(root);
+  test("accepts a complete artifact and rejects a missing representative game", async () => {
+    const root = await makeTemporaryDirectory();
+    await makeSource(root);
+    await addGeneratedRuntime(root);
+    const paths = new BuildPaths(root);
+    await updateHtml(paths, "26.07.28-abcdef1");
+    await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
+    await writeVersionMetadata(paths, "26.07.28-abcdef1");
+    await validateOutput(root);
 
-		await unlink(join(root, "swf", "bike-mania", "main.swf"));
-		expect(validateOutput(root)).rejects.toThrow("missing required files");
-	});
+    await unlink(join(root, "swf", "bike-mania", "main.swf"));
+    expect(validateOutput(root)).rejects.toThrow("missing required files");
+  });
 });
 
 describe("atomic build", () => {
-	test("does not mutate source and replaces old output", async () => {
-		const project = await makeTemporaryDirectory();
-		const source = join(project, "site");
-		const output = join(project, "dist");
-		await makeSource(source);
-		const originalFiles = await fileSnapshot(source);
-		await mkdir(output);
-		await writeFile(join(output, "stale.txt"), "stale");
+  test("does not mutate source and replaces old output", async () => {
+    const project = await makeTemporaryDirectory();
+    const source = join(project, "site");
+    const output = join(project, "dist");
+    await makeSource(source);
+    const originalFiles = await fileSnapshot(source);
+    await mkdir(output);
+    await writeFile(join(output, "stale.txt"), "stale");
 
-		await build({
-			sourceDir: source,
-			outputDir: output,
-			version: "26.07.28-abcdef1",
-			download: async (jsDir) => addGeneratedRuntime(join(jsDir, "..")),
-			generate: addGeneratedRuntime,
-		});
+    await build({
+      sourceDir: source,
+      outputDir: output,
+      version: "26.07.28-abcdef1",
+      download: async (jsDir) => addGeneratedRuntime(join(jsDir, "..")),
+      generate: addGeneratedRuntime,
+    });
 
-		const currentFiles = await fileSnapshot(source);
-		expect([...currentFiles.keys()]).toEqual([...originalFiles.keys()]);
-		for (const [path, bytes] of originalFiles) {
-			expect(currentFiles.get(path)).toEqual(bytes);
-		}
-		expect(await Bun.file(join(output, "stale.txt")).exists()).toBeFalse();
-		expect(await Bun.file(join(output, "sw.js")).exists()).toBeTrue();
-		const metadata = JSON.parse(await readFile(join(output, "version.json"), "utf8"));
-		expect(metadata.offlineBytes).toBeGreaterThan(0);
-		expect(metadata.bundledGameBytes).toBeGreaterThan(0);
-		expect(metadata.revision).toBe("abcdef1");
-		expect(metadata.version).toBe("26.07.28-abcdef1");
-	});
+    const currentFiles = await fileSnapshot(source);
+    expect([...currentFiles.keys()]).toEqual([...originalFiles.keys()]);
+    for (const [path, bytes] of originalFiles) {
+      expect(currentFiles.get(path)).toEqual(bytes);
+    }
+    expect(await Bun.file(join(output, "stale.txt")).exists()).toBeFalse();
+    expect(await Bun.file(join(output, "sw.js")).exists()).toBeTrue();
+    const metadata = JSON.parse(
+      await readFile(join(output, "version.json"), "utf8"),
+    );
+    expect(metadata.offlineBytes).toBeGreaterThan(0);
+    expect(metadata.bundledGameBytes).toBeGreaterThan(0);
+    expect(metadata.revision).toBe("abcdef1");
+    expect(metadata.version).toBe("26.07.28-abcdef1");
+  });
 
-	test("preserves previous output after a failed build", async () => {
-		const project = await makeTemporaryDirectory();
-		const source = join(project, "site");
-		const output = join(project, "dist");
-		await makeSource(source);
-		await mkdir(output);
-		await writeFile(join(output, "previous.txt"), "keep");
+  test("preserves previous output after a failed build", async () => {
+    const project = await makeTemporaryDirectory();
+    const source = join(project, "site");
+    const output = join(project, "dist");
+    await makeSource(source);
+    await mkdir(output);
+    await writeFile(join(output, "previous.txt"), "keep");
 
-		await expect(
-			build({
-				sourceDir: source,
-				outputDir: output,
-				version: "26.07.28-abcdef1",
-				download: async () => {
-					throw new Error("network failed");
-				},
-			}),
-		).rejects.toThrow("network failed");
-		expect(await readFile(join(output, "previous.txt"), "utf8")).toBe("keep");
-	});
+    await expect(
+      build({
+        sourceDir: source,
+        outputDir: output,
+        version: "26.07.28-abcdef1",
+        download: async () => {
+          throw new Error("network failed");
+        },
+      }),
+    ).rejects.toThrow("network failed");
+    expect(await readFile(join(output, "previous.txt"), "utf8")).toBe("keep");
+  });
 
-	test("rejects output inside the source tree", async () => {
-		const project = await makeTemporaryDirectory();
-		const source = join(project, "site");
-		await makeSource(source);
-		expect(
-			build({
-				sourceDir: source,
-				outputDir: join(source, "dist"),
-				version: "26.07.28-abcdef1",
-			}),
-		).rejects.toThrow("outside");
-	});
+  test("rejects output inside the source tree", async () => {
+    const project = await makeTemporaryDirectory();
+    const source = join(project, "site");
+    await makeSource(source);
+    expect(
+      build({
+        sourceDir: source,
+        outputDir: join(source, "dist"),
+        version: "26.07.28-abcdef1",
+      }),
+    ).rejects.toThrow("outside");
+  });
 });

--- a/tests/dev-server.test.ts
+++ b/tests/dev-server.test.ts
@@ -4,141 +4,138 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
-	DEV_BUILD_STATE,
-	computeSourceFingerprint,
-	createRequestHandler,
-	ensureDevelopmentBuild,
+  DEV_BUILD_STATE,
+  computeSourceFingerprint,
+  createRequestHandler,
+  ensureDevelopmentBuild,
 } from "../tools/dev-server";
 
 const temporaryDirectories: string[] = [];
 
 async function makeTemporaryDirectory(): Promise<string> {
-	const path = await mkdtemp(join(tmpdir(), "astro-flash-dev-server-test-"));
-	temporaryDirectories.push(path);
-	return path;
+  const path = await mkdtemp(join(tmpdir(), "astro-flash-dev-server-test-"));
+  temporaryDirectories.push(path);
+  return path;
 }
 
 afterEach(async () => {
-	await Promise.all(
-		temporaryDirectories.splice(0).map((path) =>
-			rm(path, { force: true, recursive: true }),
-		),
-	);
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { force: true, recursive: true })),
+  );
 });
 
 describe("development build synchronization", () => {
-	test("fingerprints build inputs but ignores unrelated files", async () => {
-		const project = await makeTemporaryDirectory();
-		await mkdir(join(project, "site"), { recursive: true });
-		await mkdir(join(project, "tools"), { recursive: true });
-		await writeFile(join(project, "site", "index.html"), "one");
-		await writeFile(join(project, "tools", "deploy.ts"), "build");
-		await writeFile(join(project, "tools", "ruffle-release.json"), "{}");
-		await writeFile(join(project, "workbox-config.ts"), "config");
-		await writeFile(join(project, "package.json"), "{}");
-		await writeFile(join(project, "bun.lock"), "lock");
-		Bun.spawnSync(["git", "init"], { cwd: project });
-		Bun.spawnSync(["git", "add", "."], { cwd: project });
-		Bun.spawnSync(
-			[
-				"git",
-				"-c",
-				"user.name=Test",
-				"-c",
-				"user.email=test@example.com",
-				"commit",
-				"-m",
-				"fixture",
-			],
-			{ cwd: project },
-		);
+  test("fingerprints build inputs but ignores unrelated files", async () => {
+    const project = await makeTemporaryDirectory();
+    await mkdir(join(project, "site"), { recursive: true });
+    await mkdir(join(project, "tools"), { recursive: true });
+    await writeFile(join(project, "site", "index.html"), "one");
+    await writeFile(join(project, "tools", "deploy.ts"), "build");
+    await writeFile(join(project, "tools", "ruffle-release.json"), "{}");
+    await writeFile(join(project, "workbox-config.ts"), "config");
+    await writeFile(join(project, "package.json"), "{}");
+    await writeFile(join(project, "bun.lock"), "lock");
+    Bun.spawnSync(["git", "init"], { cwd: project });
+    Bun.spawnSync(["git", "add", "."], { cwd: project });
+    Bun.spawnSync(
+      [
+        "git",
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "fixture",
+      ],
+      { cwd: project },
+    );
 
-		const initial = await computeSourceFingerprint(project);
-		await writeFile(join(project, "README.md"), "ignored");
-		expect(await computeSourceFingerprint(project)).toBe(initial);
-		await writeFile(join(project, "site", "index.html"), "two");
-		expect(await computeSourceFingerprint(project)).not.toBe(initial);
-	});
+    const initial = await computeSourceFingerprint(project);
+    await writeFile(join(project, "README.md"), "ignored");
+    expect(await computeSourceFingerprint(project)).toBe(initial);
+    await writeFile(join(project, "site", "index.html"), "two");
+    expect(await computeSourceFingerprint(project)).not.toBe(initial);
+  });
 
-	test("skips an unchanged build and reuses the pinned Ruffle runtime", async () => {
-		const root = await makeTemporaryDirectory();
-		const output = join(root, "dist");
-		let sourceFingerprint = "first";
-		let builds = 0;
-		const builder = async ({ outputDir }: { outputDir?: string }) => {
-			builds += 1;
-			await mkdir(join(outputDir as string, "js"), { recursive: true });
-			await writeFile(join(outputDir as string, "index.html"), "built");
-			await writeFile(join(outputDir as string, "js", "ruffle.js"), "ruffle");
-			await writeFile(
-				join(outputDir as string, "js", "core.ruffle.abc.js"),
-				"core",
-			);
-			await writeFile(join(outputDir as string, "js", "abc.wasm"), "wasm");
-		};
-		const options = {
-			outputDir: output,
-			fingerprint: async () => sourceFingerprint,
-			releaseKey: async () => "v1:asset:checksum",
-			builder,
-		};
+  test("skips an unchanged build and reuses the pinned Ruffle runtime", async () => {
+    const root = await makeTemporaryDirectory();
+    const output = join(root, "dist");
+    let sourceFingerprint = "first";
+    let builds = 0;
+    const builder = async ({ outputDir }: { outputDir?: string }) => {
+      builds += 1;
+      await mkdir(join(outputDir as string, "js"), { recursive: true });
+      await writeFile(join(outputDir as string, "index.html"), "built");
+      await writeFile(join(outputDir as string, "js", "ruffle.js"), "ruffle");
+      await writeFile(
+        join(outputDir as string, "js", "core.ruffle.abc.js"),
+        "core",
+      );
+      await writeFile(join(outputDir as string, "js", "abc.wasm"), "wasm");
+    };
+    const options = {
+      outputDir: output,
+      fingerprint: async () => sourceFingerprint,
+      releaseKey: async () => "v1:asset:checksum",
+      builder,
+    };
 
-		expect(await ensureDevelopmentBuild(options)).toEqual({
-			rebuilt: true,
-			reusedRuffle: false,
-		});
-		expect(await ensureDevelopmentBuild(options)).toEqual({
-			rebuilt: false,
-			reusedRuffle: false,
-		});
-		sourceFingerprint = "second";
-		expect(await ensureDevelopmentBuild(options)).toEqual({
-			rebuilt: true,
-			reusedRuffle: true,
-		});
-		expect(builds).toBe(2);
-		const state = JSON.parse(
-			await readFile(join(output, DEV_BUILD_STATE), "utf8"),
-		);
-		expect(state.fingerprint).toBe("second");
-	});
+    expect(await ensureDevelopmentBuild(options)).toEqual({
+      rebuilt: true,
+      reusedRuffle: false,
+    });
+    expect(await ensureDevelopmentBuild(options)).toEqual({
+      rebuilt: false,
+      reusedRuffle: false,
+    });
+    sourceFingerprint = "second";
+    expect(await ensureDevelopmentBuild(options)).toEqual({
+      rebuilt: true,
+      reusedRuffle: true,
+    });
+    expect(builds).toBe(2);
+    const state = JSON.parse(
+      await readFile(join(output, DEV_BUILD_STATE), "utf8"),
+    );
+    expect(state.fingerprint).toBe("second");
+  });
 });
 
 describe("Bun request handler", () => {
-	test("serves static files without caching and blocks traversal", async () => {
-		const root = await makeTemporaryDirectory();
-		await writeFile(join(root, "index.html"), "<h1>Astro Flash</h1>");
-		const handler = createRequestHandler(root);
+  test("serves static files without caching and blocks traversal", async () => {
+    const root = await makeTemporaryDirectory();
+    await writeFile(join(root, "index.html"), "<h1>Astro Flash</h1>");
+    const handler = createRequestHandler(root);
 
-		const response = await handler(new Request("http://localhost/"));
-		expect(response.status).toBe(200);
-		expect(await response.text()).toContain("Astro Flash");
-		expect(response.headers.get("cache-control")).toContain("no-store");
+    const response = await handler(new Request("http://localhost/"));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("Astro Flash");
+    expect(response.headers.get("cache-control")).toContain("no-store");
 
-		const traversal = await handler(
-			new Request("http://localhost/%2e%2e%2fsecret"),
-		);
-		expect(traversal.status).toBe(404);
-	});
+    const traversal = await handler(
+      new Request("http://localhost/%2e%2e%2fsecret"),
+    );
+    expect(traversal.status).toBe(404);
+  });
 
-	test("routes the local catalog API through the shared handler", async () => {
-		const root = await makeTemporaryDirectory();
-		await writeFile(join(root, "index.html"), "site");
-		const uuid = "a2fb012a-b14c-6921-b688-403571e42bb0";
-		const html = `
+  test("routes the local catalog API through the shared handler", async () => {
+    const root = await makeTemporaryDirectory();
+    await writeFile(join(root, "index.html"), "site");
+    const uuid = "a2fb012a-b14c-6921-b688-403571e42bb0";
+    const html = `
 			<div class="fp-search-result">
 				<a href="/view?id=${uuid}"></a>
 				<a class="fp-search-result-title" href="/view?id=${uuid}">Bike Mania</a>
 				<div class="fp-search-result-info">Flash game - Racing</div>
 			</div>`;
-		const handler = createRequestHandler(
-			root,
-			async () => new Response(html),
-		);
-		const response = await handler(
-			new Request("http://localhost/api/games?q=bike"),
-		);
-		expect(response.status).toBe(200);
-		expect((await response.json()).games[0].title).toBe("Bike Mania");
-	});
+    const handler = createRequestHandler(root, async () => new Response(html));
+    const response = await handler(
+      new Request("http://localhost/api/games?q=bike"),
+    );
+    expect(response.status).toBe(200);
+    expect((await response.json()).games[0].title).toBe("Bike Mania");
+  });
 });

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -447,7 +447,7 @@ test("explorer matches XP task pane toolbar and drive groups", () => {
     'src="assets/xp/ms.png"',
   );
   contains(
-    css,
+    compact(css),
     ".explorer-toolbar-separator",
     ".explorer-content:not(.folders-visible) .explorer-tree-section",
     ".explorer-content.folders-visible .explorer-sidebar > section:not(.explorer-tree-section)",
@@ -831,7 +831,7 @@ test("taskbar attention and fixed lock state are explicit", () => {
     ".task-button.needs-attention",
     ".taskbar-overflow-item.needs-attention",
   );
-  contains(html, 'data-taskbar-action="lock" disabled');
+  contains(compact(html), 'data-taskbar-action="lock" disabled');
 });
 test("taskbar supports window and taskbar context menus", () => {
   contains(

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -1,16 +1,24 @@
 import { createHash } from "node:crypto";
 import {
-	cp,
-	mkdir,
-	mkdtemp,
-	readFile,
-	readdir,
-	rename,
-	rm,
-	stat,
-	writeFile,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
 } from "node:fs/promises";
-import { dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { unzipSync } from "fflate";
@@ -20,716 +28,781 @@ import workboxConfig from "../workbox-config";
 const PROJECT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 export const SOURCE_DIR = join(PROJECT_DIR, "site");
 export const DEFAULT_OUTPUT_DIR = join(PROJECT_DIR, "dist");
-export const RUFFLE_RELEASE_PATH = join(PROJECT_DIR, "tools", "ruffle-release.json");
-const RUFFLE_DOWNLOAD_ROOT = "https://github.com/ruffle-rs/ruffle/releases/download";
+export const RUFFLE_RELEASE_PATH = join(
+  PROJECT_DIR,
+  "tools",
+  "ruffle-release.json",
+);
+const RUFFLE_DOWNLOAD_ROOT =
+  "https://github.com/ruffle-rs/ruffle/releases/download";
 const RUFFLE_FILE_SUFFIXES = [".js", ".js.map", ".wasm"];
 export const FFLATE_VERSION = "0.8.3";
 const FFLATE_SOURCE = join(PROJECT_DIR, "node_modules", "fflate");
 export const PRECACHE_FILE_SUFFIXES = new Set([
-	".ttf",
-	".woff",
-	".woff2",
-	".css",
-	".ico",
-	".svg",
-	".mp3",
-	".wav",
-	".png",
-	".jpg",
-	".jpeg",
-	".cur",
-	".json",
-	".html",
-	".js",
-	".mjs",
-	".wasm",
-	".swf",
-	".jsdos",
-	".xml",
-	".phtml",
+  ".ttf",
+  ".woff",
+  ".woff2",
+  ".css",
+  ".ico",
+  ".svg",
+  ".mp3",
+  ".wav",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".cur",
+  ".json",
+  ".html",
+  ".js",
+  ".mjs",
+  ".wasm",
+  ".swf",
+  ".jsdos",
+  ".xml",
+  ".phtml",
 ]);
 const APP_VERSION_PATTERN = /const APP_VERSION = "[^"]+";/g;
 
-type Fetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+type Fetcher = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
 type WorkboxGenerator = typeof generateSW;
 
 export interface RuffleRelease {
-	tag: string;
-	asset: string;
-	sha256: string;
+  tag: string;
+  asset: string;
+  sha256: string;
 }
 
 interface OfflineFile {
-	bytes: number;
-	url: string;
+  bytes: number;
+  url: string;
 }
 
 interface OfflineGame {
-	bytes: number;
-	files: OfflineFile[];
-	revision: string;
-	type: "iframe" | "swf";
+  bytes: number;
+  files: OfflineFile[];
+  revision: string;
+  type: "iframe" | "swf";
 }
 
 interface OfflineManifest {
-	games: Record<string, OfflineGame>;
-	runtime: {
-		bytes: number;
-		files: OfflineFile[];
-		revision: string;
-	};
-	version: string;
+  games: Record<string, OfflineGame>;
+  runtime: {
+    bytes: number;
+    files: OfflineFile[];
+    revision: string;
+  };
+  version: string;
 }
 
 export class BuildPaths {
-	readonly root: string;
+  readonly root: string;
 
-	constructor(root: string) {
-		this.root = root;
-	}
+  constructor(root: string) {
+    this.root = root;
+  }
 
-	get js() {
-		return join(this.root, "js");
-	}
+  get js() {
+    return join(this.root, "js");
+  }
 
-	get css() {
-		return join(this.root, "css");
-	}
+  get css() {
+    return join(this.root, "css");
+  }
 
-	get html() {
-		return join(this.root, "index.html");
-	}
+  get html() {
+    return join(this.root, "index.html");
+  }
 
-	get mainJs() {
-		return join(this.js, "main.js");
-	}
+  get mainJs() {
+    return join(this.js, "main.js");
+  }
 
-	get versionJson() {
-		return join(this.root, "version.json");
-	}
+  get versionJson() {
+    return join(this.root, "version.json");
+  }
 
-	get offlineGamesJson() {
-		return join(this.root, "offline-games.json");
-	}
+  get offlineGamesJson() {
+    return join(this.root, "offline-games.json");
+  }
 
-	get fflateJs() {
-		return join(this.root, "vendor", "fflate", FFLATE_VERSION, "index.js");
-	}
+  get fflateJs() {
+    return join(this.root, "vendor", "fflate", FFLATE_VERSION, "index.js");
+  }
 
-	get assetPaths(): Record<string, string> {
-		return {
-			ruffle: join(this.js, "ruffle.js"),
-			fflate: this.fflateJs,
-			gamesJs: join(this.js, "games.js"),
-			gameInstallerJs: join(this.js, "game-installer.js"),
-			gameLibraryJs: join(this.js, "game-library.js"),
-			filesystemJs: join(this.js, "filesystem.js"),
-			fileOperationsJs: join(this.js, "file-operations.js"),
-			dialogsJs: join(this.js, "dialogs.js"),
-			offlineJs: join(this.js, "offline.js"),
-			mainJs: this.mainJs,
-			mainCss: join(this.css, "main.css"),
-		};
-	}
+  get assetPaths(): Record<string, string> {
+    return {
+      ruffle: join(this.js, "ruffle.js"),
+      fflate: this.fflateJs,
+      gamesJs: join(this.js, "games.js"),
+      gameInstallerJs: join(this.js, "game-installer.js"),
+      gameLibraryJs: join(this.js, "game-library.js"),
+      filesystemJs: join(this.js, "filesystem.js"),
+      fileOperationsJs: join(this.js, "file-operations.js"),
+      dialogsJs: join(this.js, "dialogs.js"),
+      offlineJs: join(this.js, "offline.js"),
+      mainJs: this.mainJs,
+      mainCss: join(this.css, "main.css"),
+    };
+  }
 }
 
 async function isFile(path: string): Promise<boolean> {
-	try {
-		return (await stat(path)).isFile();
-	} catch {
-		return false;
-	}
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
 }
 
 async function isDirectory(path: string): Promise<boolean> {
-	try {
-		return (await stat(path)).isDirectory();
-	} catch {
-		return false;
-	}
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 async function walkFiles(root: string): Promise<string[]> {
-	const entries = await readdir(root, { withFileTypes: true });
-	const files: string[] = [];
-	for (const entry of entries) {
-		const path = join(root, entry.name);
-		if (entry.isDirectory()) {
-			files.push(...(await walkFiles(path)));
-		} else if (entry.isFile()) {
-			files.push(path);
-		}
-	}
-	return files;
+  const entries = await readdir(root, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(path)));
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
 }
 
 async function replaceExactlyOnce(
-	content: string,
-	pattern: RegExp,
-	replacement: string,
-	error: string,
+  content: string,
+  pattern: RegExp,
+  replacement: string,
+  error: string,
 ): Promise<string> {
-	const matches = content.match(pattern);
-	if (matches?.length !== 1) {
-		throw new Error(error);
-	}
-	return content.replace(pattern, replacement);
+  const matches = content.match(pattern);
+  if (matches?.length !== 1) {
+    throw new Error(error);
+  }
+  return content.replace(pattern, replacement);
 }
 
 export async function installFflate(
-	outputDir: string,
-	sourceDir = FFLATE_SOURCE,
+  outputDir: string,
+  sourceDir = FFLATE_SOURCE,
 ): Promise<void> {
-	const sourceJavaScript = join(sourceDir, "umd", "index.js");
-	const sourceLicense = join(sourceDir, "LICENSE");
-	if (!(await isFile(sourceJavaScript)) || !(await isFile(sourceLicense))) {
-		throw new Error("fflate is not installed; run `bun install --frozen-lockfile`");
-	}
-	const destination = join(outputDir, "vendor", "fflate", FFLATE_VERSION);
-	await mkdir(destination, { recursive: true });
-	await cp(sourceJavaScript, join(destination, "index.js"), { preserveTimestamps: true });
-	await cp(sourceLicense, join(destination, "LICENSE"), { preserveTimestamps: true });
+  const sourceJavaScript = join(sourceDir, "umd", "index.js");
+  const sourceLicense = join(sourceDir, "LICENSE");
+  if (!(await isFile(sourceJavaScript)) || !(await isFile(sourceLicense))) {
+    throw new Error(
+      "fflate is not installed; run `bun install --frozen-lockfile`",
+    );
+  }
+  const destination = join(outputDir, "vendor", "fflate", FFLATE_VERSION);
+  await mkdir(destination, { recursive: true });
+  await cp(sourceJavaScript, join(destination, "index.js"), {
+    preserveTimestamps: true,
+  });
+  await cp(sourceLicense, join(destination, "LICENSE"), {
+    preserveTimestamps: true,
+  });
 }
 
 export async function loadRuffleRelease(
-	path = RUFFLE_RELEASE_PATH,
+  path = RUFFLE_RELEASE_PATH,
 ): Promise<RuffleRelease> {
-	const release = JSON.parse(await readFile(path, "utf8")) as Partial<RuffleRelease>;
-	const keys = Object.keys(release).sort();
-	if (keys.join(",") !== "asset,sha256,tag") {
-		throw new Error("Ruffle release metadata must contain tag, asset, and sha256");
-	}
-	if (!/^v\d+\.\d+\.\d+$/.test(release.tag ?? "")) {
-		throw new Error("Ruffle release tag is invalid");
-	}
-	if (!release.asset?.endsWith("-web-selfhosted.zip")) {
-		throw new Error("Ruffle release asset is not the self-hosted web package");
-	}
-	if (!/^[a-f0-9]{64}$/.test(release.sha256 ?? "")) {
-		throw new Error("Ruffle release checksum is invalid");
-	}
-	return release as RuffleRelease;
+  const release = JSON.parse(
+    await readFile(path, "utf8"),
+  ) as Partial<RuffleRelease>;
+  const keys = Object.keys(release).sort();
+  if (keys.join(",") !== "asset,sha256,tag") {
+    throw new Error(
+      "Ruffle release metadata must contain tag, asset, and sha256",
+    );
+  }
+  if (!/^v\d+\.\d+\.\d+$/.test(release.tag ?? "")) {
+    throw new Error("Ruffle release tag is invalid");
+  }
+  if (!release.asset?.endsWith("-web-selfhosted.zip")) {
+    throw new Error("Ruffle release asset is not the self-hosted web package");
+  }
+  if (!/^[a-f0-9]{64}$/.test(release.sha256 ?? "")) {
+    throw new Error("Ruffle release checksum is invalid");
+  }
+  return release as RuffleRelease;
 }
 
 export function ruffleDownloadUrl(release: RuffleRelease): string {
-	return `${RUFFLE_DOWNLOAD_ROOT}/${release.tag}/${release.asset}`;
+  return `${RUFFLE_DOWNLOAD_ROOT}/${release.tag}/${release.asset}`;
 }
 
 export async function downloadRuffle(
-	jsDir: string,
-	release?: RuffleRelease,
-	fetcher: Fetcher = fetch,
+  jsDir: string,
+  release?: RuffleRelease,
+  fetcher: Fetcher = fetch,
 ): Promise<void> {
-	const selectedRelease = release ?? (await loadRuffleRelease());
-	await mkdir(jsDir, { recursive: true });
-	console.log(`Downloading Ruffle ${selectedRelease.tag}...`);
+  const selectedRelease = release ?? (await loadRuffleRelease());
+  await mkdir(jsDir, { recursive: true });
+  console.log(`Downloading Ruffle ${selectedRelease.tag}...`);
 
-	const response = await fetcher(ruffleDownloadUrl(selectedRelease), {
-		signal: AbortSignal.timeout(120_000),
-	});
-	if (!response.ok) {
-		throw new Error(`Could not download Ruffle: HTTP ${response.status}`);
-	}
-	const archiveBytes = new Uint8Array(await response.arrayBuffer());
-	const actualChecksum = createHash("sha256").update(archiveBytes).digest("hex");
-	if (actualChecksum !== selectedRelease.sha256) {
-		throw new Error(
-			`Ruffle archive checksum mismatch: expected ${selectedRelease.sha256}, got ${actualChecksum}`,
-		);
-	}
+  const response = await fetcher(ruffleDownloadUrl(selectedRelease), {
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Could not download Ruffle: HTTP ${response.status}`);
+  }
+  const archiveBytes = new Uint8Array(await response.arrayBuffer());
+  const actualChecksum = createHash("sha256")
+    .update(archiveBytes)
+    .digest("hex");
+  if (actualChecksum !== selectedRelease.sha256) {
+    throw new Error(
+      `Ruffle archive checksum mismatch: expected ${selectedRelease.sha256}, got ${actualChecksum}`,
+    );
+  }
 
-	const archive = unzipSync(archiveBytes);
-	const files = Object.entries(archive).filter(([name]) => {
-		const normalized = name.replaceAll("\\", "/");
-		return (
-			!normalized.endsWith("/") &&
-			!normalized.includes("/") &&
-			RUFFLE_FILE_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
-		);
-	});
-	const names = files.map(([name]) => name);
-	if (
-		!names.includes("ruffle.js") ||
-		!names.some((name) => name.startsWith("core.ruffle.") && name.endsWith(".js")) ||
-		!names.some((name) => name.endsWith(".wasm"))
-	) {
-		throw new Error("Downloaded Ruffle package is missing required runtime files");
-	}
+  const archive = unzipSync(archiveBytes);
+  const files = Object.entries(archive).filter(([name]) => {
+    const normalized = name.replaceAll("\\", "/");
+    return (
+      !normalized.endsWith("/") &&
+      !normalized.includes("/") &&
+      RUFFLE_FILE_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
+    );
+  });
+  const names = files.map(([name]) => name);
+  if (
+    !names.includes("ruffle.js") ||
+    !names.some(
+      (name) => name.startsWith("core.ruffle.") && name.endsWith(".js"),
+    ) ||
+    !names.some((name) => name.endsWith(".wasm"))
+  ) {
+    throw new Error(
+      "Downloaded Ruffle package is missing required runtime files",
+    );
+  }
 
-	await Promise.all(files.map(([name, content]) => writeFile(join(jsDir, name), content)));
-	console.log(`  - Installed ${files.length} Ruffle runtime files`);
+  await Promise.all(
+    files.map(([name, content]) => writeFile(join(jsDir, name), content)),
+  );
+  console.log(`  - Installed ${files.length} Ruffle runtime files`);
 }
 
 export async function getShortHash(filePath: string): Promise<string> {
-	return createHash("sha384")
-		.update(await readFile(filePath))
-		.digest("hex")
-		.slice(0, 8);
+  return createHash("sha384")
+    .update(await readFile(filePath))
+    .digest("hex")
+    .slice(0, 8);
 }
 
 export function runGit(arguments_: string[], projectDir = PROJECT_DIR): string {
-	const result = Bun.spawnSync(["git", ...arguments_], {
-		cwd: projectDir,
-		stderr: "pipe",
-		stdout: "pipe",
-	});
-	if (!result.success) {
-		throw new Error(
-			`Could not resolve deployment revision with git ${arguments_.join(" ")}`,
-		);
-	}
-	return result.stdout.toString().trim();
+  const result = Bun.spawnSync(["git", ...arguments_], {
+    cwd: projectDir,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  if (!result.success) {
+    throw new Error(
+      `Could not resolve deployment revision with git ${arguments_.join(" ")}`,
+    );
+  }
+  return result.stdout.toString().trim();
 }
 
 export function getDeploymentVersion(
-	revision = "HEAD",
-	projectDir = PROJECT_DIR,
-	git: typeof runGit = runGit,
+  revision = "HEAD",
+  projectDir = PROJECT_DIR,
+  git: typeof runGit = runGit,
 ): string {
-	const commitDate = git(["show", "-s", "--format=%cs", revision], projectDir);
-	const shortRevision = git(["rev-parse", "--short=7", revision], projectDir);
-	if (!/^\d{4}-\d{2}-\d{2}$/.test(commitDate)) {
-		throw new Error(`Git returned an invalid commit date: ${commitDate}`);
-	}
-	if (!/^[a-f0-9]{7,}$/.test(shortRevision)) {
-		throw new Error(`Git returned an invalid revision: ${shortRevision}`);
-	}
-	const [year, month, day] = commitDate.split("-");
-	return `${year.slice(2)}.${month}.${day}-${shortRevision.slice(0, 7)}`;
+  const commitDate = git(["show", "-s", "--format=%cs", revision], projectDir);
+  const shortRevision = git(["rev-parse", "--short=7", revision], projectDir);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(commitDate)) {
+    throw new Error(`Git returned an invalid commit date: ${commitDate}`);
+  }
+  if (!/^[a-f0-9]{7,}$/.test(shortRevision)) {
+    throw new Error(`Git returned an invalid revision: ${shortRevision}`);
+  }
+  const [year, month, day] = commitDate.split("-");
+  return `${year.slice(2)}.${month}.${day}-${shortRevision.slice(0, 7)}`;
 }
 
-export async function updateHtml(paths: BuildPaths, version: string): Promise<void> {
-	console.log("Updating output with version and cache-busting hashes...");
-	let mainJavaScript = await readFile(paths.mainJs, "utf8");
-	mainJavaScript = await replaceExactlyOnce(
-		mainJavaScript,
-		APP_VERSION_PATTERN,
-		`const APP_VERSION = "${version}";`,
-		"Could not update APP_VERSION in output js/main.js",
-	);
-	await writeFile(paths.mainJs, mainJavaScript);
+export async function updateHtml(
+  paths: BuildPaths,
+  version: string,
+): Promise<void> {
+  console.log("Updating output with version and cache-busting hashes...");
+  let mainJavaScript = await readFile(paths.mainJs, "utf8");
+  mainJavaScript = await replaceExactlyOnce(
+    mainJavaScript,
+    APP_VERSION_PATTERN,
+    `const APP_VERSION = "${version}";`,
+    "Could not update APP_VERSION in output js/main.js",
+  );
+  await writeFile(paths.mainJs, mainJavaScript);
 
-	const shortHashes = Object.fromEntries(
-		await Promise.all(
-			Object.entries(paths.assetPaths).map(async ([name, path]) => [
-				name,
-				await getShortHash(path),
-			]),
-		),
-	);
-	let content = await readFile(paths.html, "utf8");
-	const replacements: [RegExp, string][] = [
-		[
-			/<script src="js\/ruffle\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="js/ruffle.js?v=${shortHashes.ruffle}"></script>`,
-		],
-		[
-			/<script src="vendor\/fflate\/0\.8\.3\/index\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="vendor/fflate/0.8.3/index.js?v=${shortHashes.fflate}"></script>`,
-		],
-		[
-			/<script src="js\/games\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="js/games.js?v=${shortHashes.gamesJs}"></script>`,
-		],
-		[
-			/<script src="js\/game-installer\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="js/game-installer.js?v=${shortHashes.gameInstallerJs}"></script>`,
-		],
-		[
-			/<script src="js\/game-library\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="js/game-library.js?v=${shortHashes.gameLibraryJs}"></script>`,
-		],
-		[
-			/<script src="js\/filesystem\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="js/filesystem.js?v=${shortHashes.filesystemJs}"></script>`,
-		],
-		[
-			/<script src="js\/file-operations\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="js/file-operations.js?v=${shortHashes.fileOperationsJs}"></script>`,
-		],
-		[
-			/<script src="js\/dialogs\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="js/dialogs.js?v=${shortHashes.dialogsJs}"></script>`,
-		],
-		[
-			/<script src="js\/offline\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="js/offline.js?v=${shortHashes.offlineJs}"></script>`,
-		],
-		[
-			/<script src="js\/main\.[^"]+" ?[^>]*><\/script>/g,
-			`<script src="js/main.js?v=${shortHashes.mainJs}"></script>`,
-		],
-		[
-			/<link rel="stylesheet" href="css\/main\.[^"]+" ?[^>]*>/g,
-			`<link rel="stylesheet" href="css/main.css?v=${shortHashes.mainCss}">`,
-		],
-	];
-	for (const [pattern, replacement] of replacements) {
-		content = await replaceExactlyOnce(
-			content,
-			pattern,
-			replacement,
-			`Could not update asset reference matching ${pattern.source}`,
-		);
-	}
-	await writeFile(paths.html, content);
-	console.log(`  - Set deployment version to ${version}`);
+  const shortHashes = Object.fromEntries(
+    await Promise.all(
+      Object.entries(paths.assetPaths).map(async ([name, path]) => [
+        name,
+        await getShortHash(path),
+      ]),
+    ),
+  );
+  let content = await readFile(paths.html, "utf8");
+  const replacements: [RegExp, string][] = [
+    [
+      /<script src="js\/ruffle\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="js/ruffle.js?v=${shortHashes.ruffle}"></script>`,
+    ],
+    [
+      /<script src="vendor\/fflate\/0\.8\.3\/index\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="vendor/fflate/0.8.3/index.js?v=${shortHashes.fflate}"></script>`,
+    ],
+    [
+      /<script src="js\/games\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="js/games.js?v=${shortHashes.gamesJs}"></script>`,
+    ],
+    [
+      /<script src="js\/game-installer\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="js/game-installer.js?v=${shortHashes.gameInstallerJs}"></script>`,
+    ],
+    [
+      /<script src="js\/game-library\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="js/game-library.js?v=${shortHashes.gameLibraryJs}"></script>`,
+    ],
+    [
+      /<script src="js\/filesystem\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="js/filesystem.js?v=${shortHashes.filesystemJs}"></script>`,
+    ],
+    [
+      /<script src="js\/file-operations\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="js/file-operations.js?v=${shortHashes.fileOperationsJs}"></script>`,
+    ],
+    [
+      /<script src="js\/dialogs\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="js/dialogs.js?v=${shortHashes.dialogsJs}"></script>`,
+    ],
+    [
+      /<script src="js\/offline\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="js/offline.js?v=${shortHashes.offlineJs}"></script>`,
+    ],
+    [
+      /<script src="js\/main\.[^"]+" ?[^>]*><\/script>/g,
+      `<script src="js/main.js?v=${shortHashes.mainJs}"></script>`,
+    ],
+    [
+      /<link rel="stylesheet" href="css\/main\.[^"]+" ?[^>]*>/g,
+      `<link rel="stylesheet" href="css/main.css?v=${shortHashes.mainCss}">`,
+    ],
+  ];
+  for (const [pattern, replacement] of replacements) {
+    content = await replaceExactlyOnce(
+      content,
+      pattern,
+      replacement,
+      `Could not update asset reference matching ${pattern.source}`,
+    );
+  }
+  await writeFile(paths.html, content);
+  console.log(`  - Set deployment version to ${version}`);
 }
 
 export function isOptionalOfflinePath(relativePath: string): boolean {
-	const path = relativePath.split(sep).join("/");
-	return (
-		path.startsWith("swf/") ||
-		path.startsWith("iframe/") ||
-		path.startsWith("dos/") ||
-		(path.startsWith("js/") &&
-			(path.endsWith(".wasm") ||
-				Boolean(path.split("/").at(-1)?.startsWith("core.ruffle."))))
-	);
+  const path = relativePath.split(sep).join("/");
+  return (
+    path.startsWith("swf/") ||
+    path.startsWith("iframe/") ||
+    path.startsWith("dos/") ||
+    (path.startsWith("js/") &&
+      (path.endsWith(".wasm") ||
+        Boolean(path.split("/").at(-1)?.startsWith("core.ruffle."))))
+  );
 }
 
-async function offlineFileEntry(root: string, path: string): Promise<OfflineFile> {
-	return {
-		bytes: (await stat(path)).size,
-		url: relative(root, path).split(sep).join("/"),
-	};
+async function offlineFileEntry(
+  root: string,
+  path: string,
+): Promise<OfflineFile> {
+  return {
+    bytes: (await stat(path)).size,
+    url: relative(root, path).split(sep).join("/"),
+  };
 }
 
 async function offlineRevision(root: string, files: string[]): Promise<string> {
-	const digest = createHash("sha256");
-	for (const path of files.toSorted()) {
-		digest.update(relative(root, path).split(sep).join("/"));
-		digest.update(await readFile(path));
-	}
-	return digest.digest("hex").slice(0, 16);
+  const digest = createHash("sha256");
+  for (const path of files.toSorted()) {
+    digest.update(relative(root, path).split(sep).join("/"));
+    digest.update(await readFile(path));
+  }
+  return digest.digest("hex").slice(0, 16);
 }
 
 export async function writeOfflineGameManifest(
-	paths: BuildPaths,
-	version: string,
+  paths: BuildPaths,
+  version: string,
 ): Promise<void> {
-	const runtimeFiles = (await readdir(paths.js, { withFileTypes: true }))
-		.filter(
-			(entry) =>
-				entry.isFile() &&
-				(entry.name.endsWith(".wasm") ||
-					(entry.name.startsWith("core.ruffle.") && entry.name.endsWith(".js"))),
-		)
-		.map((entry) => join(paths.js, entry.name))
-		.toSorted();
+  const runtimeFiles = (await readdir(paths.js, { withFileTypes: true }))
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        (entry.name.endsWith(".wasm") ||
+          (entry.name.startsWith("core.ruffle.") &&
+            entry.name.endsWith(".js"))),
+    )
+    .map((entry) => join(paths.js, entry.name))
+    .toSorted();
 
-	const gameIds = new Set<string>();
-	for (const parent of [join(paths.root, "swf"), join(paths.root, "iframe")]) {
-		if (!(await isDirectory(parent))) continue;
-		for (const entry of await readdir(parent, { withFileTypes: true })) {
-			if (entry.isDirectory()) gameIds.add(entry.name);
-		}
-	}
+  const gameIds = new Set<string>();
+  for (const parent of [join(paths.root, "swf"), join(paths.root, "iframe")]) {
+    if (!(await isDirectory(parent))) continue;
+    for (const entry of await readdir(parent, { withFileTypes: true })) {
+      if (entry.isDirectory()) gameIds.add(entry.name);
+    }
+  }
 
-	const games: Record<string, OfflineGame> = {};
-	for (const gameId of [...gameIds].sort()) {
-		const gameType = (await isDirectory(join(paths.root, "swf", gameId)))
-			? "swf"
-			: "iframe";
-		const roots = [join(paths.root, gameType, gameId)];
-		const doomRoot = join(paths.root, "dos", "doom");
-		if (gameId === "doom" && (await isDirectory(doomRoot))) roots.push(doomRoot);
-		const files = (await Promise.all(roots.map(walkFiles))).flat().sort();
-		games[gameId] = {
-			bytes: (
-				await Promise.all(files.map(async (path) => (await stat(path)).size))
-			).reduce((total, bytes) => total + bytes, 0),
-			files: await Promise.all(files.map((path) => offlineFileEntry(paths.root, path))),
-			revision: await offlineRevision(paths.root, files),
-			type: gameType,
-		};
-	}
+  const games: Record<string, OfflineGame> = {};
+  for (const gameId of [...gameIds].sort()) {
+    const gameType = (await isDirectory(join(paths.root, "swf", gameId)))
+      ? "swf"
+      : "iframe";
+    const roots = [join(paths.root, gameType, gameId)];
+    const doomRoot = join(paths.root, "dos", "doom");
+    if (gameId === "doom" && (await isDirectory(doomRoot)))
+      roots.push(doomRoot);
+    const files = (await Promise.all(roots.map(walkFiles))).flat().sort();
+    games[gameId] = {
+      bytes: (
+        await Promise.all(files.map(async (path) => (await stat(path)).size))
+      ).reduce((total, bytes) => total + bytes, 0),
+      files: await Promise.all(
+        files.map((path) => offlineFileEntry(paths.root, path)),
+      ),
+      revision: await offlineRevision(paths.root, files),
+      type: gameType,
+    };
+  }
 
-	const manifest: OfflineManifest = {
-		games,
-		runtime: {
-			bytes: (
-				await Promise.all(runtimeFiles.map(async (path) => (await stat(path)).size))
-			).reduce((total, bytes) => total + bytes, 0),
-			files: await Promise.all(
-				runtimeFiles.map((path) => offlineFileEntry(paths.root, path)),
-			),
-			revision: await offlineRevision(paths.root, runtimeFiles),
-		},
-		version,
-	};
-	await writeFile(paths.offlineGamesJson, `${JSON.stringify(manifest)}\n`);
+  const manifest: OfflineManifest = {
+    games,
+    runtime: {
+      bytes: (
+        await Promise.all(
+          runtimeFiles.map(async (path) => (await stat(path)).size),
+        )
+      ).reduce((total, bytes) => total + bytes, 0),
+      files: await Promise.all(
+        runtimeFiles.map((path) => offlineFileEntry(paths.root, path)),
+      ),
+      revision: await offlineRevision(paths.root, runtimeFiles),
+    },
+    version,
+  };
+  await writeFile(paths.offlineGamesJson, `${JSON.stringify(manifest)}\n`);
 }
 
 export async function writeVersionMetadata(
-	paths: BuildPaths,
-	version: string,
+  paths: BuildPaths,
+  version: string,
 ): Promise<void> {
-	const files = await walkFiles(paths.root);
-	let offlineBytes = 0;
-	for (const path of files) {
-		const relativePath = relative(paths.root, path);
-		if (
-			path !== paths.versionJson &&
-			PRECACHE_FILE_SUFFIXES.has(extname(path).toLowerCase()) &&
-			!isOptionalOfflinePath(relativePath)
-		) {
-			offlineBytes += (await stat(path)).size;
-		}
-	}
-	const offlineManifest = JSON.parse(
-		await readFile(paths.offlineGamesJson, "utf8"),
-	) as OfflineManifest;
-	const bundledGameBytes =
-		offlineManifest.runtime.bytes +
-		Object.values(offlineManifest.games).reduce(
-			(total, game) => total + game.bytes,
-			0,
-		);
-	const revision = version.split("-").at(-1);
-	await writeFile(
-		paths.versionJson,
-		`${JSON.stringify({
-			bundledGameBytes,
-			offlineBytes,
-			revision,
-			version,
-		})}\n`,
-	);
+  const files = await walkFiles(paths.root);
+  let offlineBytes = 0;
+  for (const path of files) {
+    const relativePath = relative(paths.root, path);
+    if (
+      path !== paths.versionJson &&
+      PRECACHE_FILE_SUFFIXES.has(extname(path).toLowerCase()) &&
+      !isOptionalOfflinePath(relativePath)
+    ) {
+      offlineBytes += (await stat(path)).size;
+    }
+  }
+  const offlineManifest = JSON.parse(
+    await readFile(paths.offlineGamesJson, "utf8"),
+  ) as OfflineManifest;
+  const bundledGameBytes =
+    offlineManifest.runtime.bytes +
+    Object.values(offlineManifest.games).reduce(
+      (total, game) => total + game.bytes,
+      0,
+    );
+  const revision = version.split("-").at(-1);
+  await writeFile(
+    paths.versionJson,
+    `${JSON.stringify({
+      bundledGameBytes,
+      offlineBytes,
+      revision,
+      version,
+    })}\n`,
+  );
 }
 
 async function getWorkboxFiles(outputDir: string): Promise<string[]> {
-	return (await readdir(outputDir))
-		.filter(
-			(name) =>
-				name === "sw.js" ||
-				name === "sw.js.map" ||
-				/^workbox-.*\.js(?:\.map)?$/.test(name),
-		)
-		.map((name) => join(outputDir, name));
+  return (await readdir(outputDir))
+    .filter(
+      (name) =>
+        name === "sw.js" ||
+        name === "sw.js.map" ||
+        /^workbox-.*\.js(?:\.map)?$/.test(name),
+    )
+    .map((name) => join(outputDir, name));
 }
 
 export async function generateServiceWorker(
-	outputDir: string,
-	generator: WorkboxGenerator = generateSW,
+  outputDir: string,
+  generator: WorkboxGenerator = generateSW,
 ): Promise<void> {
-	console.log("Generating service worker...");
-	await generator({
-		...workboxConfig,
-		globDirectory: `${resolve(outputDir)}/`,
-		swDest: join(resolve(outputDir), "sw.js"),
-	});
+  console.log("Generating service worker...");
+  await generator({
+    ...workboxConfig,
+    globDirectory: `${resolve(outputDir)}/`,
+    swDest: join(resolve(outputDir), "sw.js"),
+  });
 
-	const serviceWorker = join(outputDir, "sw.js");
-	if (!(await isFile(serviceWorker))) {
-		throw new Error("Workbox did not generate output sw.js");
-	}
-	const workerSource = await readFile(serviceWorker, "utf8");
-	const referencedRuntimeNames = new Set(
-		[...workerSource.matchAll(/workbox-[a-f0-9]+(?:\.js)?/g)].map((match) =>
-			match[0].endsWith(".js") ? match[0] : `${match[0]}.js`,
-		),
-	);
-	if (referencedRuntimeNames.size === 0) {
-		throw new Error("Generated service worker references no Workbox runtime");
-	}
-	if (
-		!(await Promise.all(
-			[...referencedRuntimeNames].map((name) => isFile(join(outputDir, name))),
-		)).every(Boolean)
-	) {
-		throw new Error("Generated service worker references a missing Workbox runtime");
-	}
-	for (const path of await getWorkboxFiles(outputDir)) {
-		const name = path.split(sep).at(-1) ?? "";
-		if (name.startsWith("workbox-") && !referencedRuntimeNames.has(name)) {
-			await rm(path);
-		}
-	}
-	console.log("  - Service worker generated successfully");
+  const serviceWorker = join(outputDir, "sw.js");
+  if (!(await isFile(serviceWorker))) {
+    throw new Error("Workbox did not generate output sw.js");
+  }
+  const workerSource = await readFile(serviceWorker, "utf8");
+  const referencedRuntimeNames = new Set(
+    [...workerSource.matchAll(/workbox-[a-f0-9]+(?:\.js)?/g)].map((match) =>
+      match[0].endsWith(".js") ? match[0] : `${match[0]}.js`,
+    ),
+  );
+  if (referencedRuntimeNames.size === 0) {
+    throw new Error("Generated service worker references no Workbox runtime");
+  }
+  if (
+    !(
+      await Promise.all(
+        [...referencedRuntimeNames].map((name) =>
+          isFile(join(outputDir, name)),
+        ),
+      )
+    ).every(Boolean)
+  ) {
+    throw new Error(
+      "Generated service worker references a missing Workbox runtime",
+    );
+  }
+  for (const path of await getWorkboxFiles(outputDir)) {
+    const name = path.split(sep).at(-1) ?? "";
+    if (name.startsWith("workbox-") && !referencedRuntimeNames.has(name)) {
+      await rm(path);
+    }
+  }
+  console.log("  - Service worker generated successfully");
 }
 
 export async function validateOutput(outputDir: string): Promise<void> {
-	const paths = new BuildPaths(outputDir);
-	const required = [
-		paths.html,
-		paths.offlineGamesJson,
-		paths.versionJson,
-		join(outputDir, "sw.js"),
-		join(outputDir, "swf", "bike-mania", "main.swf"),
-		join(outputDir, "iframe", "doom", "index.html"),
-		join(outputDir, "iframe", "inside-the-firewall", "index.html"),
-		join(outputDir, "dos", "doom", "doom.jsdos"),
-		paths.fflateJs,
-	];
-	const missing = (
-		await Promise.all(
-			required.map(async (path) => ((await isFile(path)) ? undefined : relative(outputDir, path))),
-		)
-	).filter(Boolean);
-	if (missing.length > 0) {
-		throw new Error(`Build output is missing required files: ${missing.join(", ")}`);
-	}
+  const paths = new BuildPaths(outputDir);
+  const required = [
+    paths.html,
+    paths.offlineGamesJson,
+    paths.versionJson,
+    join(outputDir, "sw.js"),
+    join(outputDir, "swf", "bike-mania", "main.swf"),
+    join(outputDir, "iframe", "doom", "index.html"),
+    join(outputDir, "iframe", "inside-the-firewall", "index.html"),
+    join(outputDir, "dos", "doom", "doom.jsdos"),
+    paths.fflateJs,
+  ];
+  const missing = (
+    await Promise.all(
+      required.map(async (path) =>
+        (await isFile(path)) ? undefined : relative(outputDir, path),
+      ),
+    )
+  ).filter(Boolean);
+  if (missing.length > 0) {
+    throw new Error(
+      `Build output is missing required files: ${missing.join(", ")}`,
+    );
+  }
 
-	const html = await readFile(paths.html, "utf8");
-	for (const asset of [
-		"js/ruffle.js",
-		"vendor/fflate/0.8.3/index.js",
-		"js/games.js",
-		"js/game-installer.js",
-		"js/game-library.js",
-		"js/filesystem.js",
-		"js/file-operations.js",
-		"js/dialogs.js",
-		"js/offline.js",
-		"js/main.js",
-		"css/main.css",
-	]) {
-		const pattern = new RegExp(`${asset.replaceAll(".", "\\.")}\\?v=[a-f0-9]{8}"`);
-		if (!pattern.test(html)) {
-			throw new Error(`Build output has no hashed reference for ${asset}`);
-		}
-	}
-	const jsEntries = await readdir(paths.js);
-	if (!jsEntries.some((name) => /^core\.ruffle\..*\.js$/.test(name))) {
-		throw new Error("Build output has no Ruffle core JavaScript");
-	}
-	if (!jsEntries.some((name) => name.endsWith(".wasm"))) {
-		throw new Error("Build output has no Ruffle WebAssembly");
-	}
+  const html = await readFile(paths.html, "utf8");
+  for (const asset of [
+    "js/ruffle.js",
+    "vendor/fflate/0.8.3/index.js",
+    "js/games.js",
+    "js/game-installer.js",
+    "js/game-library.js",
+    "js/filesystem.js",
+    "js/file-operations.js",
+    "js/dialogs.js",
+    "js/offline.js",
+    "js/main.js",
+    "css/main.css",
+  ]) {
+    const pattern = new RegExp(
+      `${asset.replaceAll(".", "\\.")}\\?v=[a-f0-9]{8}"`,
+    );
+    if (!pattern.test(html)) {
+      throw new Error(`Build output has no hashed reference for ${asset}`);
+    }
+  }
+  const jsEntries = await readdir(paths.js);
+  if (!jsEntries.some((name) => /^core\.ruffle\..*\.js$/.test(name))) {
+    throw new Error("Build output has no Ruffle core JavaScript");
+  }
+  if (!jsEntries.some((name) => name.endsWith(".wasm"))) {
+    throw new Error("Build output has no Ruffle WebAssembly");
+  }
 
-	let versionMetadata: Record<string, unknown>;
-	try {
-		versionMetadata = JSON.parse(await readFile(paths.versionJson, "utf8"));
-	} catch {
-		throw new Error("Build output has invalid version metadata");
-	}
-	if (
-		Object.keys(versionMetadata).sort().join(",") !==
-		"bundledGameBytes,offlineBytes,revision,version"
-	) {
-		throw new Error("Build output has invalid version metadata");
-	}
-	if (
-		!Number.isInteger(versionMetadata.offlineBytes) ||
-		(versionMetadata.offlineBytes as number) <= 0 ||
-		!Number.isInteger(versionMetadata.bundledGameBytes) ||
-		(versionMetadata.bundledGameBytes as number) <= 0
-	) {
-		throw new Error("Build output has invalid offline download size");
-	}
+  let versionMetadata: Record<string, unknown>;
+  try {
+    versionMetadata = JSON.parse(await readFile(paths.versionJson, "utf8"));
+  } catch {
+    throw new Error("Build output has invalid version metadata");
+  }
+  if (
+    Object.keys(versionMetadata).sort().join(",") !==
+    "bundledGameBytes,offlineBytes,revision,version"
+  ) {
+    throw new Error("Build output has invalid version metadata");
+  }
+  if (
+    !Number.isInteger(versionMetadata.offlineBytes) ||
+    (versionMetadata.offlineBytes as number) <= 0 ||
+    !Number.isInteger(versionMetadata.bundledGameBytes) ||
+    (versionMetadata.bundledGameBytes as number) <= 0
+  ) {
+    throw new Error("Build output has invalid offline download size");
+  }
 
-	let offlineManifest: OfflineManifest;
-	try {
-		offlineManifest = JSON.parse(
-			await readFile(paths.offlineGamesJson, "utf8"),
-		) as OfflineManifest;
-	} catch {
-		throw new Error("Build output has invalid offline game manifest");
-	}
-	if (
-		offlineManifest.version !== versionMetadata.version ||
-		Object.keys(offlineManifest.games ?? {}).length === 0 ||
-		!offlineManifest.runtime?.files?.length
-	) {
-		throw new Error("Build output has invalid offline game manifest");
-	}
-	if (
-		!(versionMetadata.version as string).endsWith(`-${versionMetadata.revision as string}`)
-	) {
-		throw new Error("Build output has inconsistent version metadata");
-	}
-	console.log("Build output validated successfully");
+  let offlineManifest: OfflineManifest;
+  try {
+    offlineManifest = JSON.parse(
+      await readFile(paths.offlineGamesJson, "utf8"),
+    ) as OfflineManifest;
+  } catch {
+    throw new Error("Build output has invalid offline game manifest");
+  }
+  if (
+    offlineManifest.version !== versionMetadata.version ||
+    Object.keys(offlineManifest.games ?? {}).length === 0 ||
+    !offlineManifest.runtime?.files?.length
+  ) {
+    throw new Error("Build output has invalid offline game manifest");
+  }
+  if (
+    !(versionMetadata.version as string).endsWith(
+      `-${versionMetadata.revision as string}`,
+    )
+  ) {
+    throw new Error("Build output has inconsistent version metadata");
+  }
+  console.log("Build output validated successfully");
 }
 
-export async function replaceOutput(stagingDir: string, outputDir: string): Promise<void> {
-	await mkdir(dirname(outputDir), { recursive: true });
-	const backupDir = join(dirname(stagingDir), "previous-output");
-	if (await isDirectory(outputDir)) {
-		await rename(outputDir, backupDir);
-	}
-	try {
-		await rename(stagingDir, outputDir);
-	} catch (error) {
-		if (await isDirectory(backupDir)) {
-			await rename(backupDir, outputDir);
-		}
-		throw error;
-	}
+export async function replaceOutput(
+  stagingDir: string,
+  outputDir: string,
+): Promise<void> {
+  await mkdir(dirname(outputDir), { recursive: true });
+  const backupDir = join(dirname(stagingDir), "previous-output");
+  if (await isDirectory(outputDir)) {
+    await rename(outputDir, backupDir);
+  }
+  try {
+    await rename(stagingDir, outputDir);
+  } catch (error) {
+    if (await isDirectory(backupDir)) {
+      await rename(backupDir, outputDir);
+    }
+    throw error;
+  }
 }
 
 export interface BuildOptions {
-	outputDir?: string;
-	revision?: string;
-	sourceDir?: string;
-	version?: string;
-	download?: (jsDir: string) => Promise<void>;
-	generate?: (outputDir: string) => Promise<void>;
+  outputDir?: string;
+  revision?: string;
+  sourceDir?: string;
+  version?: string;
+  download?: (jsDir: string) => Promise<void>;
+  generate?: (outputDir: string) => Promise<void>;
 }
 
 export async function build({
-	outputDir = DEFAULT_OUTPUT_DIR,
-	revision = "HEAD",
-	sourceDir = SOURCE_DIR,
-	version,
-	download = downloadRuffle,
-	generate = generateServiceWorker,
+  outputDir = DEFAULT_OUTPUT_DIR,
+  revision = "HEAD",
+  sourceDir = SOURCE_DIR,
+  version,
+  download = downloadRuffle,
+  generate = generateServiceWorker,
 }: BuildOptions = {}): Promise<void> {
-	const resolvedOutput = resolve(outputDir);
-	const resolvedSource = resolve(sourceDir);
-	if (
-		resolvedOutput === resolvedSource ||
-		resolvedOutput.startsWith(`${resolvedSource}${sep}`)
-	) {
-		throw new Error("Build output must be outside the site source directory");
-	}
+  const resolvedOutput = resolve(outputDir);
+  const resolvedSource = resolve(sourceDir);
+  if (
+    resolvedOutput === resolvedSource ||
+    resolvedOutput.startsWith(`${resolvedSource}${sep}`)
+  ) {
+    throw new Error("Build output must be outside the site source directory");
+  }
 
-	const deploymentVersion = version ?? getDeploymentVersion(revision);
-	await mkdir(dirname(resolvedOutput), { recursive: true });
-	const temporaryDirectory = await mkdtemp(
-		join(dirname(resolvedOutput), `.${resolvedOutput.split(sep).at(-1)}-build-`),
-	);
-	try {
-		const stagingDir = join(temporaryDirectory, "output");
-		await cp(resolvedSource, stagingDir, { recursive: true, preserveTimestamps: true });
-		const paths = new BuildPaths(stagingDir);
-		await installFflate(stagingDir);
-		await download(paths.js);
-		await updateHtml(paths, deploymentVersion);
-		await writeOfflineGameManifest(paths, deploymentVersion);
-		await writeVersionMetadata(paths, deploymentVersion);
-		await generate(stagingDir);
-		await validateOutput(stagingDir);
-		await replaceOutput(stagingDir, resolvedOutput);
-	} finally {
-		await rm(temporaryDirectory, { recursive: true, force: true });
-	}
-	console.log(`Build completed successfully: ${resolvedOutput}`);
+  const deploymentVersion = version ?? getDeploymentVersion(revision);
+  await mkdir(dirname(resolvedOutput), { recursive: true });
+  const temporaryDirectory = await mkdtemp(
+    join(
+      dirname(resolvedOutput),
+      `.${resolvedOutput.split(sep).at(-1)}-build-`,
+    ),
+  );
+  try {
+    const stagingDir = join(temporaryDirectory, "output");
+    await cp(resolvedSource, stagingDir, {
+      recursive: true,
+      preserveTimestamps: true,
+    });
+    const paths = new BuildPaths(stagingDir);
+    await installFflate(stagingDir);
+    await download(paths.js);
+    await updateHtml(paths, deploymentVersion);
+    await writeOfflineGameManifest(paths, deploymentVersion);
+    await writeVersionMetadata(paths, deploymentVersion);
+    await generate(stagingDir);
+    await validateOutput(stagingDir);
+    await replaceOutput(stagingDir, resolvedOutput);
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+  console.log(`Build completed successfully: ${resolvedOutput}`);
 }
 
-function parseArguments(arguments_: string[]): { outputDir: string; revision: string } {
-	let outputDir = DEFAULT_OUTPUT_DIR;
-	let revision = "HEAD";
-	for (let index = 0; index < arguments_.length; index += 1) {
-		const argument = arguments_[index];
-		if (argument === "--output" || argument === "--revision") {
-			const value = arguments_[index + 1];
-			if (!value) throw new Error(`${argument} requires a value`);
-			if (argument === "--output") outputDir = isAbsolute(value) ? value : resolve(value);
-			else revision = value;
-			index += 1;
-		} else {
-			throw new Error(`Unknown argument: ${argument}`);
-		}
-	}
-	return { outputDir, revision };
+function parseArguments(arguments_: string[]): {
+  outputDir: string;
+  revision: string;
+} {
+  let outputDir = DEFAULT_OUTPUT_DIR;
+  let revision = "HEAD";
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === "--output" || argument === "--revision") {
+      const value = arguments_[index + 1];
+      if (!value) throw new Error(`${argument} requires a value`);
+      if (argument === "--output")
+        outputDir = isAbsolute(value) ? value : resolve(value);
+      else revision = value;
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  return { outputDir, revision };
 }
 
 if (import.meta.main) {
-	try {
-		await build(parseArguments(Bun.argv.slice(2)));
-	} catch (error) {
-		console.error(error instanceof Error ? error.message : error);
-		process.exitCode = 1;
-	}
+  try {
+    await build(parseArguments(Bun.argv.slice(2)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
 }

--- a/tools/dev-server.ts
+++ b/tools/dev-server.ts
@@ -1,406 +1,404 @@
 import { createHash } from "node:crypto";
 import {
-	cp,
-	mkdir,
-	readFile,
-	readdir,
-	stat,
-	writeFile,
+  cp,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  writeFile,
 } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import {
-	type CatalogFetcher,
-	handleCatalogRequest,
-} from "../catalog/catalog";
+import { type CatalogFetcher, handleCatalogRequest } from "../catalog/catalog";
 import type { BuildOptions } from "./deploy";
 
 const PROJECT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_OUTPUT_DIR = join(PROJECT_DIR, "dist");
 export const DEV_BUILD_STATE = ".dev-build-state.json";
 const BUILD_INPUTS = [
-	"site",
-	"tools/deploy.ts",
-	"tools/ruffle-release.json",
-	"workbox-config.ts",
-	"package.json",
-	"bun.lock",
+  "site",
+  "tools/deploy.ts",
+  "tools/ruffle-release.json",
+  "workbox-config.ts",
+  "package.json",
+  "bun.lock",
 ];
 
 interface DevBuildState {
-	schema: 1;
-	fingerprint: string;
-	ruffleRelease: string;
-	generatedAt: string;
+  schema: 1;
+  fingerprint: string;
+  ruffleRelease: string;
+  generatedAt: string;
 }
 
 interface EnsureDevelopmentBuildOptions {
-	outputDir?: string;
-	force?: boolean;
-	projectDir?: string;
-	fingerprint?: () => Promise<string>;
-	releaseKey?: () => Promise<string>;
-	builder?: (options: BuildOptions) => Promise<void>;
+  outputDir?: string;
+  force?: boolean;
+  projectDir?: string;
+  fingerprint?: () => Promise<string>;
+  releaseKey?: () => Promise<string>;
+  builder?: (options: BuildOptions) => Promise<void>;
 }
 
 interface EnsureDevelopmentBuildResult {
-	rebuilt: boolean;
-	reusedRuffle: boolean;
+  rebuilt: boolean;
+  reusedRuffle: boolean;
 }
 
 function gitOutput(
-	arguments_: string[],
-	projectDir: string,
+  arguments_: string[],
+  projectDir: string,
 ): Uint8Array | null {
-	const result = Bun.spawnSync(["git", ...arguments_], {
-		cwd: projectDir,
-		stderr: "ignore",
-		stdout: "pipe",
-	});
-	return result.success ? result.stdout : null;
+  const result = Bun.spawnSync(["git", ...arguments_], {
+    cwd: projectDir,
+    stderr: "ignore",
+    stdout: "pipe",
+  });
+  return result.success ? result.stdout : null;
 }
 
 async function walkFiles(root: string): Promise<string[]> {
-	const files: string[] = [];
-	for (const entry of await readdir(root, { withFileTypes: true })) {
-		const path = join(root, entry.name);
-		if (entry.isDirectory()) files.push(...(await walkFiles(path)));
-		else if (entry.isFile()) files.push(path);
-	}
-	return files;
+  const files: string[] = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...(await walkFiles(path)));
+    else if (entry.isFile()) files.push(path);
+  }
+  return files;
 }
 
 async function filesystemFingerprint(projectDir: string): Promise<string> {
-	const digest = createHash("sha256");
-	for (const input of BUILD_INPUTS) {
-		const path = join(projectDir, input);
-		try {
-			const info = await stat(path);
-			const files = info.isDirectory() ? await walkFiles(path) : [path];
-			for (const file of files.sort()) {
-				digest.update(relative(projectDir, file).split(sep).join("/"));
-				digest.update(await readFile(file));
-			}
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-			digest.update(`missing:${input}`);
-		}
-	}
-	return digest.digest("hex");
+  const digest = createHash("sha256");
+  for (const input of BUILD_INPUTS) {
+    const path = join(projectDir, input);
+    try {
+      const info = await stat(path);
+      const files = info.isDirectory() ? await walkFiles(path) : [path];
+      for (const file of files.sort()) {
+        digest.update(relative(projectDir, file).split(sep).join("/"));
+        digest.update(await readFile(file));
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      digest.update(`missing:${input}`);
+    }
+  }
+  return digest.digest("hex");
 }
 
 export async function computeSourceFingerprint(
-	projectDir = PROJECT_DIR,
+  projectDir = PROJECT_DIR,
 ): Promise<string> {
-	const tracked = gitOutput(
-		["ls-files", "-s", "--", ...BUILD_INPUTS],
-		projectDir,
-	);
-	const changes = gitOutput(
-		["diff", "--binary", "--no-ext-diff", "HEAD", "--", ...BUILD_INPUTS],
-		projectDir,
-	);
-	const untracked = gitOutput(
-		[
-			"ls-files",
-			"--others",
-			"--exclude-standard",
-			"-z",
-			"--",
-			...BUILD_INPUTS,
-		],
-		projectDir,
-	);
-	if (!tracked || !changes || !untracked) {
-		return filesystemFingerprint(projectDir);
-	}
+  const tracked = gitOutput(
+    ["ls-files", "-s", "--", ...BUILD_INPUTS],
+    projectDir,
+  );
+  const changes = gitOutput(
+    ["diff", "--binary", "--no-ext-diff", "HEAD", "--", ...BUILD_INPUTS],
+    projectDir,
+  );
+  const untracked = gitOutput(
+    ["ls-files", "--others", "--exclude-standard", "-z", "--", ...BUILD_INPUTS],
+    projectDir,
+  );
+  if (!tracked || !changes || !untracked) {
+    return filesystemFingerprint(projectDir);
+  }
 
-	const digest = createHash("sha256");
-	digest.update(tracked);
-	digest.update(changes);
-	for (const relativePath of Buffer.from(untracked)
-		.toString("utf8")
-		.split("\0")
-		.filter(Boolean)
-		.sort()) {
-		digest.update(relativePath);
-		digest.update(await readFile(join(projectDir, relativePath)));
-	}
-	return digest.digest("hex");
+  const digest = createHash("sha256");
+  digest.update(tracked);
+  digest.update(changes);
+  for (const relativePath of Buffer.from(untracked)
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+    .sort()) {
+    digest.update(relativePath);
+    digest.update(await readFile(join(projectDir, relativePath)));
+  }
+  return digest.digest("hex");
 }
 
 async function currentRuffleReleaseKey(): Promise<string> {
-	return createHash("sha256")
-		.update(await readFile(join(PROJECT_DIR, "tools", "ruffle-release.json")))
-		.digest("hex");
+  return createHash("sha256")
+    .update(await readFile(join(PROJECT_DIR, "tools", "ruffle-release.json")))
+    .digest("hex");
 }
 
-async function readBuildState(outputDir: string): Promise<DevBuildState | null> {
-	try {
-		const state = JSON.parse(
-			await readFile(join(outputDir, DEV_BUILD_STATE), "utf8"),
-		) as Partial<DevBuildState>;
-		return state.schema === 1 &&
-			typeof state.fingerprint === "string" &&
-			typeof state.ruffleRelease === "string" &&
-			typeof state.generatedAt === "string"
-			? (state as DevBuildState)
-			: null;
-	} catch {
-		return null;
-	}
+async function readBuildState(
+  outputDir: string,
+): Promise<DevBuildState | null> {
+  try {
+    const state = JSON.parse(
+      await readFile(join(outputDir, DEV_BUILD_STATE), "utf8"),
+    ) as Partial<DevBuildState>;
+    return state.schema === 1 &&
+      typeof state.fingerprint === "string" &&
+      typeof state.ruffleRelease === "string" &&
+      typeof state.generatedAt === "string"
+      ? (state as DevBuildState)
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 async function hasRuffleRuntime(jsDir: string): Promise<boolean> {
-	try {
-		const names = await readdir(jsDir);
-		return (
-			names.includes("ruffle.js") &&
-			names.some(
-				(name) => name.startsWith("core.ruffle.") && name.endsWith(".js"),
-			) &&
-			names.some((name) => name.endsWith(".wasm"))
-		);
-	} catch {
-		return false;
-	}
+  try {
+    const names = await readdir(jsDir);
+    return (
+      names.includes("ruffle.js") &&
+      names.some(
+        (name) => name.startsWith("core.ruffle.") && name.endsWith(".js"),
+      ) &&
+      names.some((name) => name.endsWith(".wasm"))
+    );
+  } catch {
+    return false;
+  }
 }
 
 async function copyRuffleRuntime(
-	sourceJsDir: string,
-	destinationJsDir: string,
+  sourceJsDir: string,
+  destinationJsDir: string,
 ): Promise<void> {
-	const names = (await readdir(sourceJsDir)).filter(
-		(name) =>
-			name === "ruffle.js" ||
-			name === "ruffle.js.map" ||
-			name.startsWith("core.ruffle.") ||
-			name.endsWith(".wasm"),
-	);
-	await mkdir(destinationJsDir, { recursive: true });
-	await Promise.all(
-		names.map((name) =>
-			cp(join(sourceJsDir, name), join(destinationJsDir, name), {
-				preserveTimestamps: true,
-			}),
-		),
-	);
+  const names = (await readdir(sourceJsDir)).filter(
+    (name) =>
+      name === "ruffle.js" ||
+      name === "ruffle.js.map" ||
+      name.startsWith("core.ruffle.") ||
+      name.endsWith(".wasm"),
+  );
+  await mkdir(destinationJsDir, { recursive: true });
+  await Promise.all(
+    names.map((name) =>
+      cp(join(sourceJsDir, name), join(destinationJsDir, name), {
+        preserveTimestamps: true,
+      }),
+    ),
+  );
 }
 
 export async function ensureDevelopmentBuild({
-	outputDir = DEFAULT_OUTPUT_DIR,
-	force = false,
-	projectDir = PROJECT_DIR,
-	fingerprint = () => computeSourceFingerprint(projectDir),
-	releaseKey = currentRuffleReleaseKey,
-	builder,
+  outputDir = DEFAULT_OUTPUT_DIR,
+  force = false,
+  projectDir = PROJECT_DIR,
+  fingerprint = () => computeSourceFingerprint(projectDir),
+  releaseKey = currentRuffleReleaseKey,
+  builder,
 }: EnsureDevelopmentBuildOptions = {}): Promise<EnsureDevelopmentBuildResult> {
-	const resolvedOutput = resolve(outputDir);
-	const [sourceFingerprint, ruffleRelease, previousState] = await Promise.all([
-		fingerprint(),
-		releaseKey(),
-		readBuildState(resolvedOutput),
-	]);
-	const hasIndex = await Bun.file(join(resolvedOutput, "index.html")).exists();
-	if (
-		!force &&
-		hasIndex &&
-		previousState?.fingerprint === sourceFingerprint &&
-		previousState.ruffleRelease === ruffleRelease
-	) {
-		console.log("Development build is already in sync.");
-		return { rebuilt: false, reusedRuffle: false };
-	}
+  const resolvedOutput = resolve(outputDir);
+  const [sourceFingerprint, ruffleRelease, previousState] = await Promise.all([
+    fingerprint(),
+    releaseKey(),
+    readBuildState(resolvedOutput),
+  ]);
+  const hasIndex = await Bun.file(join(resolvedOutput, "index.html")).exists();
+  if (
+    !force &&
+    hasIndex &&
+    previousState?.fingerprint === sourceFingerprint &&
+    previousState.ruffleRelease === ruffleRelease
+  ) {
+    console.log("Development build is already in sync.");
+    return { rebuilt: false, reusedRuffle: false };
+  }
 
-	const sourceJsDir = join(resolvedOutput, "js");
-	const canReuseRuffle =
-		previousState?.ruffleRelease === ruffleRelease &&
-		(await hasRuffleRuntime(sourceJsDir));
-	const startedAt = performance.now();
-	console.log(
-		hasIndex
-			? "Development build is stale; rebuilding..."
-			: "Development build is missing; building...",
-	);
-	const selectedBuilder = builder ?? (await import("./deploy")).build;
-	await selectedBuilder({
-		outputDir: resolvedOutput,
-		...(canReuseRuffle
-			? {
-					download: (destinationJsDir: string) =>
-						copyRuffleRuntime(sourceJsDir, destinationJsDir),
-				}
-			: {}),
-	});
-	const state: DevBuildState = {
-		schema: 1,
-		fingerprint: sourceFingerprint,
-		ruffleRelease,
-		generatedAt: new Date().toISOString(),
-	};
-	await writeFile(
-		join(resolvedOutput, DEV_BUILD_STATE),
-		`${JSON.stringify(state)}\n`,
-	);
-	console.log(
-		`Development build synchronized in ${((performance.now() - startedAt) / 1000).toFixed(2)}s${canReuseRuffle ? " (reused Ruffle)" : ""}.`,
-	);
-	return { rebuilt: true, reusedRuffle: canReuseRuffle };
+  const sourceJsDir = join(resolvedOutput, "js");
+  const canReuseRuffle =
+    previousState?.ruffleRelease === ruffleRelease &&
+    (await hasRuffleRuntime(sourceJsDir));
+  const startedAt = performance.now();
+  console.log(
+    hasIndex
+      ? "Development build is stale; rebuilding..."
+      : "Development build is missing; building...",
+  );
+  const selectedBuilder = builder ?? (await import("./deploy")).build;
+  await selectedBuilder({
+    outputDir: resolvedOutput,
+    ...(canReuseRuffle
+      ? {
+          download: (destinationJsDir: string) =>
+            copyRuffleRuntime(sourceJsDir, destinationJsDir),
+        }
+      : {}),
+  });
+  const state: DevBuildState = {
+    schema: 1,
+    fingerprint: sourceFingerprint,
+    ruffleRelease,
+    generatedAt: new Date().toISOString(),
+  };
+  await writeFile(
+    join(resolvedOutput, DEV_BUILD_STATE),
+    `${JSON.stringify(state)}\n`,
+  );
+  console.log(
+    `Development build synchronized in ${((performance.now() - startedAt) / 1000).toFixed(2)}s${canReuseRuffle ? " (reused Ruffle)" : ""}.`,
+  );
+  return { rebuilt: true, reusedRuffle: canReuseRuffle };
 }
 
 function noCacheHeaders(extra: HeadersInit = {}): Headers {
-	const headers = new Headers(extra);
-	headers.set(
-		"Cache-Control",
-		"no-store, no-cache, must-revalidate, max-age=0",
-	);
-	headers.set("Expires", "0");
-	headers.set("Pragma", "no-cache");
-	return headers;
+  const headers = new Headers(extra);
+  headers.set(
+    "Cache-Control",
+    "no-store, no-cache, must-revalidate, max-age=0",
+  );
+  headers.set("Expires", "0");
+  headers.set("Pragma", "no-cache");
+  return headers;
 }
 
 async function staticResponse(
-	request: Request,
-	directory: string,
+  request: Request,
+  directory: string,
 ): Promise<Response> {
-	if (request.method !== "GET" && request.method !== "HEAD") {
-		return new Response("Method not allowed.", {
-			status: 405,
-			headers: noCacheHeaders({ Allow: "GET, HEAD" }),
-		});
-	}
-	const url = new URL(request.url);
-	let pathname: string;
-	try {
-		pathname = decodeURIComponent(url.pathname);
-	} catch {
-		return new Response("Bad request.", {
-			status: 400,
-			headers: noCacheHeaders(),
-		});
-	}
-	const root = resolve(directory);
-	let path = resolve(root, `.${pathname}`);
-	if (path !== root && !path.startsWith(`${root}${sep}`)) {
-		return new Response("Not found.", {
-			status: 404,
-			headers: noCacheHeaders(),
-		});
-	}
-	try {
-		if ((await stat(path)).isDirectory()) path = join(path, "index.html");
-	} catch {
-		return new Response("Not found.", {
-			status: 404,
-			headers: noCacheHeaders(),
-		});
-	}
-	const file = Bun.file(path);
-	if (!(await file.exists())) {
-		return new Response("Not found.", {
-			status: 404,
-			headers: noCacheHeaders(),
-		});
-	}
-	return new Response(request.method === "HEAD" ? null : file, {
-		headers: noCacheHeaders({
-			"Content-Length": String(file.size),
-			"Content-Type": file.type || "application/octet-stream",
-		}),
-	});
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method not allowed.", {
+      status: 405,
+      headers: noCacheHeaders({ Allow: "GET, HEAD" }),
+    });
+  }
+  const url = new URL(request.url);
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(url.pathname);
+  } catch {
+    return new Response("Bad request.", {
+      status: 400,
+      headers: noCacheHeaders(),
+    });
+  }
+  const root = resolve(directory);
+  let path = resolve(root, `.${pathname}`);
+  if (path !== root && !path.startsWith(`${root}${sep}`)) {
+    return new Response("Not found.", {
+      status: 404,
+      headers: noCacheHeaders(),
+    });
+  }
+  try {
+    if ((await stat(path)).isDirectory()) path = join(path, "index.html");
+  } catch {
+    return new Response("Not found.", {
+      status: 404,
+      headers: noCacheHeaders(),
+    });
+  }
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    return new Response("Not found.", {
+      status: 404,
+      headers: noCacheHeaders(),
+    });
+  }
+  return new Response(request.method === "HEAD" ? null : file, {
+    headers: noCacheHeaders({
+      "Content-Length": String(file.size),
+      "Content-Type": file.type || "application/octet-stream",
+    }),
+  });
 }
 
 export function createRequestHandler(
-	directory: string,
-	fetcher: CatalogFetcher = fetch,
+  directory: string,
+  fetcher: CatalogFetcher = fetch,
 ): (request: Request) => Promise<Response> {
-	return (request) => {
-		const path = new URL(request.url).pathname;
-		if (path === "/api/games" || path.startsWith("/api/games/")) {
-			return handleCatalogRequest(request, fetcher);
-		}
-		return staticResponse(request, directory);
-	};
+  return (request) => {
+    const path = new URL(request.url).pathname;
+    if (path === "/api/games" || path.startsWith("/api/games/")) {
+      return handleCatalogRequest(request, fetcher);
+    }
+    return staticResponse(request, directory);
+  };
 }
 
 interface ServerArguments {
-	directory: string;
-	force: boolean;
-	hostname: string;
-	port: number;
-	sync: boolean;
+  directory: string;
+  force: boolean;
+  hostname: string;
+  port: number;
+  sync: boolean;
 }
 
 function parseArguments(arguments_: string[]): ServerArguments {
-	const parsed: ServerArguments = {
-		directory: DEFAULT_OUTPUT_DIR,
-		force: false,
-		hostname: "127.0.0.1",
-		port: 8000,
-		sync: true,
-	};
-	for (let index = 0; index < arguments_.length; index += 1) {
-		const argument = arguments_[index];
-		if (argument === "--rebuild") {
-			parsed.force = true;
-			continue;
-		}
-		if (argument === "--no-sync") {
-			parsed.sync = false;
-			continue;
-		}
-		if (
-			argument === "--directory" ||
-			argument === "--hostname" ||
-			argument === "--port"
-		) {
-			const value = arguments_[index + 1];
-			if (!value) throw new Error(`${argument} requires a value`);
-			if (argument === "--directory") parsed.directory = resolve(value);
-			else if (argument === "--hostname") parsed.hostname = value;
-			else {
-				parsed.port = Number(value);
-				if (!Number.isInteger(parsed.port) || parsed.port < 0 || parsed.port > 65535) {
-					throw new Error("--port must be an integer between 0 and 65535");
-				}
-			}
-			index += 1;
-			continue;
-		}
-		throw new Error(`Unknown argument: ${argument}`);
-	}
-	return parsed;
+  const parsed: ServerArguments = {
+    directory: DEFAULT_OUTPUT_DIR,
+    force: false,
+    hostname: "127.0.0.1",
+    port: 8000,
+    sync: true,
+  };
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === "--rebuild") {
+      parsed.force = true;
+      continue;
+    }
+    if (argument === "--no-sync") {
+      parsed.sync = false;
+      continue;
+    }
+    if (
+      argument === "--directory" ||
+      argument === "--hostname" ||
+      argument === "--port"
+    ) {
+      const value = arguments_[index + 1];
+      if (!value) throw new Error(`${argument} requires a value`);
+      if (argument === "--directory") parsed.directory = resolve(value);
+      else if (argument === "--hostname") parsed.hostname = value;
+      else {
+        parsed.port = Number(value);
+        if (
+          !Number.isInteger(parsed.port) ||
+          parsed.port < 0 ||
+          parsed.port > 65535
+        ) {
+          throw new Error("--port must be an integer between 0 and 65535");
+        }
+      }
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+  return parsed;
 }
 
 if (import.meta.main) {
-	try {
-		const arguments_ = parseArguments(Bun.argv.slice(2));
-		if (arguments_.sync) {
-			await ensureDevelopmentBuild({
-				outputDir: arguments_.directory,
-				force: arguments_.force,
-			});
-		} else if (!(await Bun.file(join(arguments_.directory, "index.html")).exists())) {
-			throw new Error(
-				`${arguments_.directory} is not built; omit --no-sync or run \`bun run build\``,
-			);
-		}
-		const server = Bun.serve({
-			hostname: arguments_.hostname,
-			port: arguments_.port,
-			fetch: createRequestHandler(arguments_.directory),
-			error(error) {
-				console.error(error);
-				return new Response("Internal server error.", {
-					status: 500,
-					headers: noCacheHeaders(),
-				});
-			},
-		});
-		console.log(`Server running on ${server.url}`);
-	} catch (error) {
-		console.error(error instanceof Error ? error.message : error);
-		process.exitCode = 1;
-	}
+  try {
+    const arguments_ = parseArguments(Bun.argv.slice(2));
+    if (arguments_.sync) {
+      await ensureDevelopmentBuild({
+        outputDir: arguments_.directory,
+        force: arguments_.force,
+      });
+    } else if (
+      !(await Bun.file(join(arguments_.directory, "index.html")).exists())
+    ) {
+      throw new Error(
+        `${arguments_.directory} is not built; omit --no-sync or run \`bun run build\``,
+      );
+    }
+    const server = Bun.serve({
+      hostname: arguments_.hostname,
+      port: arguments_.port,
+      fetch: createRequestHandler(arguments_.directory),
+      error(error) {
+        console.error(error);
+        return new Response("Internal server error.", {
+          status: 500,
+          headers: noCacheHeaders(),
+        });
+      },
+    });
+    console.log(`Server running on ${server.url}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
 }

--- a/worker/catalog-worker.ts
+++ b/worker/catalog-worker.ts
@@ -1,7 +1,7 @@
 import { handleCatalogRequest } from "../catalog/catalog";
 
 export default {
-	fetch(request: Request): Promise<Response> {
-		return handleCatalogRequest(request);
-	},
+  fetch(request: Request): Promise<Response> {
+    return handleCatalogRequest(request);
+  },
 };


### PR DESCRIPTION
## Summary

- add pinned ESLint and Prettier tooling with two-space formatting
- lint authored browser JavaScript and TypeScript while excluding vendored/generated assets
- add local format, lint, and quality scripts
- enforce formatting and linting before tests in the Pages workflow
- apply the initial formatting baseline

## Why

The project had TypeScript and custom runtime validators, but no consistent formatter or general-purpose linter and no CI gate for either. The initial lint pass also exposed a desktop icon snap-to-grid scope bug and a few dead parameters/locals, which are fixed here.

TypeScript 7 remains the compiler used by `tsc`; TypeScript 6 is installed alongside it to provide the programmatic API currently required by typescript-eslint.

## Impact

Contributors can run `bun run format`, `bun run lint`, or the combined read-only `bun run quality`. Pull requests now fail before tests/build if authored files are not formatted or lint-clean. Vendored games, SWFs, generated output, and third-party runtime files remain untouched.

## Validation

- `bun install --frozen-lockfile`
- `bun run quality`
- `bun run test` — 92 passed
- `bun run build`
- `git diff --check`