### PR TITLE
Remove source cache-busting tags

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <title>Astro Flash Collection</title>
-    <script src="js/ruffle.js?v=bf02ea2d"></script>
-    <script src="vendor/fflate/0.8.3/index.js?v=dev"></script>
-    <script src="js/games.js?v=a5b45b42"></script>
-    <script src="js/game-installer.js?v=dev"></script>
-    <script src="js/game-library.js?v=dev"></script>
-    <script src="js/filesystem.js?v=750917fa"></script>
-    <script src="js/file-operations.js?v=f2bf59d7"></script>
-    <script src="js/dialogs.js?v=63482d98"></script>
-    <script src="js/offline.js?v=1"></script>
-    <script src="js/main.js?v=2b29c40f"></script>
-    <link rel="stylesheet" href="css/main.css?v=6194f8c9" />
+    <script src="js/ruffle.js"></script>
+    <script src="vendor/fflate/0.8.3/index.js"></script>
+    <script src="js/games.js"></script>
+    <script src="js/game-installer.js"></script>
+    <script src="js/game-library.js"></script>
+    <script src="js/filesystem.js"></script>
+    <script src="js/file-operations.js"></script>
+    <script src="js/dialogs.js"></script>
+    <script src="js/offline.js"></script>
+    <script src="js/main.js"></script>
+    <link rel="stylesheet" href="css/main.css" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary

Remove the stale and placeholder `?v=` query parameters from the source `site/index.html` asset references.

## Why

The production build calculates each asset's content hash and writes the resulting `?v=<hash>` references into `dist/index.html`. Keeping old hashes, numeric placeholders, and `dev` values in the source file is unnecessary and makes the source of truth unclear.

## Impact

Source asset references are now clean paths. Production cache busting is unchanged: the build still injects eight-character content hashes into the generated output.

## Validation

- `bun run quality`
- `bun run test` — 92 passed
- `bun run build`
- confirmed generated `dist/index.html` contains `?v=<hash>` for every managed asset
- `git diff --check`