### PR TITLE
Remove restricted product names

### DIFF
--- a/site/iframe/revcdos/game.html
+++ b/site/iframe/revcdos/game.html
@@ -654,7 +654,7 @@
       <br />
       <div class="follow-container">
         <a id="follow" href="https://dos.zone/revcdos" target="_blank"
-          >Vice City by DOS Zone Team</a
+          >reVCDOS by DOS Zone Team</a
         >
       </div>
       <div class="jsdos-key">

--- a/site/js/game-data.js
+++ b/site/js/game-data.js
@@ -52,7 +52,7 @@
       if (revcdosBytes > 0) {
         items.push({
           id: "revcdos",
-          title: "Grand Theft Auto: Vice City (reVCDOS)",
+          title: "reVCDOS",
           detail: "Game data",
           bytes: revcdosBytes,
         });

--- a/tests/game-data.test.ts
+++ b/tests/game-data.test.ts
@@ -66,7 +66,7 @@ test("lists and removes external game data without save databases", async () => 
   assert.deepEqual(await manager.list(), [
     {
       id: "revcdos",
-      title: "Grand Theft Auto: Vice City (reVCDOS)",
+      title: "reVCDOS",
       detail: "Game data",
       bytes: 1000,
     },

--- a/tests/revcdos.test.ts
+++ b/tests/revcdos.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
 
 const projectDirectory = new URL("..", import.meta.url);
+const projectPath = fileURLToPath(projectDirectory);
 const read = (relativePath: string) =>
   Bun.file(new URL(relativePath, projectDirectory)).text();
 
@@ -31,6 +33,45 @@ test("registers reVCDOS as a bundled iframe application", () => {
   expect(games).toContain('title: "reVCDOS"');
   expect(games).toContain('icon: "assets/icons/revcdos.png"');
   expect(games).toContain('type: "iframe"');
+});
+
+test("keeps restricted product names out of tracked files", () => {
+  const patterns = [
+    ["grand", "theft", "auto"].join("[[:space:]-]+"),
+    ["vice", "city"].join("[[:space:]-]+"),
+    ["rock", "star"].join(""),
+    ["take", "two"].join("[[:space:]-]*"),
+  ];
+  const pattern = patterns.join("|");
+  const contents = Bun.spawnSync(
+    ["git", "grep", "-I", "-n", "-i", "-E", pattern, "--", "."],
+    {
+      cwd: projectPath,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const paths = Bun.spawnSync(["git", "ls-files", "-z"], {
+    cwd: projectPath,
+    stderr: "pipe",
+    stdout: "pipe",
+  })
+    .stdout.toString()
+    .split("\0")
+    .filter(Boolean);
+  const pathPattern = new RegExp(
+    [
+      ["grand", "theft", "auto"].join("[\\s-]+"),
+      ["vice", "city"].join("[\\s-]+"),
+      ["rock", "star"].join(""),
+      ["take", "two"].join("[\\s-]*"),
+    ].join("|"),
+    "i",
+  );
+
+  expect(contents.exitCode).toBe(1);
+  expect(contents.stdout.toString()).toBe("");
+  expect(paths.filter((path) => pathPattern.test(path))).toEqual([]);
 });
 
 test("ships the engine without bundled game data", async () => {


### PR DESCRIPTION
## Summary

- replace remaining restricted product references with neutral reVCDOS wording
- update the game-data expectation to match the neutral title
- add a repository-wide regression test covering tracked text and file paths

## Impact

The current tracked tree no longer contains any of the restricted names or their spacing and hyphen variants. Future occurrences will fail CI.

## Validation

- repository-wide case-insensitive tracked-file scan
- `bun run test` — 117 tests passed
- `bun run quality`