### PR TITLE
Fix offline update cache poisoning

### DIFF
--- a/site/js/main.js
+++ b/site/js/main.js
@@ -4931,6 +4931,8 @@ const offlineStatusText = (state) => {
       ? "An update is downloading..."
       : "An update is available.",
     "update-ready": "An update is ready. Restart Astro Flash to apply it.",
+    "repair-required":
+      "The installed update is incomplete. Repair the system files.",
     applying: "Applying the update...",
     repairing: "Clearing and downloading system files again...",
     error: "Offline system files are incomplete.",

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -12,6 +12,7 @@
   const DOWNLOAD_VERSION_KEY = "astroFlashDownloadVersion";
   const DOWNLOAD_BYTES_KEY = "astroFlashDownloadBytes";
   const GAME_RECORDS_KEY = "astroFlashOfflineGameRecords";
+  const ACTIVE_VERSION_RELOAD_KEY = "astroFlashActiveVersionReload";
   const BUNDLED_GAME_CACHE = "astro-bundled-games-v1";
   const DEFAULT_CHECK_INTERVAL = 60 * 60 * 1000;
 
@@ -102,6 +103,7 @@
   }) => {
     const navigatorObject = environment.navigator;
     const storage = environment.localStorage;
+    const sessionStorage = environment.sessionStorage || storage;
     const listeners = new Set();
     const trackedRegistrations = new WeakSet();
     const trackedWorkers = new WeakSet();
@@ -111,6 +113,33 @@
     let checkPromise = null;
     let reloadWhenControlled = false;
     let lifecycleListenersAttached = false;
+
+    const requestWorkerVersion = (worker) =>
+      new Promise((resolve) => {
+        const MessageChannelConstructor =
+          environment.MessageChannel || globalThis.MessageChannel;
+        if (!worker || !MessageChannelConstructor) {
+          resolve(null);
+          return;
+        }
+        const channel = new MessageChannelConstructor();
+        let settled = false;
+        const finish = (version = null) => {
+          if (settled) return;
+          settled = true;
+          channel.port1.close?.();
+          channel.port2.close?.();
+          resolve(typeof version === "string" ? version : null);
+        };
+        channel.port1.onmessage = (event) => finish(event.data?.version);
+        try {
+          worker.postMessage({ type: "GET_VERSION" }, [channel.port2]);
+        } catch {
+          finish();
+          return;
+        }
+        (environment.setTimeout || setTimeout)(() => finish(), 250);
+      });
 
     const cachedDownloadBytes =
       storage.getItem(DOWNLOAD_VERSION_KEY) === currentVersion
@@ -222,6 +251,35 @@
       });
     };
 
+    const reconcileActiveVersion = async (targetVersion) => {
+      if (!targetVersion || targetVersion === currentVersion) {
+        sessionStorage.removeItem?.(ACTIVE_VERSION_RELOAD_KEY);
+        return false;
+      }
+      const activeVersion = await requestWorkerVersion(registration?.active);
+      if (activeVersion !== targetVersion) return false;
+
+      setState({
+        availableVersion: targetVersion,
+        availableRevision: targetVersion.split("-").at(-1) || null,
+      });
+      if (sessionStorage.getItem(ACTIVE_VERSION_RELOAD_KEY) === targetVersion) {
+        setState({
+          phase: "repair-required",
+          updateReady: false,
+          workerState: "active",
+          error:
+            "The active update contains inconsistent system files. Repair System Files to download a clean copy.",
+        });
+        return true;
+      }
+
+      sessionStorage.setItem(ACTIVE_VERSION_RELOAD_KEY, targetVersion);
+      setState({ phase: "applying", error: null });
+      environment.location.reload();
+      return true;
+    };
+
     const trackInstallingWorker = (worker, isUpdate) => {
       if (!worker || trackedWorkers.has(worker)) return;
       trackedWorkers.add(worker);
@@ -232,16 +290,22 @@
       });
       worker.addEventListener("statechange", () => {
         setState({ workerState: worker.state });
-        if (worker.state === "installed" && registration?.waiting && isUpdate) {
-          void markWaitingUpdate(registration.waiting);
+        if (worker.state === "installed" && isUpdate) {
+          (environment.setTimeout || setTimeout)(() => {
+            if (registration?.waiting) {
+              void markWaitingUpdate(registration.waiting);
+            }
+          }, 0);
         } else if (worker.state === "activated" && !isUpdate) {
           setState({ phase: "ready", workerState: "active", error: null });
           void refreshStorageEstimate();
-        } else if (worker.state === "redundant" && !registration?.active) {
+        } else if (worker.state === "redundant") {
           setState({
             phase: "error",
             workerState: "failed",
-            error: "The system-file download did not complete.",
+            error: isUpdate
+              ? "The update download did not complete. Repair System Files and try again."
+              : "The system-file download did not complete.",
           });
         }
       });
@@ -561,9 +625,21 @@
           rememberVersionMetadata(metadata);
           if (!registration) await registerAndWait();
           await registration.update();
+          if (registration.waiting) {
+            await markWaitingUpdate(registration.waiting);
+          } else if (registration.installing) {
+            trackInstallingWorker(registration.installing, true);
+          }
           const checkedAt = environment.Date.now();
           storage.setItem(LAST_CHECKED_KEY, String(checkedAt));
           const updateAvailable = metadata.version !== currentVersion;
+          if (
+            updateAvailable &&
+            (await reconcileActiveVersion(metadata.version))
+          ) {
+            setState({ lastChecked: checkedAt });
+            return;
+          }
           setState({
             phase: updateAvailable
               ? registration?.waiting
@@ -624,6 +700,7 @@
       if (navigatorObject.onLine === false) {
         throw new Error("Connect to the internet to repair system files.");
       }
+      sessionStorage.removeItem?.(ACTIVE_VERSION_RELOAD_KEY);
       setState({ phase: "repairing", error: null });
       const currentRegistration =
         registration ||
@@ -676,6 +753,14 @@
       try {
         await registerAndWait();
         await loadGameManifest();
+        const knownVersion = storage.getItem(DOWNLOAD_VERSION_KEY);
+        if (
+          knownVersion &&
+          knownVersion !== currentVersion &&
+          (await reconcileActiveVersion(knownVersion))
+        ) {
+          return snapshot();
+        }
         automaticCheck();
         void syncDownloadedGames().catch((error) => {
           setState({ gamePhase: "error", gameError: error.message });

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -21,7 +21,6 @@ import {
   downloadRuffle,
   generateServiceWorker,
   getDeploymentVersion,
-  getShortHash,
   loadRuffleRelease,
   updateHtml,
   validateOutput,
@@ -93,6 +92,7 @@ async function makeSource(root: string): Promise<void> {
       '<script src="js/main.js?v=old"></script>',
       '<link rel="stylesheet" href="css/main.css?v=old">',
     ].join("\n"),
+    "capture.html": '<script src="js/ruffle.js?v=old"></script>',
     "js/games.js": "games",
     "js/game-installer.js": "game installer",
     "js/game-library.js": "game library",
@@ -225,23 +225,23 @@ describe("build metadata", () => {
     await addGeneratedRuntime(root);
     const paths = new BuildPaths(root);
 
-    await updateHtml(paths, "26.07.28-abcdef1");
+    const hashedAssets = await updateHtml(paths, "26.07.28-abcdef1");
     await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
     await writeVersionMetadata(paths, "26.07.28-abcdef1");
 
-    const main = await readFile(paths.mainJs, "utf8");
+    const main = await readFile(join(root, hashedAssets.mainJs), "utf8");
     const html = await readFile(paths.html, "utf8");
     expect(main).toContain('const APP_VERSION = "26.07.28-abcdef1";');
-    expect(html).toContain(`js/main.js?v=${await getShortHash(paths.mainJs)}"`);
-    expect(html).toContain(
-      `js/game-installer.js?v=${await getShortHash(join(paths.js, "game-installer.js"))}"`,
+    expect(html).toContain(`${hashedAssets.mainJs}"`);
+    expect(html).toContain(`${hashedAssets.gameInstallerJs}"`);
+    expect(html).toContain(`${hashedAssets.gameLibraryJs}"`);
+    expect(html).toContain(`${hashedAssets.fileOperationsJs}"`);
+    expect(html).toContain(`${hashedAssets.mainCss}"`);
+    expect(await readFile(paths.captureHtml, "utf8")).toContain(
+      `${hashedAssets.ruffle}"`,
     );
-    expect(html).toContain(
-      `js/game-library.js?v=${await getShortHash(join(paths.js, "game-library.js"))}"`,
-    );
-    expect(html).toContain(
-      `js/file-operations.js?v=${await getShortHash(join(paths.js, "file-operations.js"))}"`,
-    );
+    expect(await Bun.file(join(root, "js", "main.js")).exists()).toBeFalse();
+    expect(await Bun.file(join(root, "css", "main.css")).exists()).toBeFalse();
     expect(PRECACHE_FILE_SUFFIXES.has(".ttf")).toBeTrue();
 
     const metadata = JSON.parse(await readFile(paths.versionJson, "utf8"));
@@ -287,23 +287,46 @@ describe("build metadata", () => {
       updateHtml(new BuildPaths(root), "26.07.28-abcdef1"),
     ).rejects.toThrow("Could not update asset reference");
   });
+
+  test("rejects a hashed filename that does not match its content", async () => {
+    const root = await makeTemporaryDirectory();
+    await makeSource(root);
+    await addGeneratedRuntime(root);
+    const paths = new BuildPaths(root);
+    const hashedAssets = await updateHtml(paths, "26.07.28-abcdef1");
+    await writeFile(join(root, hashedAssets.mainJs), "tampered");
+    await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
+    await writeVersionMetadata(paths, "26.07.28-abcdef1");
+    await expect(validateOutput(root)).rejects.toThrow(
+      "invalid content hash for js/main.js",
+    );
+  });
 });
 
 describe("Workbox and artifact validation", () => {
   test("accepts a generated worker with its runtime", async () => {
     const root = await makeTemporaryDirectory();
+    await writeFiles(root, {
+      "js/offline-worker.12345678.js": "offline worker",
+    });
     const generator = async () => {
       await addGeneratedRuntime(root);
       return { count: 1, size: 1, warnings: [], filePaths: [] };
     };
-    await generateServiceWorker(root, generator as any);
+    await generateServiceWorker(root, generator as any, "26.07.28-abcdef1");
     expect(
       await Bun.file(join(root, "workbox-f9030226.js")).exists(),
     ).toBeTrue();
+    expect(await readFile(join(root, "sw.js"), "utf8")).toContain(
+      'self.__ASTRO_FLASH_VERSION__="26.07.28-abcdef1"',
+    );
   });
 
   test("rejects a generated worker with a missing runtime", async () => {
     const root = await makeTemporaryDirectory();
+    await writeFiles(root, {
+      "js/offline-worker.12345678.js": "offline worker",
+    });
     const generator = async () => {
       await writeFile(
         join(root, "sw.js"),

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -32,16 +32,21 @@ test("offline updates", async () => {
   }
 
   class Worker extends Events {
-    constructor(state = "activated") {
+    constructor(state = "activated", version = null) {
       super();
       this.state = state;
+      this.version = version;
       this.messages = [];
     }
     transition(state) {
       this.state = state;
       this.dispatch("statechange");
     }
-    postMessage(message) {
+    postMessage(message, ports = []) {
+      if (message.type === "GET_VERSION") {
+        if (this.version) ports[0]?.postMessage({ version: this.version });
+        return;
+      }
       this.messages.push(message);
     }
   }
@@ -72,6 +77,9 @@ test("offline updates", async () => {
     }
     setItem(key, value) {
       this.values.set(key, String(value));
+    }
+    removeItem(key) {
+      this.values.delete(key);
     }
   }
 
@@ -114,9 +122,12 @@ test("offline updates", async () => {
   };
 
   const makeEnvironment = ({
-    registration = new Registration({ active: new Worker() }),
+    registration = new Registration({
+      active: new Worker("activated", manifest.version),
+    }),
     remoteVersion = "26.07.29-aaaaaaa",
     storageValues = {},
+    sessionValues = {},
   } = {}) => {
     const serviceWorker = new Events();
     serviceWorker.controller = registration.active;
@@ -134,6 +145,7 @@ test("offline updates", async () => {
       astroFlashLastUpdateCheck: "1800000000000",
       ...storageValues,
     });
+    const sessionStorage = new MemoryStorage(sessionValues);
     let reloads = 0;
     const environment = new Events();
     Object.assign(environment, {
@@ -145,6 +157,8 @@ test("offline updates", async () => {
         },
       },
       localStorage: storage,
+      sessionStorage,
+      MessageChannel,
       location: {
         href: "https://flash.example/",
         origin: "https://flash.example",
@@ -190,6 +204,7 @@ test("offline updates", async () => {
       registration,
       serviceWorker,
       storage,
+      sessionStorage,
     };
   };
 
@@ -283,7 +298,9 @@ test("offline updates", async () => {
     manifest.runtime.revision,
   );
 
-  const updateRegistration = new Registration({ active: new Worker() });
+  const updateRegistration = new Registration({
+    active: new Worker("activated", manifest.version),
+  });
   const update = makeEnvironment({
     registration: updateRegistration,
     remoteVersion: "26.07.30-bbbbbbb",
@@ -306,4 +323,58 @@ test("offline updates", async () => {
   assert.deepStrictEqual(waitingWorker.messages, [{ type: "SKIP_WAITING" }]);
   update.serviceWorker.dispatch("controllerchange");
   assert.strictEqual(update.getReloads(), 1);
+
+  const activatedUpdate = makeEnvironment({
+    registration: new Registration({
+      active: new Worker("activated", "26.07.30-bbbbbbb"),
+    }),
+    remoteVersion: "26.07.30-bbbbbbb",
+  });
+  const activatedManager = createManager({
+    currentVersion: manifest.version,
+    environment: activatedUpdate.environment,
+  });
+  await activatedManager.initialize();
+  await activatedManager.checkForUpdates();
+  assert.strictEqual(activatedUpdate.getReloads(), 1);
+
+  const inconsistentUpdate = makeEnvironment({
+    registration: new Registration({
+      active: new Worker("activated", "26.07.30-bbbbbbb"),
+    }),
+    remoteVersion: "26.07.30-bbbbbbb",
+    sessionValues: {
+      astroFlashActiveVersionReload: "26.07.30-bbbbbbb",
+    },
+  });
+  const inconsistentManager = createManager({
+    currentVersion: manifest.version,
+    environment: inconsistentUpdate.environment,
+  });
+  await inconsistentManager.initialize();
+  await inconsistentManager.checkForUpdates();
+  assert.strictEqual(inconsistentUpdate.getReloads(), 0);
+  assert.strictEqual(
+    inconsistentManager.getSnapshot().phase,
+    "repair-required",
+  );
+  assert.match(inconsistentManager.getSnapshot().error, /Repair System Files/);
+
+  const failedWorker = new Worker("installing");
+  const failedRegistration = new Registration({
+    active: new Worker("activated", manifest.version),
+    installing: failedWorker,
+  });
+  const failedUpdate = makeEnvironment({
+    registration: failedRegistration,
+    remoteVersion: "26.07.30-bbbbbbb",
+  });
+  const failedManager = createManager({
+    currentVersion: manifest.version,
+    environment: failedUpdate.environment,
+  });
+  await failedManager.initialize();
+  failedWorker.transition("redundant");
+  assert.strictEqual(failedManager.getSnapshot().phase, "error");
+  assert.match(failedManager.getSnapshot().error, /Repair System Files/);
 });

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -668,7 +668,8 @@ test("project controls live in a taskbar window", () => {
     '"dos/**"',
     '"js/*.wasm"',
     '"js/core.ruffle.*.js"',
-    'importScripts: ["js/offline-worker.js"]',
+    "dontCacheBustURLsMatching:",
+    "importScripts: []",
     "skipWaiting: false",
     "clientsClaim: true",
   );

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -116,6 +116,10 @@ export class BuildPaths {
     return join(this.root, "index.html");
   }
 
+  get captureHtml() {
+    return join(this.root, "capture.html");
+  }
+
   get mainJs() {
     return join(this.js, "main.js");
   }
@@ -130,22 +134,6 @@ export class BuildPaths {
 
   get fflateJs() {
     return join(this.root, "vendor", "fflate", FFLATE_VERSION, "index.js");
-  }
-
-  get assetPaths(): Record<string, string> {
-    return {
-      ruffle: join(this.js, "ruffle.js"),
-      fflate: this.fflateJs,
-      gamesJs: join(this.js, "games.js"),
-      gameInstallerJs: join(this.js, "game-installer.js"),
-      gameLibraryJs: join(this.js, "game-library.js"),
-      filesystemJs: join(this.js, "filesystem.js"),
-      fileOperationsJs: join(this.js, "file-operations.js"),
-      dialogsJs: join(this.js, "dialogs.js"),
-      offlineJs: join(this.js, "offline.js"),
-      mainJs: this.mainJs,
-      mainCss: join(this.css, "main.css"),
-    };
   }
 }
 
@@ -335,8 +323,8 @@ export function getDeploymentVersion(
 export async function updateHtml(
   paths: BuildPaths,
   version: string,
-): Promise<void> {
-  console.log("Updating output with version and cache-busting hashes...");
+): Promise<Record<string, string>> {
+  console.log("Updating output with versioned asset filenames...");
   let mainJavaScript = await readFile(paths.mainJs, "utf8");
   mainJavaScript = await replaceExactlyOnce(
     mainJavaScript,
@@ -346,71 +334,71 @@ export async function updateHtml(
   );
   await writeFile(paths.mainJs, mainJavaScript);
 
-  const shortHashes = Object.fromEntries(
+  const mutableAssets = {
+    ruffle: "js/ruffle.js",
+    gamesJs: "js/games.js",
+    gameInstallerJs: "js/game-installer.js",
+    gameLibraryJs: "js/game-library.js",
+    filesystemJs: "js/filesystem.js",
+    fileOperationsJs: "js/file-operations.js",
+    dialogsJs: "js/dialogs.js",
+    offlineJs: "js/offline.js",
+    offlineWorkerJs: "js/offline-worker.js",
+    mainJs: "js/main.js",
+    mainCss: "css/main.css",
+  };
+  const hashedAssets = Object.fromEntries(
     await Promise.all(
-      Object.entries(paths.assetPaths).map(async ([name, path]) => [
-        name,
-        await getShortHash(path),
-      ]),
+      Object.entries(mutableAssets).map(async ([name, relativePath]) => {
+        const sourcePath = join(paths.root, relativePath);
+        const hash = await getShortHash(sourcePath);
+        const extension = extname(relativePath);
+        const hashedRelativePath = `${relativePath.slice(
+          0,
+          -extension.length,
+        )}.${hash}${extension}`;
+        await rename(sourcePath, join(paths.root, hashedRelativePath));
+        return [name, hashedRelativePath];
+      }),
     ),
-  );
+  ) as Record<string, string>;
+  const fflateHash = await getShortHash(paths.fflateJs);
+
   let content = await readFile(paths.html, "utf8");
-  const replacements: [RegExp, string][] = [
-    [
-      /<script src="js\/ruffle\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="js/ruffle.js?v=${shortHashes.ruffle}"></script>`,
-    ],
-    [
-      /<script src="vendor\/fflate\/0\.8\.3\/index\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="vendor/fflate/0.8.3/index.js?v=${shortHashes.fflate}"></script>`,
-    ],
-    [
-      /<script src="js\/games\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="js/games.js?v=${shortHashes.gamesJs}"></script>`,
-    ],
-    [
-      /<script src="js\/game-installer\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="js/game-installer.js?v=${shortHashes.gameInstallerJs}"></script>`,
-    ],
-    [
-      /<script src="js\/game-library\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="js/game-library.js?v=${shortHashes.gameLibraryJs}"></script>`,
-    ],
-    [
-      /<script src="js\/filesystem\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="js/filesystem.js?v=${shortHashes.filesystemJs}"></script>`,
-    ],
-    [
-      /<script src="js\/file-operations\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="js/file-operations.js?v=${shortHashes.fileOperationsJs}"></script>`,
-    ],
-    [
-      /<script src="js\/dialogs\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="js/dialogs.js?v=${shortHashes.dialogsJs}"></script>`,
-    ],
-    [
-      /<script src="js\/offline\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="js/offline.js?v=${shortHashes.offlineJs}"></script>`,
-    ],
-    [
-      /<script src="js\/main\.[^"]+" ?[^>]*><\/script>/g,
-      `<script src="js/main.js?v=${shortHashes.mainJs}"></script>`,
-    ],
-    [
-      /<link rel="stylesheet" href="css\/main\.[^"]+" ?[^>]*>/g,
-      `<link rel="stylesheet" href="css/main.css?v=${shortHashes.mainCss}">`,
-    ],
-  ];
-  for (const [pattern, replacement] of replacements) {
+  for (const [name, originalPath] of Object.entries(mutableAssets)) {
+    if (name === "offlineWorkerJs") continue;
+    const pattern = new RegExp(
+      originalPath.replaceAll(".", "\\.") + '(?:\\?v=[^"]+)?"',
+      "g",
+    );
     content = await replaceExactlyOnce(
       content,
       pattern,
-      replacement,
+      `${hashedAssets[name]}"`,
       `Could not update asset reference matching ${pattern.source}`,
     );
   }
+  const fflatePattern = /vendor\/fflate\/0\.8\.3\/index\.js(?:\?v=[^"]+)?"?/g;
+  content = await replaceExactlyOnce(
+    content,
+    fflatePattern,
+    `vendor/fflate/0.8.3/index.js?v=${fflateHash}"`,
+    "Could not update fflate asset reference",
+  );
   await writeFile(paths.html, content);
+
+  if (await isFile(paths.captureHtml)) {
+    let capture = await readFile(paths.captureHtml, "utf8");
+    capture = await replaceExactlyOnce(
+      capture,
+      /js\/ruffle\.js(?:\?v=[^"]+)?"?/g,
+      `${hashedAssets.ruffle}"`,
+      "Could not update capture Ruffle reference",
+    );
+    await writeFile(paths.captureHtml, capture);
+  }
   console.log(`  - Set deployment version to ${version}`);
+  return hashedAssets;
 }
 
 export function isOptionalOfflinePath(relativePath: string): boolean {
@@ -558,11 +546,21 @@ async function getWorkboxFiles(outputDir: string): Promise<string[]> {
 export async function generateServiceWorker(
   outputDir: string,
   generator: WorkboxGenerator = generateSW,
+  version?: string,
 ): Promise<void> {
   console.log("Generating service worker...");
+  const offlineWorkerNames = (await readdir(join(outputDir, "js"))).filter(
+    (name) => /^offline-worker\.[a-f0-9]{8}\.js$/.test(name),
+  );
+  if (offlineWorkerNames.length !== 1) {
+    throw new Error(
+      "Build output must contain exactly one hashed offline worker",
+    );
+  }
   await generator({
     ...workboxConfig,
     globDirectory: `${resolve(outputDir)}/`,
+    importScripts: [`js/${offlineWorkerNames[0]}`],
     swDest: join(resolve(outputDir), "sw.js"),
   });
 
@@ -570,7 +568,13 @@ export async function generateServiceWorker(
   if (!(await isFile(serviceWorker))) {
     throw new Error("Workbox did not generate output sw.js");
   }
-  const workerSource = await readFile(serviceWorker, "utf8");
+  let workerSource = await readFile(serviceWorker, "utf8");
+  if (version) {
+    workerSource += `\nself.__ASTRO_FLASH_VERSION__=${JSON.stringify(
+      version,
+    )};self.addEventListener("message",event=>{if(event.data?.type==="GET_VERSION")event.ports[0]?.postMessage({version:self.__ASTRO_FLASH_VERSION__})});\n`;
+    await writeFile(serviceWorker, workerSource);
+  }
   const referencedRuntimeNames = new Set(
     [...workerSource.matchAll(/workbox-[a-f0-9]+(?:\.js)?/g)].map((match) =>
       match[0].endsWith(".js") ? match[0] : `${match[0]}.js`,
@@ -630,7 +634,6 @@ export async function validateOutput(outputDir: string): Promise<void> {
   const html = await readFile(paths.html, "utf8");
   for (const asset of [
     "js/ruffle.js",
-    "vendor/fflate/0.8.3/index.js",
     "js/games.js",
     "js/game-installer.js",
     "js/game-library.js",
@@ -641,12 +644,33 @@ export async function validateOutput(outputDir: string): Promise<void> {
     "js/main.js",
     "css/main.css",
   ]) {
+    const [directory, filename] = asset.split("/");
+    const extension = extname(filename);
+    const stem = filename.slice(0, -extension.length);
     const pattern = new RegExp(
-      `${asset.replaceAll(".", "\\.")}\\?v=[a-f0-9]{8}"`,
+      `${directory}/${stem.replaceAll(".", "\\.")}\\.([a-f0-9]{8})\\${extension}"`,
     );
-    if (!pattern.test(html)) {
+    const match = html.match(pattern);
+    if (!match) {
       throw new Error(`Build output has no hashed reference for ${asset}`);
     }
+    const hashedPath = join(outputDir, match[0].slice(0, -1));
+    if (
+      !(await isFile(hashedPath)) ||
+      (await getShortHash(hashedPath)) !== match[1]
+    ) {
+      throw new Error(`Build output has an invalid content hash for ${asset}`);
+    }
+  }
+  if (!/vendor\/fflate\/0\.8\.3\/index\.js\?v=[a-f0-9]{8}"/.test(html)) {
+    throw new Error("Build output has no versioned fflate reference");
+  }
+  if (
+    (await readdir(paths.js)).filter((name) =>
+      /^offline-worker\.[a-f0-9]{8}\.js$/.test(name),
+    ).length !== 1
+  ) {
+    throw new Error("Build output has no uniquely hashed offline worker");
   }
   const jsEntries = await readdir(paths.js);
   if (!jsEntries.some((name) => /^core\.ruffle\..*\.js$/.test(name))) {
@@ -727,7 +751,7 @@ export interface BuildOptions {
   sourceDir?: string;
   version?: string;
   download?: (jsDir: string) => Promise<void>;
-  generate?: (outputDir: string) => Promise<void>;
+  generate?: (outputDir: string, version?: string) => Promise<void>;
 }
 
 export async function build({
@@ -736,7 +760,8 @@ export async function build({
   sourceDir = SOURCE_DIR,
   version,
   download = downloadRuffle,
-  generate = generateServiceWorker,
+  generate = (directory, buildVersion) =>
+    generateServiceWorker(directory, generateSW, buildVersion),
 }: BuildOptions = {}): Promise<void> {
   const resolvedOutput = resolve(outputDir);
   const resolvedSource = resolve(sourceDir);
@@ -767,7 +792,7 @@ export async function build({
     await updateHtml(paths, deploymentVersion);
     await writeOfflineGameManifest(paths, deploymentVersion);
     await writeVersionMetadata(paths, deploymentVersion);
-    await generate(stagingDir);
+    await generate(stagingDir, deploymentVersion);
     await validateOutput(stagingDir);
     await replaceOutput(stagingDir, resolvedOutput);
   } finally {

--- a/workbox-config.ts
+++ b/workbox-config.ts
@@ -17,11 +17,12 @@ export default {
   ],
   swDest: join(outputDirectory, "sw.js"),
   maximumFileSizeToCacheInBytes: 25_000_000,
+  dontCacheBustURLsMatching: /\.[a-f0-9]{8}\.(?:js|css)$/,
   ignoreURLParametersMatching: [/^utm_/, /^fbclid$/, /^v$/],
   sourcemap: false,
   cacheId: "astro-flash",
   cleanupOutdatedCaches: true,
   skipWaiting: false,
   clientsClaim: true,
-  importScripts: ["js/offline-worker.js"],
+  importScripts: [],
 };


### PR DESCRIPTION
## What changed

- emit mutable first-party JavaScript and CSS with content-hashed filenames
- make Workbox use the hashed offline worker and avoid redundant cache-busting parameters for immutable assets
- validate that generated filenames match their actual content
- expose the active service-worker build version to the page
- recover from page/worker version mismatches with one reload, then offer system-file repair instead of looping
- improve failed update detection and test the recovery paths

## Why

GitHub Pages/Fastly could return stale bytes for a stable asset path even when Workbox added a new revision query. Workbox accepted that successful response and stored the old JavaScript under the new precache key, leaving an offline installation unable to finish updating.

Content-addressed paths make each changed asset a genuinely new upstream URL, so correctness no longer depends on query-string handling at either CDN layer.

## Validation

- `bun run test` — 103 tests passed
- `bun run quality`
- `bun run build`
- verified generated hashed JS/CSS paths, hashed offline-worker import, and stamped service-worker version
