### PR TITLE
Unify browser storage quota handling

### DIFF
--- a/site/iframe/pink-panther-hokus-pokus/index.html
+++ b/site/iframe/pink-panther-hokus-pokus/index.html
@@ -22,6 +22,7 @@
         }),
       });
     </script>
+    <script src="../../js/storage-policy.js"></script>
     <script src="../scummvm/iso9660.js"></script>
     <script src="../scummvm/launcher.js"></script>
   </body>

--- a/site/iframe/pink-panther-passport-to-peril/index.html
+++ b/site/iframe/pink-panther-passport-to-peril/index.html
@@ -23,6 +23,7 @@
         }),
       });
     </script>
+    <script src="../../js/storage-policy.js"></script>
     <script src="../scummvm/iso9660.js"></script>
     <script src="../scummvm/launcher.js"></script>
   </body>

--- a/site/iframe/revcdos/index.html
+++ b/site/iframe/revcdos/index.html
@@ -195,12 +195,14 @@
       </section>
     </main>
 
+    <script src="../../js/storage-policy.js"></script>
     <script type="module">
       import WebTorrent from "../../vendor/webtorrent/3.0.21/webtorrent.min.js";
       import { loadPackedManifest, packFiles } from "./packed-store.js";
 
       ("use strict");
 
+      const storagePolicy = window.AstroStoragePolicy;
       const DEFAULT_TORRENT_SOURCE = "revcdoseng.torrent";
       const DOWNLOAD_COMPLETE_KEY = "astro-flash.revcdos.download-complete.v1";
       const DOWNLOAD_SOURCE_KEY = "astro-flash.revcdos.download-source.v1";
@@ -238,11 +240,6 @@
         if (!Number.isFinite(bytes) || bytes <= 0) return "0 MiB";
         return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
       };
-
-      const errorMessage = (error) =>
-        error?.name === "QuotaExceededError"
-          ? "The browser refused the storage write because its actual storage quota was reached."
-          : error?.message || String(error);
 
       const normalizeAssetPath = (path) =>
         String(path).replaceAll("\\", "/").replace(/^\/+/, "").toLowerCase();
@@ -534,7 +531,7 @@
 
         let rootDir = null;
         if (keepBrowserCopy) {
-          await navigator.storage.persist?.();
+          await storagePolicy.requestPersistence(navigator.storage);
           rootDir = await navigator.storage.getDirectory();
         }
         const rtcResponse = await fetch("/api/rtc", { cache: "no-store" });
@@ -649,7 +646,7 @@
             );
           } catch (error) {
             failDownload(
-              `Unable to prepare downloaded data: ${errorMessage(error)}`,
+              `Unable to prepare downloaded data: ${storagePolicy.errorMessage(error)}`,
             );
           }
         });
@@ -665,7 +662,7 @@
 
       downloadButton.addEventListener("click", () => {
         downloadGameData().catch((error) => {
-          selection.textContent = errorMessage(error);
+          selection.textContent = storagePolicy.errorMessage(error);
           downloadButton.disabled = false;
           torrentFileInput.disabled = false;
           torrentSourceInput.disabled = false;
@@ -697,7 +694,7 @@
             : "Checking selected files for direct play…";
           await packAndStart(selectedFiles);
         } catch (error) {
-          selection.textContent = `Unable to prepare selected files: ${errorMessage(error)}`;
+          selection.textContent = `Unable to prepare selected files: ${storagePolicy.errorMessage(error)}`;
           downloadButton.disabled = false;
           input.disabled = false;
           torrentFileInput.disabled = false;
@@ -722,7 +719,7 @@
             const buffer = await file.arrayBuffer();
             port.postMessage({ buffer }, [buffer]);
           } catch (error) {
-            port.postMessage({ error: errorMessage(error) });
+            port.postMessage({ error: storagePolicy.errorMessage(error) });
           }
           return;
         }
@@ -754,7 +751,7 @@
             `${Object.keys(packedManifest.files).length.toLocaleString()} packed files ready. Starting reVCDOS…`,
           );
         } catch (error) {
-          selection.textContent = errorMessage(error);
+          selection.textContent = storagePolicy.errorMessage(error);
           downloadButton.disabled = false;
           downloadButton.textContent = "Retry offline copy";
         }

--- a/site/iframe/revcdos/packed-store.js
+++ b/site/iframe/revcdos/packed-store.js
@@ -2,6 +2,7 @@ const DIRECTORY_NAME = "astro-flash-revcdos";
 const MANIFEST_NAME = "manifest.json";
 const FORMAT_VERSION = 1;
 const DATA_PREFIX = "assets-";
+const storagePolicy = globalThis.AstroStoragePolicy;
 
 const normalizePath = (path) =>
   String(path).replaceAll("\\", "/").replace(/^\/+/, "").toLowerCase();
@@ -57,7 +58,7 @@ export async function loadPackedManifest() {
 }
 
 export async function packFiles(entries, onProgress = () => {}) {
-  await navigator.storage.persist?.();
+  await storagePolicy.requestPersistence(navigator.storage);
   const files = [...entries]
     .map(([path, file]) => [normalizePath(path), file])
     .sort(([left], [right]) => left.localeCompare(right));
@@ -99,12 +100,22 @@ export async function packFiles(entries, onProgress = () => {}) {
     size: offset,
     files: index,
   };
-  const manifestHandle = await directory.getFileHandle(MANIFEST_NAME, {
-    create: true,
-  });
-  const manifestWriter = await manifestHandle.createWritable();
-  await manifestWriter.write(JSON.stringify(manifest));
-  await manifestWriter.close();
+  try {
+    const manifestHandle = await directory.getFileHandle(MANIFEST_NAME, {
+      create: true,
+    });
+    const manifestWriter = await manifestHandle.createWritable();
+    try {
+      await manifestWriter.write(JSON.stringify(manifest));
+      await manifestWriter.close();
+    } catch (error) {
+      await manifestWriter.abort().catch(() => {});
+      throw error;
+    }
+  } catch (error) {
+    await directory.removeEntry(dataFile).catch(() => {});
+    throw error;
+  }
 
   for await (const [name, handle] of directory.entries()) {
     if (

--- a/site/iframe/scummvm/launcher.js
+++ b/site/iframe/scummvm/launcher.js
@@ -2,7 +2,9 @@
 
 (() => {
   const game = window.PINK_GAME;
+  const storagePolicy = window.AstroStoragePolicy;
   if (!game) throw new Error("Missing Pink Panther game configuration.");
+  if (!storagePolicy) throw new Error("Missing browser storage policy.");
 
   const SCUMMVM_ROOT = "../../vendor/scummvm/2026.3.0/";
   const SCUMMVM_GAME_ROUTE = `/iframe/scummvm/local-games/${game.id}/`;
@@ -144,11 +146,6 @@
 
   const formatBytes = (bytes) =>
     `${(bytes / 1024 / 1024).toFixed(bytes >= 100 * 1024 * 1024 ? 0 : 1)} MiB`;
-
-  const errorMessage = (error) =>
-    error?.name === "QuotaExceededError"
-      ? "The browser refused the storage write because its actual storage quota was reached."
-      : error?.message || String(error);
 
   const nativeFetch = window.fetch.bind(window);
   window.fetch = (input, init) => {
@@ -388,10 +385,23 @@
     gameFiles,
     { keep, url = "" },
   ) => {
-    await writeRuntimeManifest(directory, fileName, gameFiles);
+    const previous = keep ? readMetadata() : null;
     if (keep) {
-      const previous = readMetadata();
       localStorage.setItem(metadataKey, JSON.stringify({ fileName, url }));
+    }
+    try {
+      await writeRuntimeManifest(directory, fileName, gameFiles);
+    } catch (error) {
+      if (keep) {
+        if (previous) {
+          localStorage.setItem(metadataKey, JSON.stringify(previous));
+        } else {
+          localStorage.removeItem(metadataKey);
+        }
+      }
+      throw error;
+    }
+    if (keep) {
       savedIso = iso;
       savedCopyButton.hidden = false;
       savedCopyButton.textContent = `Play browser copy (${formatBytes(iso.size)})`;
@@ -415,7 +425,7 @@
         `The CD image is ${formatBytes(iso.size)}, but this game requires ${formatBytes(game.isoSize)}.`,
       );
     }
-    await navigator.storage.persist?.();
+    await storagePolicy.requestPersistence(navigator.storage);
     const directory = await getStorageDirectory(true);
     const fileName = `${game.id}-${crypto.randomUUID()}.iso`;
     const handle = await directory.getFileHandle(fileName, { create: true });
@@ -438,12 +448,17 @@
       await directory.removeEntry(fileName).catch(() => {});
       throw error;
     }
-    const storedIso = await handle.getFile();
-    await activateStoredIso(directory, fileName, storedIso, gameFiles, {
-      keep,
-      url,
-    });
-    return { fileName, iso: storedIso };
+    try {
+      const storedIso = await handle.getFile();
+      await activateStoredIso(directory, fileName, storedIso, gameFiles, {
+        keep,
+        url,
+      });
+      return { fileName, iso: storedIso };
+    } catch (error) {
+      await directory.removeEntry(fileName).catch(() => {});
+      throw error;
+    }
   };
 
   const prepareIso = async (iso, options) => {
@@ -472,7 +487,7 @@
       await startScummVm();
     } catch (error) {
       setControlsDisabled(false);
-      setMessage(errorMessage(error), true);
+      setMessage(storagePolicy.errorMessage(error), true);
       discInput.value = "";
     }
   });
@@ -499,7 +514,7 @@
       await startScummVm();
     } catch (error) {
       setControlsDisabled(false);
-      setMessage(errorMessage(error), true);
+      setMessage(storagePolicy.errorMessage(error), true);
     }
   });
 
@@ -554,7 +569,7 @@
       const chunks = [];
       let downloaded = 0;
       if (keepCopy.checked) {
-        await navigator.storage.persist?.();
+        await storagePolicy.requestPersistence(navigator.storage);
         directory = await getStorageDirectory(true);
         fileName = `${game.id}-${crypto.randomUUID()}.iso`;
         const handle = await directory.getFileHandle(fileName, {
@@ -622,7 +637,7 @@
         await directory.removeEntry(fileName).catch(() => {});
       }
       setControlsDisabled(false);
-      setMessage(errorMessage(error), true);
+      setMessage(storagePolicy.errorMessage(error), true);
     }
   });
 

--- a/site/index.html
+++ b/site/index.html
@@ -8,6 +8,7 @@
     <script src="js/ruffle.js"></script>
     <script src="vendor/fflate/0.8.3/index.js"></script>
     <script src="js/games.js"></script>
+    <script src="js/storage-policy.js"></script>
     <script src="js/game-installer.js"></script>
     <script src="js/game-library.js"></script>
     <script src="js/game-data.js"></script>

--- a/site/js/game-library.js
+++ b/site/js/game-library.js
@@ -1,10 +1,14 @@
 "use strict";
 
 (function exposeGameLibrary(root, factory) {
+  if (typeof module === "object" && module.exports) {
+    require("./storage-policy.js");
+  }
   const api = factory(root);
   if (typeof module === "object" && module.exports) module.exports = api;
   if (root) root.AstroGameLibrary = api;
 })(typeof window !== "undefined" ? window : globalThis, function (root) {
+  const storagePolicy = root.AstroStoragePolicy;
   const DB_NAME = "astro-installed-games";
   const DB_VERSION = 1;
   const STORE_NAME = "games";
@@ -228,7 +232,11 @@
         status: 200,
         headers: response.headers,
       });
-      await cache.put(key, stored.clone());
+      try {
+        await cache.put(key, stored.clone());
+      } catch (error) {
+        if (!storagePolicy.isQuotaExceeded(error)) throw error;
+      }
       return stored;
     };
 
@@ -303,51 +311,45 @@
         if (installed.has(`flashpoint:${checked.uuid}`)) {
           return asGameConfig(installed.get(`flashpoint:${checked.uuid}`));
         }
-        try {
-          await storageManager?.persist?.();
-        } catch {
-          // Persistent storage is a best-effort browser capability.
-        }
+        await storagePolicy.requestPersistence(storageManager);
         const response = await fetchObject(checked.downloadUrl, { signal });
-        const contentLength =
-          Number(response.headers.get("content-length")) || null;
-        if (contentLength && storageManager?.estimate) {
-          const estimate = await storageManager.estimate();
-          const available =
-            Number.isFinite(estimate.quota) && Number.isFinite(estimate.usage)
-              ? estimate.quota - estimate.usage
-              : null;
-          if (available !== null && contentLength > available) {
-            throw new Error(
-              "There is not enough browser storage for this game.",
-            );
-          }
-        }
         const bytes = await readDownload(response, { onProgress });
-        let metadata =
-          checked.packageType === "legacy"
-            ? await installer.installLegacy(checked, bytes, {
-                cache,
-                store,
-                origin,
-              })
-            : await installer.install(checked, bytes, {
-                cache,
-                store,
-                unzipSync,
-                origin,
-              });
+        let metadata;
+        try {
+          metadata =
+            checked.packageType === "legacy"
+              ? await installer.installLegacy(checked, bytes, {
+                  cache,
+                  store,
+                  origin,
+                })
+              : await installer.install(checked, bytes, {
+                  cache,
+                  store,
+                  unzipSync,
+                  origin,
+                });
+        } catch (error) {
+          throw storagePolicy.normalizeError(error);
+        }
 
         if (checked.logoUrl) {
+          let iconPath = null;
+          let iconStored = false;
           try {
-            const logoResponse = await fetchObject(checked.logoUrl, { signal });
+            const logoResponse = await fetchObject(checked.logoUrl, {
+              signal,
+            });
             if (logoResponse.ok) {
-              const iconPath = `${origin}/__installed-games/${checked.uuid}/logo.jpg`;
+              iconPath = `${origin}/__installed-games/${checked.uuid}/logo.jpg`;
               await cache.put(iconPath, logoResponse);
-              metadata = { ...metadata, iconPath };
-              await store.put(metadata);
+              iconStored = true;
+              const metadataWithIcon = { ...metadata, iconPath };
+              await store.put(metadataWithIcon);
+              metadata = metadataWithIcon;
             }
           } catch {
+            if (iconStored) await cache.delete(iconPath).catch(() => {});
             // A missing logo should not undo a successfully installed game.
           }
         }
@@ -408,7 +410,7 @@
         return null;
       },
       async storageEstimate() {
-        return storageManager?.estimate ? storageManager.estimate() : null;
+        return storagePolicy.estimate(storageManager);
       },
     };
     return manager;

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -1,13 +1,17 @@
 "use strict";
 
 (function exposeOfflineManager(root, factory) {
-  const api = factory();
+  const storagePolicy =
+    typeof module === "object" && module.exports
+      ? require("./storage-policy.js")
+      : root.AstroStoragePolicy;
+  const api = factory(storagePolicy);
   if (typeof module !== "undefined" && module.exports) {
     module.exports = api;
   } else {
     root.AstroOffline = api;
   }
-})(typeof globalThis !== "undefined" ? globalThis : this, () => {
+})(typeof globalThis !== "undefined" ? globalThis : this, (storagePolicy) => {
   const LAST_CHECKED_KEY = "astroFlashLastUpdateCheck";
   const DOWNLOAD_VERSION_KEY = "astroFlashDownloadVersion";
   const DOWNLOAD_BYTES_KEY = "astroFlashDownloadBytes";
@@ -224,16 +228,9 @@
     };
 
     const refreshStorageEstimate = async () => {
-      if (!navigatorObject.storage?.estimate) return snapshot();
-      try {
-        const estimate = await navigatorObject.storage.estimate();
-        setState({
-          usage: Number.isFinite(estimate.usage) ? estimate.usage : null,
-          quota: Number.isFinite(estimate.quota) ? estimate.quota : null,
-        });
-      } catch {
-        // Storage estimates are optional and should never break offline mode.
-      }
+      const estimate = await storagePolicy.estimate(navigatorObject.storage);
+      if (!estimate) return snapshot();
+      setState({ usage: estimate.usage, quota: estimate.quota });
       return snapshot();
     };
 
@@ -459,17 +456,34 @@
         return;
       }
       const cache = await environment.caches.open(bundledCacheName);
+      const previousFiles = records[id]?.files || [];
       let loaded = 0;
-      for (const file of entry.files) {
-        const response = await environment.fetch(file.url, {
-          cache: "no-store",
-        });
-        if (!response.ok) {
-          throw new Error(`Offline download failed (${response.status}).`);
+      const written = [];
+      try {
+        for (const file of entry.files) {
+          const response = await environment.fetch(file.url, {
+            cache: "no-store",
+          });
+          if (!response.ok) {
+            throw new Error(`Offline download failed (${response.status}).`);
+          }
+          const url = absoluteUrl(file.url);
+          await cache.put(url, response);
+          written.push(url);
+          loaded += file.bytes;
+          progress(file.bytes);
         }
-        await cache.put(absoluteUrl(file.url), response);
-        loaded += file.bytes;
-        progress(file.bytes);
+      } catch (error) {
+        const cleanupUrls = new Set([
+          ...written,
+          ...previousFiles.map((url) => absoluteUrl(url)),
+        ]);
+        await Promise.all(
+          [...cleanupUrls].map((url) => cache.delete(url).catch(() => {})),
+        );
+        delete records[id];
+        persistRecords();
+        throw error;
       }
       records[id] = {
         bytes: entry.bytes,
@@ -480,20 +494,6 @@
       };
       persistRecords();
       return loaded;
-    };
-
-    const verifyAvailableStorage = async (requiredBytes) => {
-      if (!navigatorObject.storage?.estimate) return;
-      const estimate = await navigatorObject.storage.estimate();
-      if (
-        Number.isFinite(estimate.quota) &&
-        Number.isFinite(estimate.usage) &&
-        requiredBytes > estimate.quota - estimate.usage
-      ) {
-        throw new Error(
-          "There is not enough browser storage for this download.",
-        );
-      }
     };
 
     const downloadGame = async (id) => {
@@ -512,7 +512,7 @@
         runtimeEntry &&
         records[runtimeRecordId]?.revision !== runtimeEntry.revision;
       const total = entry.bytes + (needsRuntime ? runtimeEntry.bytes : 0);
-      await verifyAvailableStorage(total);
+      await storagePolicy.requestPersistence(navigatorObject.storage);
       let loaded = 0;
       setState({
         gamePhase: "downloading",
@@ -539,12 +539,13 @@
         await refreshStorageEstimate();
         return snapshot();
       } catch (error) {
+        const normalized = storagePolicy.normalizeError(error);
         setState({
           gamePhase: "error",
           activeGameId: null,
-          gameError: error.message,
+          gameError: normalized.message,
         });
-        throw error;
+        throw normalized;
       }
     };
 

--- a/site/js/storage-policy.js
+++ b/site/js/storage-policy.js
@@ -1,0 +1,57 @@
+"use strict";
+
+(function exposeStoragePolicy(root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.AstroStoragePolicy = api;
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  const QUOTA_MESSAGE =
+    "The browser refused the storage write because its actual storage quota was reached.";
+
+  const isQuotaExceeded = (error) =>
+    error?.name === "QuotaExceededError" ||
+    error?.name === "NS_ERROR_DOM_QUOTA_REACHED";
+
+  const normalizeError = (error, quotaMessage = QUOTA_MESSAGE) => {
+    if (isQuotaExceeded(error)) {
+      return new Error(quotaMessage, { cause: error });
+    }
+    if (error instanceof Error) return error;
+    return new Error(String(error));
+  };
+
+  const errorMessage = (error, quotaMessage = QUOTA_MESSAGE) =>
+    normalizeError(error, quotaMessage).message;
+
+  const requestPersistence = async (storageManager) => {
+    if (!storageManager?.persist) return false;
+    try {
+      return Boolean(await storageManager.persist());
+    } catch {
+      return false;
+    }
+  };
+
+  const estimate = async (storageManager) => {
+    if (!storageManager?.estimate) return null;
+    try {
+      const result = await storageManager.estimate();
+      return {
+        usage: Number.isFinite(result?.usage) ? result.usage : null,
+        quota: Number.isFinite(result?.quota) ? result.quota : null,
+        usageDetails: result?.usageDetails || null,
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    QUOTA_MESSAGE,
+    errorMessage,
+    estimate,
+    isQuotaExceeded,
+    normalizeError,
+    requestPersistence,
+  };
+});

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -83,6 +83,7 @@ async function makeSource(root: string): Promise<void> {
       '<script src="js/ruffle.js?v=old"></script>',
       '<script src="vendor/fflate/0.8.3/index.js?v=old"></script>',
       '<script src="js/games.js?v=old"></script>',
+      '<script src="js/storage-policy.js?v=old"></script>',
       '<script src="js/game-installer.js?v=old"></script>',
       '<script src="js/game-library.js?v=old"></script>',
       '<script src="js/game-data.js?v=old"></script>',
@@ -97,6 +98,7 @@ async function makeSource(root: string): Promise<void> {
     ].join("\n"),
     "capture.html": '<script src="js/ruffle.js?v=old"></script>',
     "js/games.js": 'const icon = "assets/icons/game.png";',
+    "js/storage-policy.js": "storage policy",
     "js/game-installer.js": "game installer",
     "js/game-library.js": "game library",
     "js/game-data.js": "game data",
@@ -123,6 +125,12 @@ async function makeSource(root: string): Promise<void> {
     "swf/bike-mania/main.swf": "swf",
     "iframe/doom/index.html": "doom",
     "iframe/inside-the-firewall/index.html": "firewall",
+    "iframe/pink-panther-hokus-pokus/index.html":
+      '<script src="../../js/storage-policy.js?v=old"></script>',
+    "iframe/pink-panther-passport-to-peril/index.html":
+      '<script src="../../js/storage-policy.js?v=old"></script>',
+    "iframe/revcdos/index.html":
+      '<script src="../../js/storage-policy.js?v=old"></script>',
     "dos/doom/doom.jsdos": "jsdos",
   });
 }
@@ -248,6 +256,7 @@ describe("build metadata", () => {
     const html = await readFile(paths.html, "utf8");
     expect(main).toContain('const APP_VERSION = "26.07.28-abcdef1";');
     expect(html).toContain(`${hashedAssets.mainJs}"`);
+    expect(html).toContain(`${hashedAssets.storagePolicyJs}"`);
     expect(html).toContain(`${hashedAssets.gameInstallerJs}"`);
     expect(html).toContain(`${hashedAssets.gameLibraryJs}"`);
     expect(html).toContain(`${hashedAssets.gameDataJs}"`);
@@ -256,6 +265,15 @@ describe("build metadata", () => {
     expect(await readFile(paths.captureHtml, "utf8")).toContain(
       `${hashedAssets.ruffle}"`,
     );
+    for (const iframe of [
+      "iframe/pink-panther-hokus-pokus/index.html",
+      "iframe/pink-panther-passport-to-peril/index.html",
+      "iframe/revcdos/index.html",
+    ]) {
+      expect(await readFile(join(root, iframe), "utf8")).toContain(
+        `../../${hashedAssets.storagePolicyJs}"`,
+      );
+    }
     expect(html).toMatch(/favicon\.[a-f0-9]{8}\.ico"/);
     expect(html).toMatch(/assets\/xp\/bliss\.[a-f0-9]{8}\.jpg"/);
     expect(await readFile(join(root, hashedAssets.gamesJs), "utf8")).toMatch(

--- a/tests/game-library.test.ts
+++ b/tests/game-library.test.ts
@@ -139,8 +139,10 @@ test("game library", async () => {
     cacheObject: cache,
     metadataStore: store,
     storageManager: {
-      persist: async () => true,
-      estimate: async () => ({ usage: 0, quota: 1024 }),
+      persist: async () => {
+        throw new Error("persistence unavailable");
+      },
+      estimate: async () => ({ usage: 1, quota: 1 }),
     },
     origin: "https://flash.example",
   });
@@ -171,6 +173,27 @@ test("game library", async () => {
   assert.deepEqual(manager.getGames(), {});
   assert.equal(cache.values.size, 0);
   assert.equal(store.values.size, 0);
+
+  const quotaCache = new FakeCache();
+  quotaCache.put = async () => {
+    throw new DOMException("full", "QuotaExceededError");
+  };
+  const quotaStore = new FakeStore();
+  const quotaManager = library.createManager({
+    installer,
+    unzipSync,
+    fetchObject,
+    cacheObject: quotaCache,
+    metadataStore: quotaStore,
+    storageManager: {
+      estimate: async () => ({ usage: 1, quota: 1 }),
+    },
+    origin: "https://flash.example",
+  });
+  await quotaManager.initialize();
+  await assert.rejects(quotaManager.install(details), /actual storage quota/);
+  assert.equal(quotaCache.values.size, 0);
+  assert.equal(quotaStore.values.size, 0);
 
   const legacyCache = new FakeCache();
   const legacyStore = new FakeStore();
@@ -204,6 +227,25 @@ test("game library", async () => {
       `https://flash.example/__installed-games/${legacyUuid}/content/localflash/bikemania3/data/config.bin`,
     ),
   );
+  const originalLegacyPut = legacyCache.put.bind(legacyCache);
+  legacyCache.put = async () => {
+    throw new DOMException("full", "QuotaExceededError");
+  };
+  const uncachedAsset = await legacyManager.match(
+    "http://localflash/bikemania3/data/optional.bin",
+  );
+  assert(uncachedAsset);
+  assert.deepEqual(
+    [...new Uint8Array(await uncachedAsset.arrayBuffer())],
+    [6, 7],
+  );
+  assert.equal(
+    legacyCache.values.has(
+      `https://flash.example/__installed-games/${legacyUuid}/content/localflash/bikemania3/data/optional.bin`,
+    ),
+    false,
+  );
+  legacyCache.put = originalLegacyPut;
   const fetchCountBeforeAppRequest = legacyCache.values.size;
   assert.equal(
     await legacyManager.match("https://flash.example/js/runtime.wasm"),

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -293,6 +293,54 @@ test("offline updates", async () => {
   assert.deepStrictEqual(manager.getSnapshot().downloadedGameIds, []);
   assert(initial.deletedCaches.includes(BUNDLED_GAME_CACHE));
 
+  const lowEstimate = makeEnvironment();
+  lowEstimate.environment.navigator.storage = {
+    estimate: async () => ({ usage: 100, quota: 100 }),
+    persist: async () => {
+      throw new Error("persistence unavailable");
+    },
+  };
+  const lowEstimateManager = createManager({
+    currentVersion: manifest.version,
+    environment: lowEstimate.environment,
+  });
+  await lowEstimateManager.initialize();
+  await lowEstimateManager.downloadGame("bike-mania");
+  assert.deepStrictEqual(lowEstimateManager.getSnapshot().downloadedGameIds, [
+    "bike-mania",
+  ]);
+
+  const quotaFailure = makeEnvironment();
+  const originalPut = quotaFailure.bundledCache.put.bind(
+    quotaFailure.bundledCache,
+  );
+  let putCount = 0;
+  quotaFailure.bundledCache.put = async (key, response) => {
+    putCount += 1;
+    if (putCount === 2) {
+      throw new DOMException("full", "QuotaExceededError");
+    }
+    return originalPut(key, response);
+  };
+  const quotaFailureManager = createManager({
+    currentVersion: manifest.version,
+    environment: quotaFailure.environment,
+  });
+  await quotaFailureManager.initialize();
+  await assert.rejects(
+    quotaFailureManager.downloadGame("doom"),
+    /actual storage quota/,
+  );
+  assert.strictEqual(quotaFailure.bundledCache.values.size, 0);
+  assert.deepStrictEqual(
+    quotaFailureManager.getSnapshot().downloadedGameIds,
+    [],
+  );
+  assert.match(
+    quotaFailureManager.getSnapshot().gameError,
+    /actual storage quota/,
+  );
+
   const sharedRuntime = makeEnvironment();
   const sharedRuntimeManager = createManager({
     currentVersion: manifest.version,

--- a/tests/revcdos.test.ts
+++ b/tests/revcdos.test.ts
@@ -146,7 +146,12 @@ test("offers temporary or persistent WebTorrent downloads alongside manual selec
   expect(host).toContain("destroyStoreOnDestroy: !keepBrowserCopy");
   expect(host).toContain("if (keepBrowserCopy)");
   expect(host).not.toContain("navigator.storage.estimate()");
-  expect(host).toContain('error?.name === "QuotaExceededError"');
+  expect(host).toContain("../../js/storage-policy.js");
+  expect(host).toContain("storagePolicy.errorMessage(error)");
+  expect(packedStore).toContain(
+    "storagePolicy.requestPersistence(navigator.storage)",
+  );
+  expect(packedStore).toContain("directory.removeEntry(dataFile)");
   expect(host).toContain("uploads: 2");
   expect(host).toContain("skipVerify: cached");
   expect(host).toContain("torrent.files.map");

--- a/tests/scummvm.test.ts
+++ b/tests/scummvm.test.ts
@@ -58,6 +58,8 @@ const pokusWrapper = await Bun.file(
 test("supports direct ISO sessions and optional persistent browser copies", () => {
   expect(passportWrapper).toContain("isoSize: 649084928");
   expect(pokusWrapper).toContain("isoSize: 526409728");
+  expect(passportWrapper).toContain("../../js/storage-policy.js");
+  expect(pokusWrapper).toContain("../../js/storage-policy.js");
   expect(launcher).toContain('id="disc-url"');
   expect(launcher).toContain('id="download-disc"');
   expect(launcher).toContain('id="saved-copy"');
@@ -92,7 +94,10 @@ test("supports direct ISO sessions and optional persistent browser copies", () =
   expect(launcher).toContain("localStorage.setItem(");
   expect(launcher).toContain("directory.removeEntry(fileName)");
   expect(launcher).toContain("cross-origin browser downloads (CORS)");
-  expect(launcher).toContain('error?.name === "QuotaExceededError"');
+  expect(launcher).toContain("storagePolicy.errorMessage(error)");
+  expect(launcher).toContain(
+    "storagePolicy.requestPersistence(navigator.storage)",
+  );
   expect(launcher).not.toContain('value="http');
 });
 

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -83,9 +83,13 @@ test("window dragging and resizing coalesce updates by animation frame", () => {
   contains(css, ".xp-window.moving", "will-change: transform");
 });
 test("internet games is integrated with the shell", async () => {
+  expect(await Bun.file(path("site/js/storage-policy.js")).exists()).toBe(true);
   expect(await Bun.file(path("site/js/game-installer.js")).exists()).toBe(true);
   expect(await Bun.file(path("site/js/game-library.js")).exists()).toBe(true);
   expect(await Bun.file(path("site/js/game-data.js")).exists()).toBe(true);
+  expect(html.indexOf('src="js/storage-policy.js')).toBeLessThan(
+    html.indexOf('src="js/game-library.js'),
+  );
   expect(html.indexOf('src="js/game-installer.js')).toBeLessThan(
     html.indexOf('src="js/game-library.js'),
   );

--- a/tests/storage-policy.test.ts
+++ b/tests/storage-policy.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const policy = require("../site/js/storage-policy.js");
+
+test("treats storage estimates as optional information", async () => {
+  expect(
+    await policy.estimate({
+      estimate: async () => ({ usage: 100, quota: 200 }),
+    }),
+  ).toEqual({ usage: 100, quota: 200, usageDetails: null });
+  expect(
+    await policy.estimate({
+      estimate: async () => {
+        throw new Error("estimate unavailable");
+      },
+    }),
+  ).toBeNull();
+});
+
+test("requests persistence without blocking storage writes", async () => {
+  expect(
+    await policy.requestPersistence({
+      persist: async () => {
+        throw new Error("permission denied");
+      },
+    }),
+  ).toBe(false);
+});
+
+test("normalizes real quota failures", () => {
+  const quotaError = new DOMException("full", "QuotaExceededError");
+  expect(policy.isQuotaExceeded(quotaError)).toBe(true);
+  expect(policy.normalizeError(quotaError).message).toBe(policy.QUOTA_MESSAGE);
+  expect(policy.errorMessage(new Error("network failed"))).toBe(
+    "network failed",
+  );
+});

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -364,6 +364,7 @@ export async function updateHtml(
   const mutableAssets = {
     ruffle: "js/ruffle.js",
     gamesJs: "js/games.js",
+    storagePolicyJs: "js/storage-policy.js",
     gameInstallerJs: "js/game-installer.js",
     gameLibraryJs: "js/game-library.js",
     gameDataJs: "js/game-data.js",
@@ -437,6 +438,23 @@ export async function updateHtml(
     "Could not update fflate asset reference",
   );
   await writeFile(paths.html, content);
+
+  for (const relativePath of [
+    "iframe/pink-panther-hokus-pokus/index.html",
+    "iframe/pink-panther-passport-to-peril/index.html",
+    "iframe/revcdos/index.html",
+  ]) {
+    const absolutePath = join(paths.root, relativePath);
+    if (!(await isFile(absolutePath))) continue;
+    let iframe = await readFile(absolutePath, "utf8");
+    iframe = await replaceExactlyOnce(
+      iframe,
+      /\.\.\/\.\.\/js\/storage-policy\.js(?:\?v=[^"]+)?"?/g,
+      `../../${hashedAssets.storagePolicyJs}"`,
+      `Could not update storage policy reference in ${relativePath}`,
+    );
+    await writeFile(absolutePath, iframe);
+  }
 
   if (await isFile(paths.captureHtml)) {
     let capture = await readFile(paths.captureHtml, "utf8");
@@ -739,6 +757,7 @@ export async function validateOutput(outputDir: string): Promise<void> {
   for (const asset of [
     "js/ruffle.js",
     "js/games.js",
+    "js/storage-policy.js",
     "js/game-installer.js",
     "js/game-library.js",
     "js/game-data.js",


### PR DESCRIPTION
## What changed

- Added one shared browser-storage policy for best-effort persistence, informational estimates, quota detection, and consistent error messages.
- Removed predictive `navigator.storage.estimate()` gates from bundled offline games and Internet Games installs.
- Migrated Pink Panther and reVCDOS persistence/error handling to the shared policy.
- Added rollback cleanup for partial Cache Storage writes, failed Pink Panther ISO activation, reVCDOS packed-manifest failures, and optional Internet Game artwork metadata.
- Made lazy legacy-game asset caching best-effort when the actual browser quota is full.
- Fingerprinted the shared policy in production builds and rewrote all iframe references to the hashed asset.

## Why

Brave deliberately generalizes `StorageManager.estimate()` and browser estimates are not exact capacity guarantees. Treating them as preflight authorization caused valid downloads to be rejected before the browser attempted a real write.

## Impact

Downloads now proceed until the underlying Cache Storage, IndexedDB, or OPFS operation actually refuses the write. Real `QuotaExceededError` failures are reported consistently, and partial data is cleaned up. Storage estimates remain available for informational UI only.

## Validation

- `bun run test` — 119 passing, 998 assertions
- `bun run quality`
- `bun run build --revision HEAD`
- Production artifact validation, including hashed storage-policy references in the shell and all three iframe entrypoints
- Live browser smoke test on a fresh local origin: 42-game Offline settings rendered with no console errors
- Regression coverage for low/fixed estimates, rejected persistence requests, actual quota failures, rollback cleanup, and best-effort lazy caching