### PR TITLE
Support multilingual Pink Panther ISOs

### DIFF
--- a/site/iframe/pink-panther-hokus-pokus/index.html
+++ b/site/iframe/pink-panther-hokus-pokus/index.html
@@ -15,10 +15,22 @@
         shellId: "pink-panther-hokus-pokus",
         scummvmId: "pink:pokus",
         title: "The Pink Panther: Hokus Pokus Pink",
-        isoSize: 526409728,
-        requiredFiles: Object.freeze({
-          "HPP.EXE": 697856,
-          "HPP.ORB": 503443586,
+        orbFile: "HPP.ORB",
+        fileSets: Object.freeze([Object.freeze(["HPP.ORB", "HPP.EXE"])]),
+        releases: Object.freeze({
+          509498007: "Dutch",
+          509498617: "Dutch",
+          503443586: "English",
+          492220293: "French",
+          543000636: "German",
+          502988485: "Hebrew",
+          504320381: "Italian",
+          539274161: "Polish",
+          526755539: "Brazilian Portuguese",
+          526369062: "Russian",
+          508716126: "Spanish",
+          500103742: "Swedish",
+          513518023: "Danish",
         }),
       });
     </script>

--- a/site/iframe/pink-panther-passport-to-peril/index.html
+++ b/site/iframe/pink-panther-passport-to-peril/index.html
@@ -15,11 +15,28 @@
         shellId: "pink-panther-passport-to-peril",
         scummvmId: "pink:peril",
         title: "The Pink Panther: Passport to Peril",
-        isoSize: 649084928,
-        requiredFiles: Object.freeze({
-          "PPTP.EXE": 594432,
-          "PPTP.ORB": 618203600,
-          "PPTP.BRO": 8945466,
+        orbFile: "PPTP.ORB",
+        fileSets: Object.freeze([
+          Object.freeze(["PPTP.ORB", "PPTP.EXE", "PPTP.BRO"]),
+          Object.freeze(["PPTP.ORB", "DATA1.CAB"]),
+        ]),
+        releases: Object.freeze({
+          608976918: "Danish",
+          613211963: "Dutch",
+          618203600: "English",
+          619145676: "British English",
+          612549215: "Finnish",
+          607185037: "French",
+          609695309: "German",
+          616292424: "Hebrew",
+          622766069: "Italian",
+          612644330: "Norwegian",
+          644839372: "Polish",
+          642216577: "Brazilian Portuguese",
+          635322616: "Russian",
+          634841166: "Spanish",
+          633626567: "Spanish",
+          633843917: "Swedish",
         }),
       });
     </script>

--- a/site/iframe/scummvm/iso9660.js
+++ b/site/iframe/scummvm/iso9660.js
@@ -98,16 +98,28 @@
     return files;
   };
 
-  const gameFilesFromIso = async (iso, requiredFiles, gameTitle) => {
+  const gameFilesFromIso = async (iso, game) => {
     const files = await indexIsoFiles(iso);
+    const orb = files.get(game.orbFile);
+    const language = orb && game.releases[String(orb.size)];
+    if (!language) {
+      throw new Error(
+        `This is not a supported ${game.title} CD image (${game.orbFile} was not recognized).`,
+      );
+    }
+
+    const requiredFiles = game.fileSets.find((fileSet) =>
+      fileSet.every((name) => files.has(name)),
+    );
+    if (!requiredFiles) {
+      throw new Error(
+        `This ${language} ${game.title} CD image is missing required game files.`,
+      );
+    }
+
     const gameFiles = [];
-    for (const [name, expectedSize] of Object.entries(requiredFiles)) {
+    for (const name of requiredFiles) {
       const entry = files.get(name);
-      if (!entry || entry.size !== expectedSize) {
-        throw new Error(
-          `This is not the English ${gameTitle} CD image (${name} was not found).`,
-        );
-      }
       const start = entry.extent * ISO_SECTOR_SIZE;
       gameFiles.push({
         name,
@@ -116,11 +128,10 @@
         data: iso.slice(start, start + entry.size),
       });
     }
-    return gameFiles;
+    return { gameFiles, language };
   };
 
-  const gameBlobsFromIso = async (iso, requiredFiles, gameTitle) =>
-    gameFilesFromIso(iso, requiredFiles, gameTitle);
+  const gameBlobsFromIso = gameFilesFromIso;
 
   return { gameBlobsFromIso, gameFilesFromIso, indexIsoFiles };
 });

--- a/site/iframe/scummvm/launcher.js
+++ b/site/iframe/scummvm/launcher.js
@@ -9,6 +9,7 @@
   const SCUMMVM_ROOT = "../../vendor/scummvm/2026.3.0/";
   const SCUMMVM_GAME_ROUTE = `/iframe/scummvm/local-games/${game.id}/`;
   const STORAGE_DIRECTORY = "astro-flash-scummvm";
+  const MAX_CD_IMAGE_SIZE = 800 * 1024 * 1024;
   const metadataKey = `astro-flash.scummvm.${game.id}.iso.v1`;
   const runtimeManifestName = `${game.id}-manifest.json`;
   let currentVolume = 1;
@@ -100,7 +101,7 @@
     <body>
       <main id="disc-panel">
         <h1></h1>
-        <p>Select your own English CD image. Local images are read directly and never uploaded.</p>
+        <p>Select your own CD image in any supported language. Local images are read directly and never uploaded.</p>
         <input id="disc-input" type="file" accept=".iso,application/x-iso9660-image">
         <label class="keep-copy"><input id="keep-copy" type="checkbox" checked> Keep a copy in this browser for next time</label>
         <div class="divider">or download an ISO</div>
@@ -224,7 +225,7 @@
     return root.getDirectoryHandle(STORAGE_DIRECTORY, { create });
   };
 
-  const writeRuntimeManifest = async (directory, fileName, gameFiles) => {
+  const writeRuntimeManifest = async (directory, fileName, iso, gameFiles) => {
     const handle = await directory.getFileHandle(runtimeManifestName, {
       create: true,
     });
@@ -233,7 +234,7 @@
       JSON.stringify({
         version: 1,
         isoFile: fileName,
-        isoSize: game.isoSize,
+        isoSize: iso.size,
         files: Object.fromEntries(
           gameFiles.map(({ name, offset, size }) => [name, { offset, size }]),
         ),
@@ -275,13 +276,10 @@
       const directory = await getStorageDirectory();
       const handle = await directory.getFileHandle(metadata.fileName);
       const iso = await handle.getFile();
-      if (iso.size !== game.isoSize) {
-        throw new Error("Saved CD image has the wrong size.");
-      }
       savedIso = iso;
       discUrl.value = metadata.url || "";
       savedCopyButton.hidden = false;
-      savedCopyButton.textContent = `Play browser copy (${formatBytes(iso.size)})`;
+      savedCopyButton.textContent = `Play ${metadata.language ? `${metadata.language} ` : ""}browser copy (${formatBytes(iso.size)})`;
     } catch {
       localStorage.removeItem(metadataKey);
     }
@@ -383,14 +381,17 @@
     fileName,
     iso,
     gameFiles,
-    { keep, url = "" },
+    { keep, language, url = "" },
   ) => {
     const previous = keep ? readMetadata() : null;
     if (keep) {
-      localStorage.setItem(metadataKey, JSON.stringify({ fileName, url }));
+      localStorage.setItem(
+        metadataKey,
+        JSON.stringify({ fileName, language, url }),
+      );
     }
     try {
-      await writeRuntimeManifest(directory, fileName, gameFiles);
+      await writeRuntimeManifest(directory, fileName, iso, gameFiles);
     } catch (error) {
       if (keep) {
         if (previous) {
@@ -404,7 +405,7 @@
     if (keep) {
       savedIso = iso;
       savedCopyButton.hidden = false;
-      savedCopyButton.textContent = `Play browser copy (${formatBytes(iso.size)})`;
+      savedCopyButton.textContent = `Play ${language} browser copy (${formatBytes(iso.size)})`;
       if (previous?.fileName && previous.fileName !== fileName) {
         await directory.removeEntry(previous.fileName).catch(() => {});
       }
@@ -419,12 +420,7 @@
     );
   };
 
-  const storeIso = async (iso, gameFiles, { keep, url = "" }) => {
-    if (iso.size !== game.isoSize) {
-      throw new Error(
-        `The CD image is ${formatBytes(iso.size)}, but this game requires ${formatBytes(game.isoSize)}.`,
-      );
-    }
+  const storeIso = async (iso, gameFiles, options) => {
     await storagePolicy.requestPersistence(navigator.storage);
     const directory = await getStorageDirectory(true);
     const fileName = `${game.id}-${crypto.randomUUID()}.iso`;
@@ -439,7 +435,7 @@
         copied += value.byteLength;
         await writable.write(value);
         setMessage(
-          `Saving browser copy… ${formatBytes(copied)} of ${formatBytes(game.isoSize)} (${((copied / game.isoSize) * 100).toFixed(1)}%)`,
+          `Saving browser copy… ${formatBytes(copied)} of ${formatBytes(iso.size)} (${((copied / iso.size) * 100).toFixed(1)}%)`,
         );
       }
       await writable.close();
@@ -451,8 +447,7 @@
     try {
       const storedIso = await handle.getFile();
       await activateStoredIso(directory, fileName, storedIso, gameFiles, {
-        keep,
-        url,
+        ...options,
       });
       return { fileName, iso: storedIso };
     } catch (error) {
@@ -464,25 +459,36 @@
   const prepareIso = async (iso, options) => {
     setControlsDisabled(true);
     setMessage("Checking CD image…");
-    const gameFiles = await window.AstroIso9660.gameFilesFromIso(
+    if (iso.size > MAX_CD_IMAGE_SIZE) {
+      throw new Error(
+        "The CD image is larger than the supported 800 MiB limit.",
+      );
+    }
+    const { gameFiles, language } = await window.AstroIso9660.gameFilesFromIso(
       iso,
-      game.requiredFiles,
-      game.title,
+      game,
     );
-    if (options.keep) return storeIso(iso, gameFiles, options);
+    const preparedOptions = { ...options, language };
+    if (options.keep)
+      return {
+        ...(await storeIso(iso, gameFiles, preparedOptions)),
+        language,
+      };
     activateTemporaryIso(iso, gameFiles);
-    return { fileName: null, iso };
+    return { fileName: null, iso, language };
   };
 
   discInput.addEventListener("change", async () => {
     const [iso] = discInput.files;
     if (!iso) return;
     try {
-      await prepareIso(iso, { keep: keepCopy.checked });
+      const { language } = await prepareIso(iso, {
+        keep: keepCopy.checked,
+      });
       setMessage(
         keepCopy.checked
-          ? "Browser copy saved. Starting ScummVM…"
-          : "Starting ScummVM…",
+          ? `${language} browser copy saved. Starting ScummVM…`
+          : `${language} CD image verified. Starting ScummVM…`,
       );
       await startScummVm();
     } catch (error) {
@@ -497,11 +503,8 @@
     try {
       setControlsDisabled(true);
       setMessage("Checking browser copy…");
-      const gameFiles = await window.AstroIso9660.gameFilesFromIso(
-        savedIso,
-        game.requiredFiles,
-        game.title,
-      );
+      const { gameFiles, language } =
+        await window.AstroIso9660.gameFilesFromIso(savedIso, game);
       const metadata = readMetadata();
       const directory = await getStorageDirectory();
       await activateStoredIso(
@@ -509,7 +512,7 @@
         metadata.fileName,
         savedIso,
         gameFiles,
-        { keep: true, url: metadata.url || "" },
+        { keep: true, language, url: metadata.url || "" },
       );
       await startScummVm();
     } catch (error) {
@@ -559,9 +562,9 @@
       }
 
       const contentLength = Number(response.headers.get("Content-Length"));
-      if (contentLength && contentLength !== game.isoSize) {
+      if (contentLength > MAX_CD_IMAGE_SIZE) {
         throw new Error(
-          `The remote file is ${formatBytes(contentLength)}, but this game requires ${formatBytes(game.isoSize)}.`,
+          "The remote CD image is larger than the supported 800 MiB limit.",
         );
       }
 
@@ -581,11 +584,9 @@
         const { done, value } = await reader.read();
         if (done) break;
         downloaded += value.byteLength;
-        if (downloaded > game.isoSize) {
+        if (downloaded > MAX_CD_IMAGE_SIZE) {
           await reader.cancel();
-          throw new Error(
-            "The downloaded file is larger than the expected CD image.",
-          );
+          throw new Error("The downloaded CD image exceeds the 800 MiB limit.");
         }
         if (writable) {
           await writable.write(value);
@@ -593,7 +594,9 @@
           chunks.push(value);
         }
         setMessage(
-          `Downloading… ${formatBytes(downloaded)} of ${formatBytes(game.isoSize)} (${((downloaded / game.isoSize) * 100).toFixed(1)}%)`,
+          contentLength
+            ? `Downloading… ${formatBytes(downloaded)} of ${formatBytes(contentLength)} (${((downloaded / contentLength) * 100).toFixed(1)}%)`
+            : `Downloading… ${formatBytes(downloaded)}`,
         );
       }
       let iso;
@@ -604,20 +607,13 @@
       } else {
         iso = new Blob(chunks, { type: "application/x-iso9660-image" });
       }
-      if (iso.size !== game.isoSize) {
-        throw new Error(
-          `The download is ${formatBytes(iso.size)}, but this game requires ${formatBytes(game.isoSize)}.`,
-        );
-      }
       setMessage("Checking downloaded CD image…");
-      const gameFiles = await window.AstroIso9660.gameFilesFromIso(
-        iso,
-        game.requiredFiles,
-        game.title,
-      );
+      const { gameFiles, language } =
+        await window.AstroIso9660.gameFilesFromIso(iso, game);
       if (keepCopy.checked) {
         await activateStoredIso(directory, fileName, iso, gameFiles, {
           keep: true,
+          language,
           url: url.href,
         });
       } else {
@@ -625,8 +621,8 @@
       }
       setMessage(
         keepCopy.checked
-          ? "Download verified and saved. Starting ScummVM…"
-          : "Download verified. Starting ScummVM…",
+          ? `${language} download verified and saved. Starting ScummVM…`
+          : `${language} download verified. Starting ScummVM…`,
       );
       directory = null;
       fileName = null;

--- a/tests/scummvm.test.ts
+++ b/tests/scummvm.test.ts
@@ -6,11 +6,21 @@ const require = createRequire(import.meta.url);
 const { gameBlobsFromIso } = require("../site/iframe/scummvm/iso9660.js") as {
   gameBlobsFromIso: (
     iso: Blob,
-    requiredFiles: Record<string, number>,
-    gameTitle: string,
-  ) => Promise<
-    Array<{ data: Blob; name: string; offset: number; size: number }>
-  >;
+    game: {
+      fileSets: readonly (readonly string[])[];
+      orbFile: string;
+      releases: Readonly<Record<string, string>>;
+      title: string;
+    },
+  ) => Promise<{
+    gameFiles: Array<{
+      data: Blob;
+      name: string;
+      offset: number;
+      size: number;
+    }>;
+    language: string;
+  }>;
 };
 const offlineWorker = await Bun.file(
   new URL("../site/js/offline-worker.js", import.meta.url),
@@ -20,7 +30,13 @@ const sourceRoot = `${import.meta.dir}/../source-media/scummvm`;
 const games = [
   {
     iso: "passport-to-peril-english.iso",
-    title: "The Pink Panther: Passport to Peril",
+    language: "English",
+    game: {
+      title: "The Pink Panther: Passport to Peril",
+      orbFile: "PPTP.ORB",
+      fileSets: [["PPTP.ORB", "PPTP.EXE", "PPTP.BRO"]],
+      releases: { 618203600: "English" },
+    },
     files: {
       "PPTP.EXE": 594432,
       "PPTP.ORB": 618203600,
@@ -28,11 +44,46 @@ const games = [
     },
   },
   {
+    iso: "Peligrosa.iso",
+    language: "Spanish",
+    game: {
+      title: "The Pink Panther: Passport to Peril",
+      orbFile: "PPTP.ORB",
+      fileSets: [["PPTP.ORB", "PPTP.EXE", "PPTP.BRO"]],
+      releases: { 633626567: "Spanish" },
+    },
+    files: {
+      "PPTP.EXE": 595456,
+      "PPTP.ORB": 633626567,
+      "PPTP.BRO": 20,
+    },
+  },
+  {
     iso: "hokus-pokus-pink-english.iso",
-    title: "The Pink Panther: Hokus Pokus Pink",
+    language: "English",
+    game: {
+      title: "The Pink Panther: Hokus Pokus Pink",
+      orbFile: "HPP.ORB",
+      fileSets: [["HPP.ORB", "HPP.EXE"]],
+      releases: { 503443586: "English" },
+    },
     files: {
       "HPP.EXE": 697856,
       "HPP.ORB": 503443586,
+    },
+  },
+  {
+    iso: "ABRACADABRA.iso",
+    language: "Spanish",
+    game: {
+      title: "The Pink Panther: Hokus Pokus Pink",
+      orbFile: "HPP.ORB",
+      fileSets: [["HPP.ORB", "HPP.EXE"]],
+      releases: { 508716126: "Spanish" },
+    },
+    files: {
+      "HPP.EXE": 699904,
+      "HPP.ORB": 508716126,
     },
   },
 ] as const;
@@ -54,10 +105,48 @@ const pokusWrapper = await Bun.file(
     import.meta.url,
   ),
 ).text();
+const releaseTable = (wrapper: string) =>
+  Object.fromEntries(
+    [...wrapper.matchAll(/^\s+(\d+): "([^"]+)",$/gm)].map((match) => [
+      match[1],
+      match[2],
+    ]),
+  );
 
 test("supports direct ISO sessions and optional persistent browser copies", () => {
-  expect(passportWrapper).toContain("isoSize: 649084928");
-  expect(pokusWrapper).toContain("isoSize: 526409728");
+  expect(releaseTable(passportWrapper)).toEqual({
+    608976918: "Danish",
+    613211963: "Dutch",
+    618203600: "English",
+    619145676: "British English",
+    612549215: "Finnish",
+    607185037: "French",
+    609695309: "German",
+    616292424: "Hebrew",
+    622766069: "Italian",
+    612644330: "Norwegian",
+    644839372: "Polish",
+    642216577: "Brazilian Portuguese",
+    635322616: "Russian",
+    634841166: "Spanish",
+    633626567: "Spanish",
+    633843917: "Swedish",
+  });
+  expect(releaseTable(pokusWrapper)).toEqual({
+    509498007: "Dutch",
+    509498617: "Dutch",
+    503443586: "English",
+    492220293: "French",
+    543000636: "German",
+    502988485: "Hebrew",
+    504320381: "Italian",
+    539274161: "Polish",
+    526755539: "Brazilian Portuguese",
+    526369062: "Russian",
+    508716126: "Spanish",
+    500103742: "Swedish",
+    513518023: "Danish",
+  });
   expect(passportWrapper).toContain("../../js/storage-policy.js");
   expect(pokusWrapper).toContain("../../js/storage-policy.js");
   expect(launcher).toContain('id="disc-url"');
@@ -72,13 +161,15 @@ test("supports direct ISO sessions and optional persistent browser copies", () =
   expect(launcher).toContain("handle.createWritable()");
   expect(launcher).toContain("response.body.getReader()");
   expect(launcher).toContain("activateTemporaryIso(iso, gameFiles)");
-  expect(launcher).toContain("if (options.keep) return storeIso");
+  expect(launcher).toContain("await storeIso(iso, gameFiles, preparedOptions)");
   expect(launcher).toContain("chunks.push(value)");
   expect(launcher).toContain("window.fetch = (input, init)");
   expect(launcher).toContain("temporaryIso.slice(");
   expect(launcher).not.toContain("navigator.storage.estimate()");
-  expect(launcher).toContain("downloaded > game.isoSize");
-  expect(launcher).toContain("iso.size !== game.isoSize");
+  expect(launcher).toContain("downloaded > MAX_CD_IMAGE_SIZE");
+  expect(launcher).toContain("isoSize: iso.size");
+  expect(launcher).not.toContain("game.isoSize");
+  expect(launcher).not.toContain("game.requiredFiles");
   expect(launcher).toContain("gameFilesFromIso(");
   expect(launcher).toContain("SCUMMVM_GAME_UPDATED");
   expect(launcher).toContain('event: "astro.offline-game-ready"');
@@ -101,18 +192,18 @@ test("supports direct ISO sessions and optional persistent browser copies", () =
   expect(launcher).not.toContain('value="http');
 });
 
-test("mounts the required English files from both authorized CD images", async () => {
+test("mounts supported English and Spanish CD images", async () => {
   if (!authorizedCopiesAvailable) return;
   for (const game of games) {
-    const blobs = await gameBlobsFromIso(
+    const { gameFiles, language } = await gameBlobsFromIso(
       Bun.file(`${sourceRoot}/${game.iso}`),
-      game.files,
-      game.title,
+      game.game,
     );
+    expect(language).toBe(game.language);
     expect(
-      Object.fromEntries(blobs.map(({ data, name }) => [name, data.size])),
+      Object.fromEntries(gameFiles.map(({ data, name }) => [name, data.size])),
     ).toEqual(game.files);
-    expect(blobs.every(({ offset }) => Number.isSafeInteger(offset))).toBe(
+    expect(gameFiles.every(({ offset }) => Number.isSafeInteger(offset))).toBe(
       true,
     );
   }
@@ -121,10 +212,6 @@ test("mounts the required English files from both authorized CD images", async (
 test("rejects a CD image for the other Pink Panther game", async () => {
   if (!authorizedCopiesAvailable) return;
   await expect(
-    gameBlobsFromIso(
-      Bun.file(`${sourceRoot}/${games[1].iso}`),
-      games[0].files,
-      games[0].title,
-    ),
-  ).rejects.toThrow("PPTP.EXE was not found");
+    gameBlobsFromIso(Bun.file(`${sourceRoot}/${games[2].iso}`), games[0].game),
+  ).rejects.toThrow("PPTP.ORB was not recognized");
 });


### PR DESCRIPTION
## Summary

- support every Pink Panther language release recognized by the bundled ScummVM Pink engine
- detect the release language from its ORB payload and mount the matching disc files
- support alternate Spanish releases and the compressed Polish Passport layout
- store each disc's actual ISO size and detected language instead of assuming English media sizes
- update ISO download progress, validation messaging, and regression coverage

## Root cause

The launcher hard-coded the total ISO size and payload sizes of the two English discs. Valid localized releases use different ISO, executable, support-file, and ORB sizes, so they were rejected before ScummVM could start them.

## Impact

Users can now select or download supported localized Pink Panther ISOs without a language selector. The launcher identifies the release automatically while preserving temporary and persistent browser-copy workflows.

## Validation

- `bun run test` — 129 tests passed
- `bun run quality`
- `git diff --check`
- browser-tested `Peligrosa.iso` through the Passport to Peril opening sequence
- browser-tested `ABRACADABRA.iso` through the Hokus Pokus opening sequence