### PR TITLE
Support session-only game data

### DIFF
--- a/site/iframe/revcdos/game.js
+++ b/site/iframe/revcdos/game.js
@@ -5,6 +5,7 @@ var spinnerElement = document.getElementById("spinner");
 var wasm_content = "index.wasm";
 
 const params = new URLSearchParams(window.location.search);
+const sessionAssets = params.get("session") === "1";
 
 // Base URLs
 const localAssetUrl = (path) => {
@@ -20,6 +21,26 @@ const localAssetUrl = (path) => {
   ).href;
 };
 const replaceFetch = localAssetUrl;
+
+const requestSessionAsset = (path) =>
+  new Promise((resolve, reject) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = (event) => {
+      channel.port1.close();
+      if (event.data?.error) {
+        reject(new Error(event.data.error));
+      } else if (event.data?.buffer instanceof ArrayBuffer) {
+        resolve(event.data.buffer);
+      } else {
+        reject(new Error(`Unable to read ${path} from this session.`));
+      }
+    };
+    window.parent.postMessage(
+      { event: "revcdos.asset-request", path },
+      location.origin,
+      [channel.port2],
+    );
+  });
 
 // Configurable mode - show settings UI before play
 const configurableMode = params.get("configurable") === "1";
@@ -205,13 +226,18 @@ async function loadData() {
   const workers = Array.from({ length: 8 }, async () => {
     while (nextFile < DATA_PACKAGE.files.length) {
       const { filename, start, end } = DATA_PACKAGE.files[nextFile++];
-      const response = await fetch(localAssetUrl(filename), {
-        cache: "no-store",
-      });
-      if (!response.ok) {
-        throw new Error(`Unable to load ${filename}: HTTP ${response.status}`);
+      let buffer;
+      if (sessionAssets) {
+        buffer = await requestSessionAsset(filename);
+      } else {
+        const response = await fetch(localAssetUrl(filename), {
+          cache: "no-store",
+        });
+        if (!response.ok) {
+          throw new Error(`Unable to load ${filename}: HTTP ${response.status}`);
+        }
+        buffer = await response.arrayBuffer();
       }
-      const buffer = await response.arrayBuffer();
       const expectedSize = end - start;
       if (buffer.byteLength !== expectedSize) {
         throw new Error(

--- a/site/iframe/revcdos/index.html
+++ b/site/iframe/revcdos/index.html
@@ -202,7 +202,6 @@
       ("use strict");
 
       const DEFAULT_TORRENT_SOURCE = "revcdoseng.torrent";
-      const DOWNLOAD_SIZE = 901786388;
       const DOWNLOAD_COMPLETE_KEY = "astro-flash.revcdos.download-complete.v1";
       const DOWNLOAD_SOURCE_KEY = "astro-flash.revcdos.download-source.v1";
       const WEB_TRACKERS = ["wss://cloud.dos.zone:8444/announce-ws"];
@@ -216,6 +215,8 @@
       const setup = document.getElementById("setup");
       const selection = document.getElementById("selection");
       let gameFrame = null;
+      let sessionFiles = new Map();
+      let activeTorrentSession = null;
 
       const cacheEngineForOfflineUse = () => {
         window.parent.postMessage(
@@ -224,10 +225,10 @@
         );
       };
 
-      const startGame = (message) => {
+      const startGame = (message, session = false) => {
         selection.textContent = message;
         gameFrame = document.createElement("iframe");
-        gameFrame.src = "game.html";
+        gameFrame.src = session ? "game.html?session=1" : "game.html";
         gameFrame.allow = "fullscreen";
         gameFrame.title = "reVCDOS";
         setup.replaceWith(gameFrame);
@@ -236,6 +237,37 @@
       const formatBytes = (bytes) => {
         if (!Number.isFinite(bytes) || bytes <= 0) return "0 MiB";
         return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+      };
+
+      const errorMessage = (error) =>
+        error?.name === "QuotaExceededError"
+          ? "The browser refused the storage write because its actual storage quota was reached."
+          : error?.message || String(error);
+
+      const normalizeAssetPath = (path) =>
+        String(path).replaceAll("\\", "/").replace(/^\/+/, "").toLowerCase();
+
+      const findSessionFile = (requestedPath) => {
+        const path = normalizeAssetPath(requestedPath);
+        const candidates = [
+          path,
+          path.replace(/^fetched\//, "vc-assets/local/"),
+          path.replace(/^vcsky\/fetched\//, "vc-assets/local/"),
+        ];
+        for (const candidate of candidates) {
+          const file = sessionFiles.get(candidate);
+          if (file) return file;
+        }
+        return null;
+      };
+
+      const setSessionFiles = (entries) => {
+        sessionFiles = new Map(
+          [...entries].map(([path, file]) => [normalizeAssetPath(path), file]),
+        );
+        if (!sessionFiles.size) {
+          throw new Error("The selected folder is empty.");
+        }
       };
 
       const selectedTorrentSource = async () => {
@@ -330,6 +362,16 @@
         torrentFileInput.disabled = true;
         torrentSourceInput.disabled = true;
         keepCopyInput.disabled = true;
+        if (!keepCopyInput.checked) {
+          setSessionFiles(entries);
+          activeTorrentSession = torrentSession || null;
+          startGame(
+            `${sessionFiles.size.toLocaleString()} files ready. Starting reVCDOS directly from this session…`,
+            true,
+          );
+          return;
+        }
+
         let lastUpdate = 0;
         const manifest = await packFiles(entries, (packed, total, path) => {
           const now = Date.now();
@@ -468,7 +510,8 @@
         });
 
       const downloadGameData = async () => {
-        if (!navigator.storage?.getDirectory) {
+        const keepBrowserCopy = keepCopyInput.checked;
+        if (keepBrowserCopy && !navigator.storage?.getDirectory) {
           throw new Error(
             "Persistent browser storage is unavailable. Select a local vc-assets folder instead.",
           );
@@ -477,18 +520,9 @@
         const { source: torrentSource, identity: sourceIdentity } =
           await selectedTorrentSource();
         const cached =
+          keepBrowserCopy &&
           localStorage.getItem(DOWNLOAD_COMPLETE_KEY) === "true" &&
           localStorage.getItem(DOWNLOAD_SOURCE_KEY) === sourceIdentity;
-        const estimate = await navigator.storage.estimate();
-        const available = (estimate.quota || 0) - (estimate.usage || 0);
-        const packingSpace = cached ? DOWNLOAD_SIZE : DOWNLOAD_SIZE * 2;
-        if (estimate.quota && available < packingSpace) {
-          throw new Error(
-            `Not enough temporary browser storage. ${formatBytes(
-              packingSpace,
-            )} is required to download and optimize the offline copy, and ${formatBytes(available)} is available.`,
-          );
-        }
 
         downloadButton.disabled = true;
         downloadButton.textContent = cached
@@ -498,8 +532,11 @@
           ? "Opening the downloaded game data…"
           : "Connecting to peers. Your IP address is visible to torrent peers.";
 
-        await navigator.storage.persist?.();
-        const rootDir = await navigator.storage.getDirectory();
+        let rootDir = null;
+        if (keepBrowserCopy) {
+          await navigator.storage.persist?.();
+          rootDir = await navigator.storage.getDirectory();
+        }
         const rtcResponse = await fetch("/api/rtc", { cache: "no-store" });
         if (!rtcResponse.ok) {
           throw new Error(
@@ -549,13 +586,14 @@
           failDownload(`Download failed: ${error.message}`),
         );
 
-        const torrent = client.add(torrentSource, {
+        const torrentOptions = {
           announce: WEB_TRACKERS,
-          destroyStoreOnDestroy: false,
-          storeOpts: { rootDir },
+          destroyStoreOnDestroy: !keepBrowserCopy,
           skipVerify: cached,
           uploads: 2,
-        });
+        };
+        if (rootDir) torrentOptions.storeOpts = { rootDir };
+        const torrent = client.add(torrentSource, torrentOptions);
 
         let lastProgressUpdate = 0;
         torrent.on("download", () => {
@@ -597,10 +635,13 @@
         torrent.on("done", async () => {
           if (failed) return;
           clearTimeout(connectionTimer);
-          localStorage.setItem(DOWNLOAD_COMPLETE_KEY, "true");
-          localStorage.setItem(DOWNLOAD_SOURCE_KEY, sourceIdentity);
-          selection.textContent =
-            "Download complete. Optimizing data for smooth offline play…";
+          if (keepBrowserCopy) {
+            localStorage.setItem(DOWNLOAD_COMPLETE_KEY, "true");
+            localStorage.setItem(DOWNLOAD_SOURCE_KEY, sourceIdentity);
+          }
+          selection.textContent = keepBrowserCopy
+            ? "Download complete. Optimizing data for smooth offline play…"
+            : "Download complete. Starting directly from temporary memory…";
           try {
             await packAndStart(
               torrent.files.map((file) => [file.path, file]),
@@ -608,7 +649,7 @@
             );
           } catch (error) {
             failDownload(
-              `Unable to optimize downloaded data: ${error.message}`,
+              `Unable to prepare downloaded data: ${errorMessage(error)}`,
             );
           }
         });
@@ -624,7 +665,7 @@
 
       downloadButton.addEventListener("click", () => {
         downloadGameData().catch((error) => {
-          selection.textContent = error.message;
+          selection.textContent = errorMessage(error);
           downloadButton.disabled = false;
           torrentFileInput.disabled = false;
           torrentSourceInput.disabled = false;
@@ -651,11 +692,12 @@
         ]);
         if (!selectedFiles.length) return;
         try {
-          selection.textContent =
-            "Optimizing selected files for smooth offline play…";
+          selection.textContent = keepCopyInput.checked
+            ? "Optimizing selected files for smooth offline play…"
+            : "Checking selected files for direct play…";
           await packAndStart(selectedFiles);
         } catch (error) {
-          selection.textContent = `Unable to optimize selected files: ${error.message}`;
+          selection.textContent = `Unable to prepare selected files: ${errorMessage(error)}`;
           downloadButton.disabled = false;
           input.disabled = false;
           torrentFileInput.disabled = false;
@@ -669,10 +711,39 @@
         const message = event.data;
         if (!message || typeof message.event !== "string") return;
 
+        if (message.event === "revcdos.asset-request") {
+          const [port] = event.ports;
+          if (!port) return;
+          try {
+            const file = findSessionFile(message.path);
+            if (!file) {
+              throw new Error(`Game file not found: ${message.path}`);
+            }
+            const buffer = await file.arrayBuffer();
+            port.postMessage({ buffer }, [buffer]);
+          } catch (error) {
+            port.postMessage({ error: errorMessage(error) });
+          }
+          return;
+        }
+
         if (message.event === "request-fullscreen") {
           gameFrame.requestFullscreen?.();
         }
       });
+
+      window.addEventListener(
+        "pagehide",
+        () => {
+          if (!activeTorrentSession) return;
+          void destroyTorrent(
+            activeTorrentSession.client,
+            activeTorrentSession.torrent,
+          );
+          activeTorrentSession = null;
+        },
+        { once: true },
+      );
 
       const packedManifest = await loadPackedManifest();
       if (packedManifest) {
@@ -683,7 +754,7 @@
             `${Object.keys(packedManifest.files).length.toLocaleString()} packed files ready. Starting reVCDOS…`,
           );
         } catch (error) {
-          selection.textContent = error.message;
+          selection.textContent = errorMessage(error);
           downloadButton.disabled = false;
           downloadButton.textContent = "Retry offline copy";
         }

--- a/site/iframe/scummvm/launcher.js
+++ b/site/iframe/scummvm/launcher.js
@@ -5,12 +5,15 @@
   if (!game) throw new Error("Missing Pink Panther game configuration.");
 
   const SCUMMVM_ROOT = "../../vendor/scummvm/2026.3.0/";
+  const SCUMMVM_GAME_ROUTE = `/iframe/scummvm/local-games/${game.id}/`;
   const STORAGE_DIRECTORY = "astro-flash-scummvm";
   const metadataKey = `astro-flash.scummvm.${game.id}.iso.v1`;
   const runtimeManifestName = `${game.id}-manifest.json`;
   let currentVolume = 1;
   let outputGain = null;
   let savedIso = null;
+  let temporaryIso = null;
+  let temporaryGameFiles = null;
 
   document.documentElement.innerHTML = `
     <head>
@@ -141,6 +144,70 @@
 
   const formatBytes = (bytes) =>
     `${(bytes / 1024 / 1024).toFixed(bytes >= 100 * 1024 * 1024 ? 0 : 1)} MiB`;
+
+  const errorMessage = (error) =>
+    error?.name === "QuotaExceededError"
+      ? "The browser refused the storage write because its actual storage quota was reached."
+      : error?.message || String(error);
+
+  const nativeFetch = window.fetch.bind(window);
+  window.fetch = (input, init) => {
+    const requestUrl = new URL(
+      typeof input === "string" || input instanceof URL ? input : input.url,
+      location.href,
+    );
+    if (
+      !temporaryIso ||
+      !temporaryGameFiles ||
+      requestUrl.origin !== location.origin ||
+      !requestUrl.pathname.startsWith(SCUMMVM_GAME_ROUTE)
+    ) {
+      return nativeFetch(input, init);
+    }
+
+    const requestedName = decodeURIComponent(
+      requestUrl.pathname.slice(SCUMMVM_GAME_ROUTE.length),
+    );
+    if (requestedName === "index.json") {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(
+            Object.fromEntries(
+              Object.entries(temporaryGameFiles).map(([name, entry]) => [
+                name,
+                entry.size,
+              ]),
+            ),
+          ),
+          {
+            headers: {
+              "Cache-Control": "no-store",
+              "Content-Type": "application/json",
+            },
+          },
+        ),
+      );
+    }
+
+    const entry = temporaryGameFiles[requestedName.toUpperCase()];
+    if (!entry) {
+      return Promise.resolve(
+        new Response("Game file not found", { status: 404 }),
+      );
+    }
+    return Promise.resolve(
+      new Response(
+        temporaryIso.slice(entry.offset, entry.offset + entry.size),
+        {
+          headers: {
+            "Cache-Control": "no-store",
+            "Content-Length": String(entry.size),
+            "Content-Type": "application/octet-stream",
+          },
+        },
+      ),
+    );
+  };
 
   const readMetadata = () => {
     try {
@@ -335,6 +402,13 @@
     notifyGameDataReady(keep, fileName);
   };
 
+  const activateTemporaryIso = (iso, gameFiles) => {
+    temporaryIso = iso;
+    temporaryGameFiles = Object.fromEntries(
+      gameFiles.map(({ name, offset, size }) => [name, { offset, size }]),
+    );
+  };
+
   const storeIso = async (iso, gameFiles, { keep, url = "" }) => {
     if (iso.size !== game.isoSize) {
       throw new Error(
@@ -342,13 +416,6 @@
       );
     }
     await navigator.storage.persist?.();
-    const estimate = await navigator.storage.estimate();
-    const available = (estimate.quota || 0) - (estimate.usage || 0);
-    if (estimate.quota && available < game.isoSize) {
-      throw new Error(
-        `Not enough browser storage. ${formatBytes(game.isoSize)} is required and ${formatBytes(available)} is available.`,
-      );
-    }
     const directory = await getStorageDirectory(true);
     const fileName = `${game.id}-${crypto.randomUUID()}.iso`;
     const handle = await directory.getFileHandle(fileName, { create: true });
@@ -387,7 +454,9 @@
       game.requiredFiles,
       game.title,
     );
-    return storeIso(iso, gameFiles, options);
+    if (options.keep) return storeIso(iso, gameFiles, options);
+    activateTemporaryIso(iso, gameFiles);
+    return { fileName: null, iso };
   };
 
   discInput.addEventListener("change", async () => {
@@ -403,7 +472,7 @@
       await startScummVm();
     } catch (error) {
       setControlsDisabled(false);
-      setMessage(error.message, true);
+      setMessage(errorMessage(error), true);
       discInput.value = "";
     }
   });
@@ -430,7 +499,7 @@
       await startScummVm();
     } catch (error) {
       setControlsDisabled(false);
-      setMessage(error.message, true);
+      setMessage(errorMessage(error), true);
     }
   });
 
@@ -456,15 +525,6 @@
     let writable;
     setControlsDisabled(true);
     try {
-      await navigator.storage.persist?.();
-      const estimate = await navigator.storage.estimate();
-      const available = (estimate.quota || 0) - (estimate.usage || 0);
-      if (estimate.quota && available < game.isoSize) {
-        throw new Error(
-          `Not enough browser storage. ${formatBytes(game.isoSize)} is required and ${formatBytes(available)} is available.`,
-        );
-      }
-
       setMessage("Connecting to CD image source…");
       let response;
       try {
@@ -490,12 +550,18 @@
         );
       }
 
-      directory = await getStorageDirectory(true);
-      fileName = `${game.id}-${crypto.randomUUID()}.iso`;
-      const handle = await directory.getFileHandle(fileName, { create: true });
-      writable = await handle.createWritable();
       const reader = response.body.getReader();
+      const chunks = [];
       let downloaded = 0;
+      if (keepCopy.checked) {
+        await navigator.storage.persist?.();
+        directory = await getStorageDirectory(true);
+        fileName = `${game.id}-${crypto.randomUUID()}.iso`;
+        const handle = await directory.getFileHandle(fileName, {
+          create: true,
+        });
+        writable = await handle.createWritable();
+      }
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
@@ -506,15 +572,23 @@
             "The downloaded file is larger than the expected CD image.",
           );
         }
-        await writable.write(value);
+        if (writable) {
+          await writable.write(value);
+        } else {
+          chunks.push(value);
+        }
         setMessage(
           `Downloading… ${formatBytes(downloaded)} of ${formatBytes(game.isoSize)} (${((downloaded / game.isoSize) * 100).toFixed(1)}%)`,
         );
       }
-      await writable.close();
-      writable = null;
-
-      const iso = await handle.getFile();
+      let iso;
+      if (writable) {
+        await writable.close();
+        writable = null;
+        iso = await (await directory.getFileHandle(fileName)).getFile();
+      } else {
+        iso = new Blob(chunks, { type: "application/x-iso9660-image" });
+      }
       if (iso.size !== game.isoSize) {
         throw new Error(
           `The download is ${formatBytes(iso.size)}, but this game requires ${formatBytes(game.isoSize)}.`,
@@ -526,10 +600,14 @@
         game.requiredFiles,
         game.title,
       );
-      await activateStoredIso(directory, fileName, iso, gameFiles, {
-        keep: keepCopy.checked,
-        url: url.href,
-      });
+      if (keepCopy.checked) {
+        await activateStoredIso(directory, fileName, iso, gameFiles, {
+          keep: true,
+          url: url.href,
+        });
+      } else {
+        activateTemporaryIso(iso, gameFiles);
+      }
       setMessage(
         keepCopy.checked
           ? "Download verified and saved. Starting ScummVM…"
@@ -544,7 +622,7 @@
         await directory.removeEntry(fileName).catch(() => {});
       }
       setControlsDisabled(false);
-      setMessage(error.message, true);
+      setMessage(errorMessage(error), true);
     }
   });
 

--- a/tests/revcdos.test.ts
+++ b/tests/revcdos.test.ts
@@ -66,7 +66,7 @@ test("serves the Lolendor runtime through a packed OPFS store", async () => {
   expect(host).toContain('id="file-input"');
   expect(host).toContain("webkitdirectory");
   expect(host).toContain("directory");
-  expect(host).toContain('gameFrame.src = "game.html"');
+  expect(host).toContain('"game.html?session=1"');
   expect(host).toContain("loadPackedManifest");
   expect(host).toContain("packFiles");
   expect(host).toContain("destroyTorrent");
@@ -80,6 +80,11 @@ test("serves the Lolendor runtime through a packed OPFS store", async () => {
   expect(game).toContain("return data.buffer");
   expect(game).toContain("local-assets/");
   expect(game).toContain("await fetch(localAssetUrl(filename)");
+  expect(game).toContain('params.get("session") === "1"');
+  expect(game).toContain('event: "revcdos.asset-request"');
+  expect(host).toContain("setSessionFiles(entries)");
+  expect(host).toContain('message.event === "revcdos.asset-request"');
+  expect(host).toContain("const buffer = await file.arrayBuffer()");
   expect(game).not.toContain("fetchLocalAsset");
   expect(game).toContain(`let cheatsEnabled = params.get("cheats") !== "0"`);
   expect(game).toContain("ownerShipConfirmed();");
@@ -107,7 +112,7 @@ test("serves the Lolendor runtime through a packed OPFS store", async () => {
   expect(offlineWorker).toContain('"Content-Range"');
 });
 
-test("offers configurable persistent WebTorrent downloads alongside manual selection", async () => {
+test("offers temporary or persistent WebTorrent downloads alongside manual selection", async () => {
   expect(host).toContain('id="download-button"');
   expect(host).toContain("Select your game files…");
   expect(host).toContain("Download from torrent");
@@ -124,7 +129,7 @@ test("offers configurable persistent WebTorrent downloads alongside manual selec
   );
   expect(host).toContain("revcdoseng.torrent");
   expect(host).toContain("await navigator.storage.getDirectory()");
-  expect(host).toContain("storeOpts: { rootDir }");
+  expect(host).toContain("torrentOptions.storeOpts = { rootDir }");
   expect(host).toContain("const torrent = client.add(torrentSource");
   expect(host).toContain("wss://cloud.dos.zone:8444/announce-ws");
   expect(host).toContain("announce: WEB_TRACKERS");
@@ -138,7 +143,10 @@ test("offers configurable persistent WebTorrent downloads alongside manual selec
   expect(host).toContain("Try torrent download again");
   expect(host).not.toContain("Download automatically");
   expect(host).not.toContain("Download and optimize");
-  expect(host).toContain("destroyStoreOnDestroy: false");
+  expect(host).toContain("destroyStoreOnDestroy: !keepBrowserCopy");
+  expect(host).toContain("if (keepBrowserCopy)");
+  expect(host).not.toContain("navigator.storage.estimate()");
+  expect(host).toContain('error?.name === "QuotaExceededError"');
   expect(host).toContain("uploads: 2");
   expect(host).toContain("skipVerify: cached");
   expect(host).toContain("torrent.files.map");

--- a/tests/scummvm.test.ts
+++ b/tests/scummvm.test.ts
@@ -55,7 +55,7 @@ const pokusWrapper = await Bun.file(
   ),
 ).text();
 
-test("supports optional verified URL downloads in persistent browser storage", () => {
+test("supports direct ISO sessions and optional persistent browser copies", () => {
   expect(passportWrapper).toContain("isoSize: 649084928");
   expect(pokusWrapper).toContain("isoSize: 526409728");
   expect(launcher).toContain('id="disc-url"');
@@ -69,6 +69,12 @@ test("supports optional verified URL downloads in persistent browser storage", (
   expect(launcher).toContain("navigator.storage.getDirectory()");
   expect(launcher).toContain("handle.createWritable()");
   expect(launcher).toContain("response.body.getReader()");
+  expect(launcher).toContain("activateTemporaryIso(iso, gameFiles)");
+  expect(launcher).toContain("if (options.keep) return storeIso");
+  expect(launcher).toContain("chunks.push(value)");
+  expect(launcher).toContain("window.fetch = (input, init)");
+  expect(launcher).toContain("temporaryIso.slice(");
+  expect(launcher).not.toContain("navigator.storage.estimate()");
   expect(launcher).toContain("downloaded > game.isoSize");
   expect(launcher).toContain("iso.size !== game.isoSize");
   expect(launcher).toContain("gameFilesFromIso(");
@@ -86,6 +92,7 @@ test("supports optional verified URL downloads in persistent browser storage", (
   expect(launcher).toContain("localStorage.setItem(");
   expect(launcher).toContain("directory.removeEntry(fileName)");
   expect(launcher).toContain("cross-origin browser downloads (CORS)");
+  expect(launcher).toContain('error?.name === "QuotaExceededError"');
   expect(launcher).not.toContain('value="http');
 });
 


### PR DESCRIPTION
## What changed

- Run Pink Panther directly from a selected or downloaded ISO when browser-copy retention is disabled.
- Serve reVCDOS assets from the active file/torrent session without packing them into persistent browser storage.
- Keep the existing persistent OPFS paths when users opt into retaining a browser copy.
- Remove storage-estimate prechecks and surface actual quota-write failures clearly.
- Add regression coverage for both temporary and persistent paths.

## Why

The launchers always used persistent browser storage, even when users disabled the **Keep a copy** option. Storage-estimate checks could also reject valid runs before the browser attempted a write.

## Impact

Users can play from session memory without consuming persistent browser storage. Temporary game data disappears when the page/session closes. Persistent copies remain subject to the browser's actual quota.

## Validation

- `bun run test` — 116 passing
- `bun run lint`
- `bun run quality`
- `bun run build --revision HEAD`
- Live browser smoke test: Pink Panther launched from an unchecked local ISO and was not retained after reload
- Live browser smoke test: reVCDOS setup path rendered correctly