### PR TITLE
Hash static shell assets

### DIFF
--- a/site/js/main.js
+++ b/site/js/main.js
@@ -65,6 +65,45 @@ const SIMULATED_RESOLUTIONS = Object.freeze({
   "800x600": { width: 800, height: 600 },
   "1024x768": { width: 1024, height: 768 },
 });
+const XP_ICON_PATHS = Object.freeze({
+  "Back.png": "assets/xp/icons/Back.png",
+  "ControlPanel.png": "assets/xp/icons/ControlPanel.png",
+  "Exit.png": "assets/xp/icons/Exit.png",
+  "FolderView-Classic.png": "assets/xp/icons/FolderView-Classic.png",
+  "FolderView.png": "assets/xp/icons/FolderView.png",
+  "Forward.png": "assets/xp/icons/Forward.png",
+  "Go.png": "assets/xp/icons/Go.png",
+  "HelpandSupport.png": "assets/xp/icons/HelpandSupport.png",
+  "LocalDisk.png": "assets/xp/icons/LocalDisk.png",
+  "Logout.png": "assets/xp/icons/Logout.png",
+  "Maximize.png": "assets/xp/icons/Maximize.png",
+  "Minimize.png": "assets/xp/icons/Minimize.png",
+  "Mute.png": "assets/xp/icons/Mute.png",
+  "MyComputer.png": "assets/xp/icons/MyComputer.png",
+  "MyDocuments.png": "assets/xp/icons/MyDocuments.png",
+  "MyMusic.png": "assets/xp/icons/MyMusic.png",
+  "MyNetworkPlaces.png": "assets/xp/icons/MyNetworkPlaces.png",
+  "MyPictures.png": "assets/xp/icons/MyPictures.png",
+  "NetworkConnection.png": "assets/xp/icons/NetworkConnection.png",
+  "NewFolder.png": "assets/xp/icons/NewFolder.png",
+  "Power.png": "assets/xp/icons/Power.png",
+  "PrintersandFaxes.png": "assets/xp/icons/PrintersandFaxes.png",
+  "Programs.png": "assets/xp/icons/Programs.png",
+  "Publishtoweb.png": "assets/xp/icons/Publishtoweb.png",
+  "RecentDocuments.png": "assets/xp/icons/RecentDocuments.png",
+  "RemovableMedia.png": "assets/xp/icons/RemovableMedia.png",
+  "Restore.png": "assets/xp/icons/Restore.png",
+  "Run.png": "assets/xp/icons/Run.png",
+  "Search.png": "assets/xp/icons/Search.png",
+  "SharedFolder.png": "assets/xp/icons/SharedFolder.png",
+  "Up.png": "assets/xp/icons/Up.png",
+  "Volume.png": "assets/xp/icons/Volume.png",
+  "explorerproperties.png": "assets/xp/icons/explorerproperties.png",
+  "mycomputer.png": "assets/xp/icons/mycomputer.png",
+  "mydocuments.png": "assets/xp/icons/mydocuments.png",
+  "recycler-empty.png": "assets/xp/icons/recycler-empty.png",
+  "shortcut.png": "assets/xp/icons/shortcut.png",
+});
 const TASKBAR_HEIGHT = 30;
 let activeMonitorResolution = "auto";
 
@@ -1872,7 +1911,7 @@ const createSystemWindowContent = (shortcutId, win) => {
     button.type = "button";
     if (place) button.dataset.place = place;
     const image = document.createElement("img");
-    image.src = `assets/xp/icons/${icon}`;
+    image.src = XP_ICON_PATHS[icon];
     image.alt = "";
     const text = document.createElement("span");
     text.textContent = label;
@@ -3381,7 +3420,7 @@ const renderExplorerTaskPane = (win) => {
     button.type = "button";
     button.disabled = disabled;
     const image = document.createElement("img");
-    image.src = `assets/xp/icons/${icon}`;
+    image.src = XP_ICON_PATHS[icon];
     image.alt = "";
     const text = document.createElement("span");
     text.textContent = label;
@@ -3577,7 +3616,7 @@ const createExplorerIcon = (node) => {
   icon.className = "explorer-item-icon";
   const addImage = (fileName) => {
     const image = document.createElement("img");
-    image.src = `assets/xp/icons/${fileName}`;
+    image.src = XP_ICON_PATHS[fileName];
     image.alt = "";
     icon.appendChild(image);
     return icon;
@@ -6707,7 +6746,7 @@ const buildPlaces = () => {
     glyph.className = "sm-place-icon";
     if (icon.endsWith(".png")) {
       const image = document.createElement("img");
-      image.src = `assets/xp/icons/${icon}`;
+      image.src = XP_ICON_PATHS[icon];
       image.alt = "";
       glyph.appendChild(image);
     } else {
@@ -7006,9 +7045,17 @@ const setupSearch = () => {
 
 // Original Windows XP system sounds (playback is skipped if the
 // browser still blocks audio before the user's first interaction)
+const xpSoundPaths = {
+  error: "assets/xp/sounds/error.mp3",
+  logoff: "assets/xp/sounds/logoff.mp3",
+  logon: "assets/xp/sounds/logon.mp3",
+  shutdown: "assets/xp/sounds/shutdown.mp3",
+  startup: "assets/xp/sounds/startup.mp3",
+};
+
 const playXPSound = (name) => {
   const { volume, isMuted } = getMasterVolume();
-  const audio = new Audio(`assets/xp/sounds/${name}.mp3`);
+  const audio = new Audio(xpSoundPaths[name]);
   audio.volume = isMuted ? 0 : Math.min(Math.max(volume, 0), 100) / 100;
   audio.play().catch(() => {});
 };

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -91,9 +91,11 @@ async function makeSource(root: string): Promise<void> {
       '<script src="js/offline.js?v=old"></script>',
       '<script src="js/main.js?v=old"></script>',
       '<link rel="stylesheet" href="css/main.css?v=old">',
+      '<link rel="icon" href="favicon.ico">',
+      '<img src="assets/xp/bliss.jpg">',
     ].join("\n"),
     "capture.html": '<script src="js/ruffle.js?v=old"></script>',
-    "js/games.js": "games",
+    "js/games.js": 'const icon = "assets/icons/game.png";',
     "js/game-installer.js": "game installer",
     "js/game-library.js": "game library",
     "js/filesystem.js": "filesystem",
@@ -101,9 +103,20 @@ async function makeSource(root: string): Promise<void> {
     "js/dialogs.js": "dialogs",
     "js/offline.js": "offline",
     "js/offline-worker.js": "offline worker",
-    "js/main.js": 'const APP_VERSION = "old";\n',
-    "css/main.css": "css",
+    "js/main.js": [
+      'const APP_VERSION = "old";',
+      'const sound = "assets/xp/sounds/startup.mp3";',
+    ].join("\n"),
+    "css/main.css": [
+      '@font-face { src: url("fonts/test.ttf"); }',
+      'body { background: url("../assets/xp/bliss.jpg"); }',
+    ].join("\n"),
     "css/fonts/test.ttf": "font",
+    "assets/icons/game.png": "icon",
+    "assets/icons/SOURCES.json": "{}",
+    "assets/xp/bliss.jpg": "wallpaper",
+    "assets/xp/sounds/startup.mp3": "sound",
+    "favicon.ico": "favicon",
     "vendor/fflate/0.8.3/index.js": "fflate",
     "swf/bike-mania/main.swf": "swf",
     "iframe/doom/index.html": "doom",
@@ -239,6 +252,20 @@ describe("build metadata", () => {
     expect(html).toContain(`${hashedAssets.mainCss}"`);
     expect(await readFile(paths.captureHtml, "utf8")).toContain(
       `${hashedAssets.ruffle}"`,
+    );
+    expect(html).toMatch(/favicon\.[a-f0-9]{8}\.ico"/);
+    expect(html).toMatch(/assets\/xp\/bliss\.[a-f0-9]{8}\.jpg"/);
+    expect(await readFile(join(root, hashedAssets.gamesJs), "utf8")).toMatch(
+      /assets\/icons\/game\.[a-f0-9]{8}\.png/,
+    );
+    expect(await readFile(join(root, hashedAssets.mainJs), "utf8")).toMatch(
+      /assets\/xp\/sounds\/startup\.[a-f0-9]{8}\.mp3/,
+    );
+    expect(await readFile(join(root, hashedAssets.mainCss), "utf8")).toMatch(
+      /fonts\/test\.[a-f0-9]{8}\.ttf/,
+    );
+    expect(await readFile(join(root, hashedAssets.mainCss), "utf8")).toMatch(
+      /\.\.\/assets\/xp\/bliss\.[a-f0-9]{8}\.jpg/,
     );
     expect(await Bun.file(join(root, "js", "main.js")).exists()).toBeFalse();
     expect(await Bun.file(join(root, "css", "main.css")).exists()).toBeFalse();

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -334,6 +334,28 @@ export async function updateHtml(
   );
   await writeFile(paths.mainJs, mainJavaScript);
 
+  const staticPaths = [
+    ...(await walkFiles(join(paths.root, "assets"))),
+    ...(await walkFiles(join(paths.css, "fonts"))),
+    join(paths.root, "favicon.ico"),
+  ];
+  const staticAssets = new Map<string, string>();
+  await Promise.all(
+    staticPaths.map(async (sourcePath) => {
+      const relativePath = relative(paths.root, sourcePath)
+        .split(sep)
+        .join("/");
+      const extension = extname(relativePath);
+      const hash = await getShortHash(sourcePath);
+      const hashedRelativePath = `${relativePath.slice(
+        0,
+        -extension.length,
+      )}.${hash}${extension}`;
+      await rename(sourcePath, join(paths.root, hashedRelativePath));
+      staticAssets.set(relativePath, hashedRelativePath);
+    }),
+  );
+
   const mutableAssets = {
     ruffle: "js/ruffle.js",
     gamesJs: "js/games.js",
@@ -347,6 +369,29 @@ export async function updateHtml(
     mainJs: "js/main.js",
     mainCss: "css/main.css",
   };
+  const referenceFiles = [
+    ...Object.values(mutableAssets).filter(
+      (path) => path !== "js/ruffle.js" && path !== "js/offline-worker.js",
+    ),
+    "index.html",
+    ...((await isFile(paths.captureHtml)) ? ["capture.html"] : []),
+  ];
+  for (const referencePath of referenceFiles) {
+    const absolutePath = join(paths.root, referencePath);
+    let content = await readFile(absolutePath, "utf8");
+    for (const [originalPath, hashedPath] of staticAssets) {
+      content = content.replaceAll(originalPath, hashedPath);
+      if (referencePath.startsWith("css/")) {
+        const originalCssPath = relative("css", originalPath)
+          .split(sep)
+          .join("/");
+        const hashedCssPath = relative("css", hashedPath).split(sep).join("/");
+        content = content.replaceAll(originalCssPath, hashedCssPath);
+      }
+    }
+    await writeFile(absolutePath, content);
+  }
+
   const hashedAssets = Object.fromEntries(
     await Promise.all(
       Object.entries(mutableAssets).map(async ([name, relativePath]) => {
@@ -664,6 +709,72 @@ export async function validateOutput(outputDir: string): Promise<void> {
   }
   if (!/vendor\/fflate\/0\.8\.3\/index\.js\?v=[a-f0-9]{8}"/.test(html)) {
     throw new Error("Build output has no versioned fflate reference");
+  }
+  const staticFiles = [
+    ...(await walkFiles(join(outputDir, "assets"))),
+    ...(await walkFiles(join(outputDir, "css", "fonts"))),
+  ];
+  const favicons = (await readdir(outputDir))
+    .filter((name) => /^favicon\.[a-f0-9]{8}\.ico$/.test(name))
+    .map((name) => join(outputDir, name));
+  if (favicons.length !== 1) {
+    throw new Error("Build output has no uniquely hashed favicon");
+  }
+  for (const path of [...staticFiles, ...favicons]) {
+    const filename = path.split(sep).at(-1) ?? "";
+    const match = filename.match(/\.([a-f0-9]{8})\.[^./]+$/);
+    if (!match || (await getShortHash(path)) !== match[1]) {
+      throw new Error(
+        `Build output has an invalid static asset hash for ${relative(
+          outputDir,
+          path,
+        )}`,
+      );
+    }
+  }
+  const referenceDocuments = [
+    { content: html, path: paths.html },
+    ...((await isFile(paths.captureHtml))
+      ? [
+          {
+            content: await readFile(paths.captureHtml, "utf8"),
+            path: paths.captureHtml,
+          },
+        ]
+      : []),
+  ];
+  for (const match of html.matchAll(
+    /(?:src|href)="((?:js|css)\/[^"]+\.(?:js|css))"/g,
+  )) {
+    referenceDocuments.push({
+      content: await readFile(join(outputDir, match[1]), "utf8"),
+      path: join(outputDir, match[1]),
+    });
+  }
+  for (const document of referenceDocuments) {
+    for (const match of document.content.matchAll(
+      /(?:\.\.\/)?assets\/[^"'`()\s]+|fonts\/[^"'`()\s]+|favicon[^"'`()\s]+/g,
+    )) {
+      const reference = match[0];
+      if (!/\.[a-f0-9]{8}\.[^./]+$/.test(reference)) {
+        throw new Error(
+          `Build output has an unhashed static reference in ${relative(
+            outputDir,
+            document.path,
+          )}: ${reference}`,
+        );
+      }
+      const target = reference.startsWith("../")
+        ? join(outputDir, reference.slice(3))
+        : reference.startsWith("fonts/")
+          ? join(outputDir, "css", reference)
+          : join(outputDir, reference);
+      if (!(await isFile(target))) {
+        throw new Error(
+          `Build output references a missing static asset: ${reference}`,
+        );
+      }
+    }
   }
   if (
     (await readdir(paths.js)).filter((name) =>

--- a/workbox-config.ts
+++ b/workbox-config.ts
@@ -17,7 +17,7 @@ export default {
   ],
   swDest: join(outputDirectory, "sw.js"),
   maximumFileSizeToCacheInBytes: 25_000_000,
-  dontCacheBustURLsMatching: /\.[a-f0-9]{8}\.(?:js|css)$/,
+  dontCacheBustURLsMatching: /\.[a-f0-9]{8}\.[^./]+$/,
   ignoreURLParametersMatching: [/^utm_/, /^fbclid$/, /^v$/],
   sourcemap: false,
   cacheId: "astro-flash",


### PR DESCRIPTION
## What changed

- emit first-party shell images, icons, fonts, sounds, cursors, metadata assets, and the favicon with content-hashed filenames
- rewrite static references in HTML, JavaScript, and CSS before hashing those files
- replace dynamically constructed XP icon and sound URLs with explicit paths that the deployment can rewrite
- treat every content-hashed extension as immutable in Workbox
- reject builds containing incorrect hashes, unhashed static references, or missing referenced assets

## Why

The previous fix protected JavaScript and CSS from stale stable-path responses, but other mutable shell assets could still be cached under an incorrect Workbox revision. Extending content-addressing makes asset identity independent of CDN query-string behavior.

Game packages, versioned vendors, Ruffle runtime chunks, and stable update-discovery files remain outside this logic.

## Validation

- `bun run test` — 103 tests passed
- `bun run quality`
- `bun run build`
- production artifact validation confirmed all shell asset references resolve to files with matching content hashes
