### PR TITLE
Prioritize bundled Flash routes

### DIFF
--- a/site/js/main.js
+++ b/site/js/main.js
@@ -8746,6 +8746,11 @@ const routedFetch = flashUrlRouter.wrapFetch(originalFetch, (routed) => {
 });
 window.fetch = async (...args) => {
   const originalRequest = args[0];
+  // Bundled routes are exact and authoritative. Resolve them before the
+  // installed-game fallback, which may probe every legacy package remotely.
+  if (flashUrlRouter.resolve(originalRequest)) {
+    return routedFetch(...args);
+  }
   if (gameLibraryReady && gameLibrary && !gameLibraryError) {
     try {
       const installedResponse = await gameLibrary.match(originalRequest);

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -150,7 +150,16 @@ test("Flash URL routing is shared and uses exact archived assets", async () => {
   js(
     "window.AstroFlashUrlRouter.create(",
     "const routedFetch = flashUrlRouter.wrapFetch",
+    "if (flashUrlRouter.resolve(originalRequest))",
   );
+  const bundledRouteCheck = javascript.indexOf(
+    "if (flashUrlRouter.resolve(originalRequest))",
+  );
+  const installedGameLookup = javascript.indexOf(
+    "await gameLibrary.match(originalRequest)",
+  );
+  expect(bundledRouteCheck).toBeGreaterThan(-1);
+  expect(bundledRouteCheck).toBeLessThan(installedGameLookup);
   contains(
     html,
     '<script src="js/games.js"></script>',


### PR DESCRIPTION
## What changed

- route exact bundled Flash archive URLs before consulting installed Internet Games
- add regression coverage that enforces the fetch-order contract

## Why

The installed-game fallback treated every external Flash request as a possible legacy asset and probed every installed game UUID first. Bundled games such as The Simpsons Movie: Wrecking Ball therefore generated repeated `/api/games/.../asset` 404s and could remain stuck while their real packaged resources waited.

Bundled routes are explicit and authoritative, so they now bypass that fallback and load directly from their versioned package root. Installed games retain the fallback for unmatched URLs.

## Validation

- `bun run test` — 131 tests passed
- `bun run quality`
- browser-tested The Simpsons Movie: Wrecking Ball locally; the title screen loaded and all four archived resources routed to the versioned package without installed-game UUID probes