### PR TITLE
Serve reVCDOS assets from packed OPFS storage

### DIFF
--- a/site/iframe/revcdos/SOURCE.md
+++ b/site/iframe/revcdos/SOURCE.md
@@ -8,10 +8,14 @@
 
 The browser runtime, page, modules, and package manifest are vendored from that
 Lolendor commit. Original-game media from the upstream distribution is not
-bundled. Astro Flash does not bundle the compatible game-data package. A small
-local adapter assembles the upstream 135,355,111-byte preload from files
-selected or downloaded by the user and serves remaining assets from the same
-local file set instead of the upstream CDN.
+bundled. Astro Flash does not bundle the compatible game-data package.
+
+Files selected or downloaded by the user are streamed once into a single
+indexed OPFS file. The offline service worker serves slices of that file through
+same-origin HTTP-like requests, including byte ranges. The upstream
+135,355,111-byte preload and remaining runtime assets therefore use normal
+`fetch()`/XHR paths without per-file parent-frame messages. After a torrent is
+packed successfully, its peer connections and piece store are destroyed.
 
 The upstream MIT license is stored in `LOLENDOR-LICENSE`.
 

--- a/site/iframe/revcdos/game.js
+++ b/site/iframe/revcdos/game.js
@@ -7,7 +7,19 @@ var wasm_content = "index.wasm";
 const params = new URLSearchParams(window.location.search);
 
 // Base URLs
-const replaceFetch = (url) => url.replace("https://cdn.dos.zone/vcsky/", "");
+const localAssetUrl = (path) => {
+  const normalized = String(path)
+    .replace("https://cdn.dos.zone/vcsky/", "")
+    .replace(/^\/+/, "");
+  return new URL(
+    `local-assets/${normalized
+      .split("/")
+      .map((part) => encodeURIComponent(part))
+      .join("/")}`,
+    location.href,
+  ).href;
+};
+const replaceFetch = localAssetUrl;
 
 // Configurable mode - show settings UI before play
 const configurableMode = params.get("configurable") === "1";
@@ -185,44 +197,34 @@ function updateAllTranslations() {
     configMaxFpsUnlimited.textContent = t("configUnlimited");
 }
 
-function requestParent(event, payload, responseEvent) {
-  return new Promise((resolve, reject) => {
-    const requestId = crypto.randomUUID();
-    const listener = (messageEvent) => {
-      const data = messageEvent.data;
-      if (
-        messageEvent.source !== window.parent ||
-        messageEvent.origin !== location.origin ||
-        data?.event !== responseEvent ||
-        data.requestId !== requestId
-      ) {
-        return;
-      }
-      window.removeEventListener("message", listener);
-      if (data.error) reject(new Error(data.error));
-      else resolve(data.data);
-    };
-    window.addEventListener("message", listener);
-    window.parent.postMessage(
-      { event, requestId, ...payload },
-      location.origin,
-    );
-  });
-}
-
 async function loadData() {
   setStatus("Preparing local game data…");
-  const files = DATA_PACKAGE.files.map(({ filename, start, end }) => ({
-    path: filename.replace(/^\/+/, ""),
-    start,
-    end,
-  }));
-  const buffer = await requestParent(
-    "module.package",
-    { files, size: DATA_PACKAGE.remote_package_size },
-    ">module.package",
-  );
-  return new Uint8Array(buffer);
+  const packageData = new Uint8Array(DATA_PACKAGE.remote_package_size);
+  let nextFile = 0;
+  let loaded = 0;
+  const workers = Array.from({ length: 8 }, async () => {
+    while (nextFile < DATA_PACKAGE.files.length) {
+      const { filename, start, end } = DATA_PACKAGE.files[nextFile++];
+      const response = await fetch(localAssetUrl(filename), {
+        cache: "no-store",
+      });
+      if (!response.ok) {
+        throw new Error(`Unable to load ${filename}: HTTP ${response.status}`);
+      }
+      const buffer = await response.arrayBuffer();
+      const expectedSize = end - start;
+      if (buffer.byteLength !== expectedSize) {
+        throw new Error(
+          `Unexpected size for ${filename}: expected ${expectedSize}, received ${buffer.byteLength}`,
+        );
+      }
+      packageData.set(new Uint8Array(buffer), start);
+      loaded += buffer.byteLength;
+      setStatus(`Preparing... (${loaded}/${packageData.byteLength})`);
+    }
+  });
+  await Promise.all(workers);
+  return packageData;
 }
 
 async function startGame(e) {
@@ -326,8 +328,6 @@ async function loadGame(data) {
         throw new Error(t("cantContinuePlaying"));
       }
     },
-    fetchLocalAsset: (file) =>
-      requestParent("module.getfile", { file }, ">module.getfile"),
   };
   Module.log = Module.print;
   Module.instantiateWasm = async (info, receiveInstance) => {

--- a/site/iframe/revcdos/index.html
+++ b/site/iframe/revcdos/index.html
@@ -145,6 +145,7 @@
 
     <script type="module">
       import WebTorrent from "../../vendor/webtorrent/3.0.21/webtorrent.min.js";
+      import { loadPackedManifest, packFiles } from "./packed-store.js";
 
       ("use strict");
 
@@ -158,24 +159,7 @@
       const downloadButton = document.getElementById("download-button");
       const setup = document.getElementById("setup");
       const selection = document.getElementById("selection");
-      let files = new Map();
       let gameFrame = null;
-
-      const readFile = (file) => file.arrayBuffer();
-      const normalizeAssetPath = (path) =>
-        String(path).replaceAll("\\", "/").replace(/^\/+/, "").toLowerCase();
-
-      const findAssetFile = (requestedPath) => {
-        const path = normalizeAssetPath(requestedPath);
-        const candidates = [
-          path,
-          path.replace(/^fetched\//, "vc-assets/local/"),
-          path.replace(/^vcsky\/fetched\//, "vc-assets/local/"),
-        ];
-        return candidates
-          .map((candidate) => files.get(candidate))
-          .find(Boolean);
-      };
 
       const cacheEngineForOfflineUse = () => {
         window.parent.postMessage(
@@ -184,8 +168,7 @@
         );
       };
 
-      const startGame = (selectedFiles, message) => {
-        files = selectedFiles;
+      const startGame = (message) => {
         selection.textContent = message;
         gameFrame = document.createElement("iframe");
         gameFrame.src = "game.html";
@@ -197,6 +180,86 @@
       const formatBytes = (bytes) => {
         if (!Number.isFinite(bytes) || bytes <= 0) return "0 MiB";
         return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+      };
+
+      const localAssetUrl = (path) =>
+        `local-assets/${path
+          .split("/")
+          .map((part) => encodeURIComponent(part))
+          .join("/")}`;
+
+      const waitForServiceWorkerController = async () => {
+        await navigator.serviceWorker.ready;
+        if (navigator.serviceWorker.controller) return;
+        await new Promise((resolve, reject) => {
+          const timeout = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  "The offline engine is not ready. Reload Astro Flash and try again.",
+                ),
+              ),
+            10000,
+          );
+          navigator.serviceWorker.addEventListener(
+            "controllerchange",
+            () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+            { once: true },
+          );
+        });
+      };
+
+      const verifyPackedAssets = async (manifest) => {
+        const firstPath = Object.keys(manifest.files)[0];
+        if (!firstPath) throw new Error("The selected folder is empty.");
+        await waitForServiceWorkerController();
+        navigator.serviceWorker.controller.postMessage({
+          type: "REVCDOS_PACK_UPDATED",
+        });
+        const response = await fetch(localAssetUrl(firstPath), {
+          cache: "no-store",
+          headers: { Range: "bytes=0-0" },
+        });
+        if (response.status !== 206) {
+          throw new Error(
+            "The offline data service is not ready. Install any pending Astro Flash update, reload, and try again.",
+          );
+        }
+      };
+
+      const destroyTorrent = (client, torrent) =>
+        new Promise((resolve) => {
+          client.remove(torrent.infoHash, { destroyStore: true }, () =>
+            client.destroy(resolve),
+          );
+        });
+
+      const packAndStart = async (entries, torrentSession) => {
+        downloadButton.disabled = true;
+        input.disabled = true;
+        let lastUpdate = 0;
+        const manifest = await packFiles(entries, (packed, total, path) => {
+          const now = Date.now();
+          if (now - lastUpdate < 100 && packed !== total) return;
+          lastUpdate = now;
+          selection.textContent = `Optimizing offline data… ${(
+            (packed / total) *
+            100
+          ).toFixed(1)}% · ${path}`;
+        });
+        await verifyPackedAssets(manifest);
+        if (torrentSession) {
+          selection.textContent = "Stopping peer connections…";
+          await destroyTorrent(torrentSession.client, torrentSession.torrent);
+          localStorage.removeItem(DOWNLOAD_COMPLETE_KEY);
+        }
+        cacheEngineForOfflineUse();
+        startGame(
+          `${Object.keys(manifest.files).length.toLocaleString()} packed files ready. Starting reVCDOS…`,
+        );
       };
 
       const showProgress = (torrent) => {
@@ -312,11 +375,12 @@
         const cached = localStorage.getItem(DOWNLOAD_COMPLETE_KEY) === "true";
         const estimate = await navigator.storage.estimate();
         const available = (estimate.quota || 0) - (estimate.usage || 0);
-        if (!cached && estimate.quota && available < DOWNLOAD_SIZE) {
+        const packingSpace = cached ? DOWNLOAD_SIZE : DOWNLOAD_SIZE * 2;
+        if (estimate.quota && available < packingSpace) {
           throw new Error(
-            `Not enough browser storage. ${formatBytes(DOWNLOAD_SIZE)} is required and ${formatBytes(
-              available,
-            )} is available.`,
+            `Not enough temporary browser storage. ${formatBytes(
+              packingSpace,
+            )} is required to download and optimize the offline copy, and ${formatBytes(available)} is available.`,
           );
         }
 
@@ -368,6 +432,7 @@
           client.destroy();
           selection.textContent = message;
           downloadButton.disabled = false;
+          input.disabled = false;
           downloadButton.textContent = "Try automatic download again";
         };
 
@@ -420,18 +485,22 @@
         torrent.on("error", (error) =>
           failDownload(`Download failed: ${error.message}`),
         );
-        torrent.on("done", () => {
+        torrent.on("done", async () => {
           if (failed) return;
           clearTimeout(connectionTimer);
           localStorage.setItem(DOWNLOAD_COMPLETE_KEY, "true");
-          cacheEngineForOfflineUse();
-          const downloadedFiles = new Map(
-            torrent.files.map((file) => [file.path.toLowerCase(), file]),
-          );
-          startGame(
-            downloadedFiles,
-            `${downloadedFiles.size.toLocaleString()} files ready. Starting reVCDOS…`,
-          );
+          selection.textContent =
+            "Download complete. Optimizing data for smooth offline play…";
+          try {
+            await packAndStart(
+              torrent.files.map((file) => [file.path, file]),
+              { client, torrent },
+            );
+          } catch (error) {
+            failDownload(
+              `Unable to optimize downloaded data: ${error.message}`,
+            );
+          }
         });
         if (!cached) {
           connectionTimer = setTimeout(() => {
@@ -443,12 +512,6 @@
         }
       };
 
-      downloadButton.disabled = false;
-      downloadButton.textContent =
-        localStorage.getItem(DOWNLOAD_COMPLETE_KEY) === "true"
-          ? "Use downloaded copy"
-          : "Download automatically (860 MiB)";
-
       downloadButton.addEventListener("click", () => {
         downloadGameData().catch((error) => {
           selection.textContent = error.message;
@@ -457,20 +520,21 @@
         });
       });
 
-      input.addEventListener("change", () => {
-        const selectedFiles = new Map(
-          Array.from(input.files).map((file) => [
-            file.webkitRelativePath.toLowerCase(),
-            file,
-          ]),
-        );
-        if (!selectedFiles.size) return;
-
-        cacheEngineForOfflineUse();
-        startGame(
-          selectedFiles,
-          `${selectedFiles.size.toLocaleString()} files selected. Starting reVCDOS…`,
-        );
+      input.addEventListener("change", async () => {
+        const selectedFiles = Array.from(input.files).map((file) => [
+          file.webkitRelativePath,
+          file,
+        ]);
+        if (!selectedFiles.length) return;
+        try {
+          selection.textContent =
+            "Optimizing selected files for smooth offline play…";
+          await packAndStart(selectedFiles);
+        } catch (error) {
+          selection.textContent = `Unable to optimize selected files: ${error.message}`;
+          downloadButton.disabled = false;
+          input.disabled = false;
+        }
       });
 
       window.addEventListener("message", async (event) => {
@@ -478,75 +542,31 @@
         const message = event.data;
         if (!message || typeof message.event !== "string") return;
 
-        if (
-          message.event === "module.package" &&
-          Array.isArray(message.files)
-        ) {
-          try {
-            const packageData = new Uint8Array(message.size);
-            let nextFile = 0;
-            const workers = Array.from({ length: 8 }, async () => {
-              while (nextFile < message.files.length) {
-                const packageFile = message.files[nextFile++];
-                const file = findAssetFile(packageFile.path);
-                if (!file) {
-                  throw new Error(
-                    `Required file is missing: ${packageFile.path}`,
-                  );
-                }
-                const buffer = await readFile(file);
-                const expectedSize = packageFile.end - packageFile.start;
-                if (buffer.byteLength !== expectedSize) {
-                  throw new Error(
-                    `Unexpected size for ${packageFile.path}: expected ${expectedSize}, received ${buffer.byteLength}`,
-                  );
-                }
-                packageData.set(new Uint8Array(buffer), packageFile.start);
-              }
-            });
-            await Promise.all(workers);
-            event.source.postMessage(
-              {
-                event: ">module.package",
-                requestId: message.requestId,
-                data: packageData,
-              },
-              location.origin,
-              [packageData.buffer],
-            );
-          } catch (error) {
-            event.source.postMessage(
-              {
-                event: ">module.package",
-                requestId: message.requestId,
-                error: error.message,
-              },
-              location.origin,
-            );
-          }
-          return;
-        }
-
-        if (message.event === "module.getfile" && message.file) {
-          const file = findAssetFile(message.file);
-          const buffer = file ? await readFile(file) : null;
-          event.source.postMessage(
-            {
-              event: ">module.getfile",
-              requestId: message.requestId,
-              data: buffer || undefined,
-              error: buffer ? undefined : `File not found: ${message.file}`,
-            },
-            location.origin,
-            buffer ? [buffer] : [],
-          );
-          return;
-        }
-
         if (message.event === "request-fullscreen") {
           gameFrame.requestFullscreen?.();
         }
       });
+
+      const packedManifest = await loadPackedManifest();
+      if (packedManifest) {
+        try {
+          await verifyPackedAssets(packedManifest);
+          cacheEngineForOfflineUse();
+          startGame(
+            `${Object.keys(packedManifest.files).length.toLocaleString()} packed files ready. Starting reVCDOS…`,
+          );
+        } catch (error) {
+          selection.textContent = error.message;
+          downloadButton.disabled = false;
+          downloadButton.textContent = "Retry offline copy";
+        }
+      } else {
+        downloadButton.disabled = false;
+        downloadButton.textContent =
+          localStorage.getItem(DOWNLOAD_COMPLETE_KEY) === "true"
+            ? "Optimize downloaded copy"
+            : "Download automatically (860 MiB)";
+      }
     </script>
   </body>
 </html>

--- a/site/iframe/revcdos/modules/fetch.js
+++ b/site/iframe/revcdos/modules/fetch.js
@@ -54,41 +54,7 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
   var fetchAttrSynchronous = !!(fetchAttributes & 64);
   var userNameStr = userName ? UTF8ToString(userName) : undefined;
   var passwordStr = password ? UTF8ToString(password) : undefined;
-  var isLocalAsset =
-    typeof Module["fetchLocalAsset"] === "function" &&
-    !/^(?:https?:)?\/\//.test(url_);
-  var xhr = isLocalAsset
-    ? {
-        readyState: 0,
-        status: 0,
-        statusText: "",
-        response: null,
-        responseURL: url_,
-        open() {
-          this.readyState = 1;
-        },
-        overrideMimeType() {},
-        setRequestHeader() {},
-        send() {
-          Module["fetchLocalAsset"](url_)
-            .then((data) => {
-              this.response = data;
-              this.status = 200;
-              this.statusText = "OK";
-              this.readyState = 4;
-              this.onreadystatechange?.({});
-              this.onload?.({});
-            })
-            .catch((error) => {
-              this.status = 404;
-              this.statusText = "Not Found";
-              this.readyState = 4;
-              this.onreadystatechange?.({});
-              this.onerror?.(error);
-            });
-        },
-      }
-    : new XMLHttpRequest();
+  var xhr = new XMLHttpRequest();
   xhr.withCredentials = !!HEAPU8[fetch_attr + 60];
   xhr.open(
     requestMethod,

--- a/site/iframe/revcdos/packed-store.js
+++ b/site/iframe/revcdos/packed-store.js
@@ -1,0 +1,124 @@
+const DIRECTORY_NAME = "astro-flash-revcdos";
+const MANIFEST_NAME = "manifest.json";
+const FORMAT_VERSION = 1;
+const DATA_PREFIX = "assets-";
+
+const normalizePath = (path) =>
+  String(path).replaceAll("\\", "/").replace(/^\/+/, "").toLowerCase();
+
+const getSize = (file) => file.size ?? file.length;
+
+async function* readChunks(file) {
+  if (typeof file[Symbol.asyncIterator] === "function") {
+    for await (const chunk of file) yield chunk;
+    return;
+  }
+
+  if (typeof file.stream === "function") {
+    const reader = file.stream().getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return;
+        yield value;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  } else {
+    yield new Uint8Array(await file.arrayBuffer());
+  }
+}
+
+const getDirectory = async () => {
+  const root = await navigator.storage.getDirectory();
+  return root.getDirectoryHandle(DIRECTORY_NAME, { create: true });
+};
+
+export async function loadPackedManifest() {
+  try {
+    const directory = await getDirectory();
+    const manifestHandle = await directory.getFileHandle(MANIFEST_NAME);
+    const manifest = JSON.parse(await (await manifestHandle.getFile()).text());
+    if (
+      manifest.version !== FORMAT_VERSION ||
+      typeof manifest.dataFile !== "string" ||
+      typeof manifest.size !== "number" ||
+      typeof manifest.files !== "object"
+    ) {
+      return null;
+    }
+    const dataHandle = await directory.getFileHandle(manifest.dataFile);
+    const dataFile = await dataHandle.getFile();
+    return dataFile.size === manifest.size ? manifest : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function packFiles(entries, onProgress = () => {}) {
+  await navigator.storage.persist?.();
+  const files = [...entries]
+    .map(([path, file]) => [normalizePath(path), file])
+    .sort(([left], [right]) => left.localeCompare(right));
+  const total = files.reduce((sum, [, file]) => sum + getSize(file), 0);
+  const directory = await getDirectory();
+  const generation = crypto.randomUUID();
+  const dataFile = `${DATA_PREFIX}${generation}.bin`;
+  const dataHandle = await directory.getFileHandle(dataFile, { create: true });
+  const writable = await dataHandle.createWritable();
+  const index = {};
+  let offset = 0;
+
+  try {
+    for (const [path, file] of files) {
+      const length = getSize(file);
+      if (!Number.isSafeInteger(length) || length < 0) {
+        throw new Error(`Invalid file size: ${path}`);
+      }
+      index[path] = { offset, length };
+      for await (const chunk of readChunks(file)) {
+        await writable.write(chunk);
+        offset += chunk.byteLength;
+        onProgress(offset, total, path);
+      }
+      if (offset !== index[path].offset + length) {
+        throw new Error(`Unexpected file size while packing: ${path}`);
+      }
+    }
+    await writable.close();
+  } catch (error) {
+    await writable.abort().catch(() => {});
+    await directory.removeEntry(dataFile).catch(() => {});
+    throw error;
+  }
+
+  const manifest = {
+    version: FORMAT_VERSION,
+    dataFile,
+    size: offset,
+    files: index,
+  };
+  const manifestHandle = await directory.getFileHandle(MANIFEST_NAME, {
+    create: true,
+  });
+  const manifestWriter = await manifestHandle.createWritable();
+  await manifestWriter.write(JSON.stringify(manifest));
+  await manifestWriter.close();
+
+  for await (const [name, handle] of directory.entries()) {
+    if (
+      handle.kind === "file" &&
+      name.startsWith(DATA_PREFIX) &&
+      name !== dataFile
+    ) {
+      await directory.removeEntry(name).catch(() => {});
+    }
+  }
+
+  const registration = await navigator.serviceWorker.ready;
+  (navigator.serviceWorker.controller || registration.active)?.postMessage({
+    type: "REVCDOS_PACK_UPDATED",
+  });
+  return manifest;
+}

--- a/site/js/offline-worker.js
+++ b/site/js/offline-worker.js
@@ -6,11 +6,123 @@
   // optional bundled games and shared Ruffle runtime selected by the user.
   const BUNDLED_GAME_CACHE = "astro-bundled-games-v1";
   const OPTIONAL_PATHS = ["/swf/", "/iframe/", "/dos/"];
+  const REVCDOS_ROUTE = "/iframe/revcdos/local-assets/";
+  const REVCDOS_DIRECTORY = "astro-flash-revcdos";
+  const REVCDOS_MANIFEST = "manifest.json";
+  let revcdosStorePromise;
+
+  const normalizeAssetPath = (path) =>
+    decodeURIComponent(path)
+      .replaceAll("\\", "/")
+      .replace(/^\/+/, "")
+      .toLowerCase();
+
+  const findPackedAsset = (files, requestedPath) => {
+    const path = normalizeAssetPath(requestedPath);
+    const candidates = [
+      path,
+      path.replace(/^fetched\//, "vc-assets/local/"),
+      path.replace(/^vcsky\/fetched\//, "vc-assets/local/"),
+    ];
+    for (const candidate of candidates) {
+      if (files[candidate]) return files[candidate];
+    }
+    return null;
+  };
+
+  const openRevcdosStore = async () => {
+    const root = await navigator.storage.getDirectory();
+    const directory = await root.getDirectoryHandle(REVCDOS_DIRECTORY);
+    const manifestHandle = await directory.getFileHandle(REVCDOS_MANIFEST);
+    const manifest = JSON.parse(await (await manifestHandle.getFile()).text());
+    if (
+      manifest.version !== 1 ||
+      typeof manifest.dataFile !== "string" ||
+      typeof manifest.files !== "object"
+    ) {
+      throw new Error("Invalid reVCDOS packed manifest");
+    }
+    const dataHandle = await directory.getFileHandle(manifest.dataFile);
+    const data = await dataHandle.getFile();
+    if (data.size !== manifest.size) {
+      throw new Error("Incomplete reVCDOS packed data");
+    }
+    return { data, files: manifest.files };
+  };
+
+  const parseRange = (header, length) => {
+    if (!header) return { start: 0, end: length - 1, partial: false };
+    const match = /^bytes=(\d*)-(\d*)$/.exec(header);
+    if (!match) return null;
+    let start = match[1] ? Number(match[1]) : null;
+    let end = match[2] ? Number(match[2]) : null;
+    if (start === null) {
+      const suffix = end;
+      if (!suffix) return null;
+      start = Math.max(0, length - suffix);
+      end = length - 1;
+    } else {
+      end = end === null ? length - 1 : Math.min(end, length - 1);
+    }
+    if (start < 0 || start > end || start >= length) return null;
+    return { start, end, partial: true };
+  };
+
+  const serveRevcdosAsset = async (request, url) => {
+    try {
+      revcdosStorePromise ||= openRevcdosStore();
+      const { data, files } = await revcdosStorePromise;
+      const requestedPath = url.pathname.slice(
+        url.pathname.indexOf(REVCDOS_ROUTE) + REVCDOS_ROUTE.length,
+      );
+      const asset = findPackedAsset(files, requestedPath);
+      if (!asset) return new Response("Asset not found", { status: 404 });
+      const range = parseRange(request.headers.get("range"), asset.length);
+      if (!range) {
+        return new Response(null, {
+          status: 416,
+          headers: { "Content-Range": `bytes */${asset.length}` },
+        });
+      }
+      const length = range.end - range.start + 1;
+      const headers = new Headers({
+        "Accept-Ranges": "bytes",
+        "Cache-Control": "no-store",
+        "Content-Length": String(length),
+        "Content-Type": "application/octet-stream",
+      });
+      if (range.partial) {
+        headers.set(
+          "Content-Range",
+          `bytes ${range.start}-${range.end}/${asset.length}`,
+        );
+      }
+      return new Response(
+        data.slice(asset.offset + range.start, asset.offset + range.end + 1),
+        { status: range.partial ? 206 : 200, headers },
+      );
+    } catch (error) {
+      revcdosStorePromise = undefined;
+      return new Response(`Packed asset unavailable: ${error.message}`, {
+        status: 503,
+      });
+    }
+  };
+
+  self.addEventListener("message", (event) => {
+    if (event.data?.type === "REVCDOS_PACK_UPDATED") {
+      revcdosStorePromise = undefined;
+    }
+  });
 
   self.addEventListener("fetch", (event) => {
     if (event.request.method !== "GET") return;
     const url = new URL(event.request.url);
     if (url.origin !== self.location.origin) return;
+    if (url.pathname.startsWith(REVCDOS_ROUTE)) {
+      event.respondWith(serveRevcdosAsset(event.request, url));
+      return;
+    }
     const isGameFile = OPTIONAL_PATHS.some((prefix) =>
       url.pathname.startsWith(prefix),
     );

--- a/tests/revcdos.test.ts
+++ b/tests/revcdos.test.ts
@@ -4,16 +4,27 @@ const projectDirectory = new URL("..", import.meta.url);
 const read = (relativePath: string) =>
   Bun.file(new URL(relativePath, projectDirectory)).text();
 
-const [games, main, host, game, source, packageManifest, fetchModule] =
-  await Promise.all([
-    read("site/js/games.js"),
-    read("site/js/main.js"),
-    read("site/iframe/revcdos/index.html"),
-    read("site/iframe/revcdos/game.js"),
-    read("site/iframe/revcdos/SOURCE.md"),
-    read("site/iframe/revcdos/modules/packages/en.js"),
-    read("site/iframe/revcdos/modules/fetch.js"),
-  ]);
+const [
+  games,
+  main,
+  host,
+  game,
+  source,
+  packageManifest,
+  fetchModule,
+  packedStore,
+  offlineWorker,
+] = await Promise.all([
+  read("site/js/games.js"),
+  read("site/js/main.js"),
+  read("site/iframe/revcdos/index.html"),
+  read("site/iframe/revcdos/game.js"),
+  read("site/iframe/revcdos/SOURCE.md"),
+  read("site/iframe/revcdos/modules/packages/en.js"),
+  read("site/iframe/revcdos/modules/fetch.js"),
+  read("site/iframe/revcdos/packed-store.js"),
+  read("site/js/offline-worker.js"),
+]);
 
 test("registers reVCDOS as a bundled iframe application", () => {
   expect(games).toContain("revcdos: {");
@@ -51,17 +62,23 @@ test("ships the engine without bundled game data", async () => {
   ).toBe(false);
 });
 
-test("adapts the Lolendor package and streaming protocols to local files", async () => {
+test("serves the Lolendor runtime through a packed OPFS store", async () => {
   expect(host).toContain('type="file" webkitdirectory directory');
   expect(host).toContain('gameFrame.src = "game.html"');
-  expect(host).toContain('message.event === "module.package"');
-  expect(host).toContain('message.event === "module.getfile"');
-  expect(host).toContain("new Uint8Array(message.size)");
-  expect(host).toContain("Required file is missing");
-  expect(game).toContain("DATA_PACKAGE.files.map");
+  expect(host).toContain("loadPackedManifest");
+  expect(host).toContain("packFiles");
+  expect(host).toContain("destroyTorrent");
+  expect(host).toContain("{ destroyStore: true }");
+  expect(host).toContain("verifyPackedAssets");
+  expect(host).toContain('headers: { Range: "bytes=0-0" }');
+  expect(host).not.toContain('message.event === "module.package"');
+  expect(host).not.toContain('message.event === "module.getfile"');
+  expect(game).toContain("DATA_PACKAGE.files[nextFile++]");
   expect(game).toContain("getPreloadedPackage: () => {");
   expect(game).toContain("return data.buffer");
-  expect(game).toContain("fetchLocalAsset");
+  expect(game).toContain("local-assets/");
+  expect(game).toContain("await fetch(localAssetUrl(filename)");
+  expect(game).not.toContain("fetchLocalAsset");
   expect(game).toContain(`let cheatsEnabled = params.get("cheats") !== "0"`);
   expect(game).toContain("ownerShipConfirmed();");
   expect(
@@ -69,11 +86,23 @@ test("adapts the Lolendor package and streaming protocols to local files", async
       new URL("site/iframe/revcdos/modules/cheats.js", projectDirectory),
     ).exists(),
   ).toBe(true);
-  expect(fetchModule).toContain('Module["fetchLocalAsset"](url_)');
+  expect(fetchModule).toContain("var xhr = new XMLHttpRequest()");
+  expect(fetchModule).not.toContain('Module["fetchLocalAsset"]');
   expect(game).toContain("window.parent.postMessage");
   expect(game).not.toContain("window.top.postMessage");
   expect(game).not.toContain("vc-sky-en-v6.data");
   expect(host).not.toContain("preload_files.list");
+  expect(packedStore).toContain('"astro-flash-revcdos"');
+  expect(packedStore).toContain("createWritable()");
+  expect(packedStore).toContain("for await (const chunk of readChunks(file))");
+  expect(packedStore).toContain(
+    "manifestWriter.write(JSON.stringify(manifest))",
+  );
+  expect(offlineWorker).toContain(
+    'const REVCDOS_ROUTE = "/iframe/revcdos/local-assets/"',
+  );
+  expect(offlineWorker).toContain("data.slice(");
+  expect(offlineWorker).toContain('"Content-Range"');
 });
 
 test("offers a persistent WebTorrent download alongside manual selection", async () => {


### PR DESCRIPTION
## Summary

- pack downloaded or manually selected assets into one indexed OPFS file
- serve local assets through the existing service worker with byte-range support
- stop WebTorrent and remove its piece store after the packed copy is verified
- preload the runtime through normal fetch and XHR requests instead of iframe messaging

## Why

The previous runtime kept thousands of torrent-backed files and an active WebTorrent client while playing. Packing the assets first reduces storage overhead and removes peer-to-peer work from gameplay.

## Validation

- bun run quality
- bun run test (103 tests)
- bun run build
- git diff --check
- local reVCDOS setup-screen smoke test