### PR TITLE
Improve XP desktop navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # Astro Flash Collection
 
-A Windows XP-style desktop for playing classic Flash, HTML5, and DOS games in
-the browser.
+A Windows XP-style desktop for playing classic browser games with Ruffle,
+js-dos, ScummVM, and embedded web runtimes.
 
 [Open Astro Flash Collection](https://flash.4st.li/)
 
 ## Highlights
 
 - Authentic Windows XP shell, Explorer, Notepad, themes, and display settings
-- Flash emulation with Ruffle and DOS emulation with js-dos
 - Draggable game windows, task switching, fullscreen, and volume controls
 - Favorites, recently played games, categories, search, and deep links
-- Automatic offline support for the desktop and optional game downloads
+- Automatic offline support with optional per-game downloads
 - Internet Games catalog backed by Flashpoint Archive
 
 ## Development
 
-Install dependencies and run the test suite:
+Install dependencies and run the checks:
 
 ```bash
 bun install --frozen-lockfile
+bun run quality
 bun run test
 ```
 
@@ -43,42 +43,18 @@ existing output unchanged.
 - `tests/` — Bun/TypeScript tests
 - `dist/` — generated production build; ignored by Git
 
-## Games and offline storage
+## Games and offline support
 
-Included games are defined in `site/js/games.js`. Flash games use `type: "swf"`;
-DOS and HTML5 games use `type: "iframe"`.
-
-```javascript
-{
-  type: "swf",
-  title: "Display Name",
-  icon: "assets/icons/game.png",
-  category: "Racing",
-  frameRate: 45,
-  aspectRatio: 480 / 360,
-  archive: {
-    launchUrl: "https://example.com/game/main.swf",
-    routes: {
-      "https://example.com/game/main.swf": "swf/game/main.swf",
-    },
-  },
-}
-```
+Included games are defined in `site/js/games.js`. Ruffle games use `type: "swf"`;
+embedded HTML5, js-dos, ScummVM, and reVCDOS games use `type: "iframe"`.
 
 The Windows XP shell is cached automatically. Included games can be downloaded
 individually or all at once from **Settings > Offline**. The shared Ruffle
-runtime is downloaded when the first Flash game is selected.
+and ScummVM runtimes are downloaded only when needed.
 
 Games installed through **Internet Games** are stored separately in IndexedDB
 and Cache Storage. GameZIP titles are installed fully; Legacy titles cache
 additional files as they are requested.
-
-Icon sources and checksums live in `site/assets/icons/SOURCES.json`. Validate
-them with:
-
-```bash
-bun run validate:icons
-```
 
 ## Deployment
 
@@ -94,7 +70,7 @@ The repository requires these GitHub Actions secrets:
 The API token needs **Workers Scripts: Edit** for the account and **Workers
 Routes: Edit** for the `4st.li` zone.
 
-To deploy the Worker manually:
+Deploy the Worker manually with:
 
 ```bash
 bun run deploy:worker
@@ -106,4 +82,4 @@ new stable releases and opens a reviewable pull request.
 ## Contributing
 
 Test game compatibility, controls, frame rate, and categorization before
-submitting a pull request. Run `bun run test` before pushing.
+submitting a pull request. Run `bun run quality && bun run test` before pushing.

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -675,6 +675,7 @@ html[data-xp-appearance="silver"] {
   inset: 0;
   z-index: 1;
   overflow: hidden;
+  outline: none;
 }
 
 #desktop-icons.desktop-icons-overflow {
@@ -804,6 +805,10 @@ html[data-xp-appearance="silver"] {
 
 .desktop-icon.selected:focus .icon-label {
   outline: 1px dotted #fff;
+}
+
+.explorer-items:focus {
+  outline: none;
 }
 
 #desktop-icons:not(:focus-within) .desktop-icon.selected .icon-label {

--- a/site/index.html
+++ b/site/index.html
@@ -75,7 +75,7 @@
 
     <!-- Desktop -->
     <div id="desktop" hidden>
-      <div id="desktop-icons"></div>
+      <div id="desktop-icons" tabindex="0"></div>
       <div id="desktop-selection" aria-hidden="true" hidden></div>
 
       <div

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -2345,7 +2345,13 @@ const createSystemWindowContent = (shortcutId, win) => {
 
   const items = document.createElement("div");
   items.className = "explorer-items";
+  items.tabIndex = 0;
   main.appendChild(items);
+  main.addEventListener("pointerdown", (event) => {
+    if (!event.target.closest(".explorer-item")) {
+      items.focus({ preventScroll: true });
+    }
+  });
 
   const chrome = document.createElement("div");
   chrome.className = "explorer-chrome";
@@ -6474,6 +6480,7 @@ const wireDesktopSelectionRectangle = () => {
   container.addEventListener("pointerdown", (event) => {
     if (event.button !== 0 || event.target !== container) return;
 
+    container.focus({ preventScroll: true });
     closeDesktopContextMenu();
     const additive = event.ctrlKey || event.metaKey;
     const initialSelection = new Set(
@@ -6568,17 +6575,24 @@ const buildDesktopIcons = () => {
     (id) => systemShortcuts[id]?.desktop !== false,
   );
   const desktopSort = getDesktopLayoutSettings().sort;
+  const desktopNodeSortName = (node) =>
+    node.ext === ".game" ? node.name.slice(0, -node.ext.length) : node.name;
+  const compareDesktopNodeNames = (a, b) =>
+    desktopNodeSortName(a).localeCompare(desktopNodeSortName(b), undefined, {
+      numeric: true,
+      sensitivity: "base",
+    });
   const compareDesktopNodes = (a, b) => {
     if (desktopSort === "size")
-      return a.size - b.size || a.name.localeCompare(b.name);
+      return a.size - b.size || compareDesktopNodeNames(a, b);
     if (desktopSort === "type")
       return (
         (a.ext || a.type).localeCompare(b.ext || b.type) ||
-        a.name.localeCompare(b.name)
+        compareDesktopNodeNames(a, b)
       );
     if (desktopSort === "modified")
-      return b.modified - a.modified || a.name.localeCompare(b.name);
-    return a.name.localeCompare(b.name);
+      return b.modified - a.modified || compareDesktopNodeNames(a, b);
+    return compareDesktopNodeNames(a, b);
   };
   const entries = [
     ...desktopItems.map((id) => ({ id, system: true })),
@@ -8008,6 +8022,48 @@ const finishAltTab = () => {
 const isEditableTarget = (target) =>
   /^(INPUT|TEXTAREA|SELECT)$/.test(target?.tagName || "") ||
   target?.isContentEditable;
+const typeaheadState = new WeakMap();
+const normalizeTypeaheadText = (value) =>
+  String(value || "")
+    .trim()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase();
+const cycleTypeaheadItem = (event, scope, items, getLabel) => {
+  if (
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.isComposing ||
+    Array.from(event.key).length !== 1
+  )
+    return null;
+
+  const key = normalizeTypeaheadText(event.key);
+  if (!key) return null;
+  const matches = items.filter((item) =>
+    normalizeTypeaheadText(getLabel(item)).startsWith(key),
+  );
+  if (!matches.length) return null;
+
+  const previous = typeaheadState.get(scope);
+  const repeated =
+    previous?.key === key &&
+    matches.includes(previous.target) &&
+    document.activeElement === previous.target;
+  const target = repeated
+    ? matches[(matches.indexOf(previous.target) + 1) % matches.length]
+    : matches[0];
+  typeaheadState.set(scope, { key, target });
+  event.preventDefault();
+  return target;
+};
+const typeaheadItemLabel = (item) =>
+  item.getAttribute("aria-label") ||
+  item.querySelector(
+    ".icon-label, .menu-item-label, .context-label, .sm-game-title, b",
+  )?.textContent ||
+  item.textContent;
 const confirmPermanentDelete = (ids) =>
   XPDialogs.confirm(
     ids.length === 1
@@ -8016,6 +8072,37 @@ const confirmPermanentDelete = (ids) =>
     "Confirm File Delete",
     "warning",
   ).then((yes) => yes && ids.forEach((id) => fs.destroy(id)));
+
+document.addEventListener(
+  "keydown",
+  (event) => {
+    if (event.defaultPrevented || isEditableTarget(event.target)) return;
+    const active = document.activeElement;
+    let scope = active?.closest?.('[role="menu"], [role="menubar"]');
+    const startMenu = document.getElementById("start-menu");
+    if (
+      !scope &&
+      !startMenu.hidden &&
+      (startMenu.contains(active) || active?.id === "start-button")
+    ) {
+      scope = startMenu;
+    }
+    if (!scope) return;
+
+    const items = [...scope.querySelectorAll("button:not(:disabled)")].filter(
+      (item) => {
+        if (!item.getClientRects().length) return false;
+        if (scope === startMenu) return startMenu.contains(item);
+        return item.closest('[role="menu"], [role="menubar"]') === scope;
+      },
+    );
+    const target = cycleTypeaheadItem(event, scope, items, typeaheadItemLabel);
+    if (!target) return;
+    target.focus();
+    event.stopImmediatePropagation();
+  },
+  true,
+);
 
 gameLibraryInitialization = initializeGameLibrary();
 
@@ -8142,6 +8229,18 @@ document.addEventListener("keydown", (e) => {
   const desktopHasFocus =
     desktopIcon || document.activeElement?.id === "desktop-icons";
   if (desktopHasFocus) {
+    const desktopIcons = [...document.querySelectorAll(".desktop-icon")];
+    const typeaheadTarget = cycleTypeaheadItem(
+      e,
+      document.getElementById("desktop-icons"),
+      desktopIcons,
+      typeaheadItemLabel,
+    );
+    if (typeaheadTarget) {
+      selectDesktopIcon(typeaheadTarget.dataset.desktopId);
+      typeaheadTarget.focus();
+      return;
+    }
     const {
       filesystemIds: selectedFsIds,
       allFilesystem,
@@ -8204,10 +8303,12 @@ document.addEventListener("keydown", (e) => {
       desktopIcon &&
       ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key)
     ) {
-      const icons = [...document.querySelectorAll(".desktop-icon")];
-      const current = icons.indexOf(desktopIcon);
+      const current = desktopIcons.indexOf(desktopIcon);
       const direction = e.key === "ArrowLeft" || e.key === "ArrowUp" ? -1 : 1;
-      const target = icons[(current + direction + icons.length) % icons.length];
+      const target =
+        desktopIcons[
+          (current + direction + desktopIcons.length) % desktopIcons.length
+        ];
       e.preventDefault();
       if (!e.ctrlKey && !e.shiftKey)
         selectDesktopIcon(target.dataset.desktopId);
@@ -8217,11 +8318,27 @@ document.addEventListener("keydown", (e) => {
     }
   }
 
+  const explorerSurface = document.activeElement?.closest?.(".explorer-items");
   const explorerItem = document.activeElement?.closest?.(".explorer-item");
   const explorerWin =
-    explorerItem &&
-    [...openWindows.values()].find((win) => win.el.contains(explorerItem));
+    explorerSurface &&
+    [...openWindows.values()].find((win) => win.el.contains(explorerSurface));
   if (explorerWin) {
+    const explorerItems = [
+      ...explorerSurface.querySelectorAll(".explorer-item"),
+    ];
+    const typeaheadTarget = cycleTypeaheadItem(
+      e,
+      explorerSurface,
+      explorerItems,
+      typeaheadItemLabel,
+    );
+    if (typeaheadTarget) {
+      explorerItems.forEach((item) => item.classList.remove("selected"));
+      typeaheadTarget.classList.add("selected");
+      typeaheadTarget.focus();
+      return;
+    }
     const selected = selectedExplorerNodes(explorerWin);
     const protectedSelection = selected.some((id) => fs.isProtected(id));
     if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "a") {

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -968,6 +968,14 @@ test("desktop game labels hide virtual extension", () =>
     'node.ext === ".game"',
     "node.name.slice(0, -node.ext.length)",
   ));
+test("desktop games use natural title order", () =>
+  contains(
+    javascript,
+    "const desktopNodeSortName =",
+    'node.ext === ".game" ? node.name.slice(0, -node.ext.length) : node.name',
+    "numeric: true",
+    'sensitivity: "base"',
+  ));
 test("anchored recycle bin does not consume an early grid slot", () => {
   const entries = javascript.indexOf("const entries = [");
   const files = javascript.indexOf(".getChildren(fs.DESKTOP)", entries);
@@ -1053,6 +1061,21 @@ test("shell keyboard router covers window switching and file shortcuts", () =>
     "if (!showSwitcher) altTabIndex = order.findIndex",
     "altTabIndex = 0;",
   ));
+test("desktop folders and menus cycle matching items by first letter", () => {
+  contains(html, 'id="desktop-icons" tabindex="0"');
+  js(
+    "const typeaheadState = new WeakMap()",
+    "const cycleTypeaheadItem =",
+    "document.activeElement === previous.target",
+    "matches[(matches.indexOf(previous.target) + 1) % matches.length]",
+    "event.stopImmediatePropagation()",
+    "selectDesktopIcon(typeaheadTarget.dataset.desktopId)",
+    'document.activeElement?.closest?.(".explorer-items")',
+    'typeaheadTarget.classList.add("selected")',
+    "items.tabIndex = 0",
+  );
+  contains(css, "#desktop-icons", "outline: none", ".explorer-items:focus");
+});
 test("show desktop restores focus and resize reflows tasks", () => {
   contains(javascript, "focusedGameId,", "showDesktopSnapshot.windows.forEach");
   contains(


### PR DESCRIPTION
## Summary

- simplify and update the README around current runtimes, development, offline support, and deployment
- sort desktop game shortcuts by their visible titles with natural numeric ordering
- add Windows XP-style first-letter cycling across desktop icons, Explorer items, and menus
- preserve the original top-to-bottom desktop icon flow

## Why

Desktop sorting used the hidden `.game` extension, which placed base titles after numbered sequels. Keyboard navigation also lacked the Windows XP behavior where repeated letter presses cycle through matching items.

## Impact

Desktop and Explorer navigation now behaves more like Windows XP without changing the existing desktop layout. Editable controls and Ctrl/Alt shortcuts keep their existing behavior.

## Validation

- `bun run quality`
- `bun run test` — 129 tests
- `bun run build --revision HEAD`
- `bun run deploy:worker -- --dry-run --outdir /tmp/astro-flash-worker-check-navigation`
- browser verification for desktop, Explorer, and menu letter cycling
- browser verification that the original icon column flow remains unchanged
