### PR TITLE
Fix Windows Classic shell fidelity

### DIFF
--- a/site/css/main.css
+++ b/site/css/main.css
@@ -662,6 +662,18 @@ html[data-xp-appearance="silver"] {
   --taskbar-gradient: linear-gradient(#8793a5, #596575);
 }
 
+/* Windows Classic is the native USER32 style, not a gray Luna skin. */
+html[data-xp-appearance="classic"] {
+  --xp-beige: #d4d0c8;
+  --xp-beige-dark: #aca899;
+  --titlebar-active: linear-gradient(90deg, #0a246a, #a6caf0);
+  --titlebar-inactive: linear-gradient(90deg, #808080, #c0c0c0);
+  --taskbar-gradient: #d4d0c8;
+  --tray-gradient: #d4d0c8;
+  --window-frame: none;
+  --window-frame-inactive: none;
+}
+
 /* ---- Desktop icons ---- */
 
 #desktop-icons {
@@ -13148,4 +13160,450 @@ html[data-xp-menu-shadows="false"] .desktop-context-menu {
     font-size: 10px;
     padding: 1px;
   }
+}
+
+/* ============ Windows Classic visual style ============ */
+
+html[data-xp-appearance="classic"] #desktop {
+  bottom: 28px;
+}
+
+html[data-xp-appearance="classic"] .xp-window {
+  padding: 2px;
+  border: 1px solid #000;
+  border-radius: 0;
+  background: #d4d0c8;
+  box-shadow:
+    inset 1px 1px #fff,
+    inset -1px -1px #808080;
+}
+
+html[data-xp-appearance="classic"] .xp-window.active {
+  box-shadow:
+    inset 1px 1px #fff,
+    inset -1px -1px #808080;
+}
+
+html[data-xp-appearance="classic"] .xp-window.maximized {
+  padding: 2px;
+}
+
+html[data-xp-appearance="classic"] .title-bar,
+html[data-xp-appearance="classic"] .xp-window.maximized .title-bar {
+  height: 18px;
+  min-height: 18px;
+  gap: 3px;
+  margin: 0;
+  padding: 1px 2px;
+  border-radius: 0;
+  background: var(--titlebar-inactive);
+  box-shadow: none;
+  font-family: Tahoma, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-shadow: none;
+}
+
+html[data-xp-appearance="classic"] .xp-window.active .title-bar {
+  background: var(--titlebar-active);
+}
+
+html[data-xp-appearance="classic"] .title-icon,
+html[data-xp-appearance="classic"] .title-icon img {
+  width: 16px;
+  height: 16px;
+}
+
+html[data-xp-appearance="classic"] .title-buttons {
+  gap: 2px;
+  margin-right: 0;
+}
+
+html[data-xp-appearance="classic"] .tb-btn,
+html[data-xp-appearance="classic"] .help-btn {
+  width: 16px;
+  height: 14px;
+  border: 1px solid #000;
+  border-radius: 0;
+  background: #d4d0c8;
+  box-shadow:
+    inset 1px 1px #fff,
+    inset -1px -1px #808080;
+}
+
+html[data-xp-appearance="classic"] .tb-btn:active:not(:disabled) {
+  box-shadow:
+    inset 1px 1px #808080,
+    inset -1px -1px #fff;
+}
+
+html[data-xp-appearance="classic"] .tb-btn::after {
+  inset: 0;
+  background: none;
+}
+
+html[data-xp-appearance="classic"] .minimize-btn::after {
+  content: "";
+  top: auto;
+  right: 3px;
+  bottom: 3px;
+  left: 3px;
+  height: 2px;
+  background: #000;
+}
+
+html[data-xp-appearance="classic"] .maximize-btn::after {
+  content: "";
+  inset: 2px 3px 3px;
+  border: 1px solid #000;
+  border-top-width: 2px;
+}
+
+html[data-xp-appearance="classic"] .restore-btn::after {
+  content: "";
+  inset: 3px 2px 2px 4px;
+  border: 1px solid #000;
+  box-shadow:
+    -2px 2px 0 -1px #d4d0c8,
+    -3px 3px 0 -1px #000;
+}
+
+html[data-xp-appearance="classic"] .close-btn::after {
+  content: "×";
+  display: grid;
+  place-items: center;
+  color: #000;
+  font:
+    bold 14px/12px Arial,
+    sans-serif;
+}
+
+html[data-xp-appearance="classic"] .help-btn::after {
+  content: "?";
+  display: grid;
+  inset: 0;
+  place-items: center;
+  color: #000;
+  background: none;
+  font:
+    bold 11px/12px Tahoma,
+    sans-serif;
+  text-shadow: none;
+}
+
+html[data-xp-appearance="classic"] #taskbar {
+  height: 28px;
+  align-items: center;
+  border-top: 1px solid #fff;
+  background: #d4d0c8;
+  box-shadow: inset 0 1px #d4d0c8;
+}
+
+#start-button > img,
+#start-button > span {
+  display: none;
+}
+
+html[data-xp-appearance="classic"] #start-button {
+  width: 54px;
+  height: 23px;
+  margin: 2px 3px 2px 2px;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 4px 1px 2px;
+  border: 1px solid #000;
+  border-radius: 0;
+  background: #d4d0c8;
+  box-shadow:
+    inset 1px 1px #fff,
+    inset -1px -1px #808080;
+  color: #000;
+  font:
+    bold 11px Tahoma,
+    sans-serif;
+}
+
+html[data-xp-appearance="classic"] #start-button:hover {
+  background: #d4d0c8;
+}
+
+html[data-xp-appearance="classic"] #start-button.active,
+html[data-xp-appearance="classic"] #start-button:active {
+  padding: 2px 3px 0 3px;
+  background: #d4d0c8;
+  box-shadow:
+    inset 1px 1px #808080,
+    inset -1px -1px #fff;
+}
+
+html[data-xp-appearance="classic"] #start-button > img {
+  display: block;
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+}
+
+html[data-xp-appearance="classic"] #start-button > span {
+  display: inline;
+}
+
+html[data-xp-appearance="classic"] #task-buttons {
+  gap: 3px;
+  padding: 2px 3px;
+}
+
+html[data-xp-appearance="classic"] .task-button,
+html[data-xp-appearance="classic"] .task-button.active {
+  height: 22px;
+  border: 1px solid #000;
+  border-radius: 0;
+  background: #d4d0c8;
+  box-shadow:
+    inset 1px 1px #fff,
+    inset -1px -1px #808080;
+  color: #000;
+  text-shadow: none;
+}
+
+html[data-xp-appearance="classic"] .task-button.active,
+html[data-xp-appearance="classic"] .task-button[aria-pressed="true"] {
+  transform: none;
+  background-color: #fff;
+  background-image: radial-gradient(#c0c0c0 0.6px, transparent 0.7px);
+  background-size: 2px 2px;
+  box-shadow:
+    inset 1px 1px #808080,
+    inset -1px -1px #fff;
+}
+
+html[data-xp-appearance="classic"] .explorer-sidebar {
+  padding: 10px 12px 8px;
+  background: #d4d0c8;
+}
+
+html[data-xp-appearance="classic"] .explorer-sidebar section {
+  margin-bottom: 14px;
+  padding: 0 10px 8px;
+  border: 1px solid #fff;
+  border-right-color: #808080;
+  border-bottom-color: #808080;
+  border-radius: 0;
+  background: #f1f0e8;
+}
+
+html[data-xp-appearance="classic"] .explorer-sidebar h3 {
+  height: 22px;
+  margin: 0 -10px 4px;
+  border-bottom: 1px solid #aca899;
+  background: #d4d0c8;
+  color: #000;
+}
+
+html[data-xp-appearance="classic"]
+  .explorer-sidebar
+  h3
+  .explorer-section-toggle {
+  height: 22px;
+  padding: 2px 3px 2px 10px;
+  color: #000;
+}
+
+html[data-xp-appearance="classic"]
+  .explorer-sidebar
+  h3
+  .explorer-section-toggle
+  span[aria-hidden="true"] {
+  width: 13px;
+  height: 13px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #000;
+}
+
+html[data-xp-appearance="classic"]
+  .explorer-sidebar
+  .explorer-section-body
+  > button {
+  color: #000;
+}
+
+html[data-xp-appearance="classic"] #taskbar-tray {
+  height: 24px;
+  gap: 4px;
+  margin: 1px 2px 1px 4px;
+  padding: 0 5px;
+  border: 1px solid #808080;
+  border-right-color: #fff;
+  border-bottom-color: #fff;
+  background: #d4d0c8;
+  box-shadow: none;
+}
+
+html[data-xp-appearance="classic"] #taskbar-clock {
+  color: #000;
+  text-shadow: none;
+}
+
+html[data-xp-appearance="classic"] #start-menu {
+  width: min(380px, 96vw);
+  border: 1px solid #000;
+  border-radius: 0;
+  background: #d4d0c8;
+  box-shadow: 2px -2px 3px rgba(0, 0, 0, 0.45);
+}
+
+html[data-xp-appearance="classic"] #start-menu::before {
+  display: none;
+}
+
+html[data-xp-appearance="classic"] .start-menu-header {
+  min-height: 42px;
+  padding: 6px 9px;
+  border: 0;
+  background: linear-gradient(90deg, #0a246a, #a6caf0);
+}
+
+html[data-xp-appearance="classic"] .start-menu-avatar {
+  display: none;
+}
+
+html[data-xp-appearance="classic"] .start-menu-user {
+  font-size: 16px;
+  font-style: italic;
+  text-shadow: 1px 1px #000;
+}
+
+html[data-xp-appearance="classic"] .start-menu-body {
+  min-height: 364px;
+  margin: 0;
+  border-bottom: 1px solid #808080;
+}
+
+html[data-xp-appearance="classic"] .start-menu-right {
+  background: #d4d0c8;
+  border-left-color: #808080;
+}
+
+html[data-xp-appearance="classic"] .sm-place {
+  border-radius: 0;
+  color: #000;
+}
+
+html[data-xp-appearance="classic"] .sm-place:hover {
+  background: #0a246a;
+  color: #fff;
+}
+
+html[data-xp-appearance="classic"] .sm-place-separator {
+  background: #808080;
+  box-shadow: 0 1px #fff;
+}
+
+html[data-xp-appearance="classic"] .start-menu-footer {
+  min-height: 32px;
+  margin: 0;
+  padding: 3px 5px;
+  background: #d4d0c8;
+}
+
+html[data-xp-appearance="classic"] .start-menu-footer button {
+  border-radius: 0;
+  color: #000;
+  text-shadow: none;
+}
+
+html[data-xp-appearance="classic"] .start-menu-footer button:hover {
+  border-color: #0a246a;
+  background: #0a246a;
+  color: #fff;
+}
+
+.display-theme-sample[data-appearance="classic"] {
+  background-color: #3a6ea5;
+  background-image: none !important;
+}
+
+.display-theme-sample[data-appearance="classic"]::after {
+  height: 20px;
+  border-top: 1px solid #fff;
+  background: #d4d0c8;
+}
+
+.display-theme-sample[data-appearance="classic"] .display-sample-window {
+  border: 3px ridge #d4d0c8;
+}
+
+.display-theme-sample[data-appearance="classic"]
+  .display-sample-window
+  > strong {
+  height: 18px;
+  width: calc(100% - 54px);
+  padding: 2px 3px;
+  background: linear-gradient(90deg, #0a246a, #a6caf0);
+  font:
+    bold 11px Tahoma,
+    sans-serif;
+}
+
+.display-theme-sample[data-appearance="classic"] .display-sample-window > i {
+  width: 16px;
+  height: 14px;
+  margin: 2px 1px 0 0;
+  border: 1px outset #fff;
+  border-radius: 0;
+  background: #d4d0c8;
+  color: #000;
+  font-size: 10px;
+}
+
+.display-theme-sample[data-appearance="classic"]
+  .display-sample-window
+  > i:last-of-type {
+  background: #d4d0c8;
+}
+
+.display-theme-sample[data-appearance="classic"] .display-sample-window > span {
+  padding: 2px;
+}
+
+.display-theme-sample[data-appearance="classic"] .sample-scroll-up {
+  top: 20px;
+}
+
+.display-theme-sample[data-appearance="classic"] .sample-scroll-thumb {
+  top: 38px;
+}
+
+.appearance-preview[data-appearance="classic"] {
+  background: #3a6ea5;
+}
+
+.appearance-preview[data-appearance="classic"] .appearance-window,
+.appearance-preview[data-appearance="classic"] .appearance-message {
+  border: 3px ridge #d4d0c8;
+}
+
+.appearance-preview[data-appearance="classic"] .appearance-window > strong,
+.appearance-preview[data-appearance="classic"] .appearance-message > strong {
+  height: 18px;
+  padding: 2px 3px;
+  background: linear-gradient(90deg, #0a246a, #a6caf0);
+  font:
+    bold 11px Tahoma,
+    sans-serif;
+}
+
+.appearance-preview[data-appearance="classic"] .appearance-window > i,
+.appearance-preview[data-appearance="classic"] .appearance-message > i {
+  width: 16px;
+  height: 14px;
+  margin-top: 2px;
+  border: 1px outset #fff;
+  border-radius: 0;
+  background: #d4d0c8;
+  color: #000;
+  font-size: 10px;
 }

--- a/site/index.html
+++ b/site/index.html
@@ -139,7 +139,10 @@
 
     <!-- Taskbar -->
     <div id="taskbar" hidden>
-      <button id="start-button" type="button" aria-label="start"></button>
+      <button id="start-button" type="button" aria-label="start">
+        <img src="assets/xp/WindowsFlag.png" alt="" aria-hidden="true" />
+        <span>Start</span>
+      </button>
       <div id="task-buttons"></div>
       <div id="taskbar-tray">
         <button

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -36,6 +36,7 @@ let automaticOfflineDownloadQueue = Promise.resolve();
 
 const DISPLAY_SETTINGS_KEY = "displaySettings";
 const DESKTOP_SYSTEM_ICONS_KEY = "desktopSystemIcons";
+const DESKTOP_SYSTEM_NAMES_KEY = "desktopSystemNames";
 const GAME_PLAYBACK_SETTINGS_KEY = "gamePlaybackSettings";
 const USER_STORAGE_KEYS = Object.freeze([
   DISPLAY_SETTINGS_KEY,
@@ -43,6 +44,7 @@ const USER_STORAGE_KEYS = Object.freeze([
   "desktopIconPositions",
   "desktopLayoutSettings",
   DESKTOP_SYSTEM_ICONS_KEY,
+  DESKTOP_SYSTEM_NAMES_KEY,
   "favorites",
   "gameStats",
   GAME_PLAYBACK_SETTINGS_KEY,
@@ -159,7 +161,6 @@ const XP_ICON_PATHS = Object.freeze({
   "RecyclerFull.png": "assets/xp/icons/RecyclerFull.png",
   "Shortcut.png": "assets/xp/icons/Shortcut.png",
 });
-const TASKBAR_HEIGHT = 30;
 let activeMonitorResolution = "auto";
 
 const categoryIcons = {
@@ -348,7 +349,7 @@ const isDisplaySettings = (value) =>
     )) &&
   ["center", "tile", "stretch"].includes(value.position) &&
   /^#[0-9a-f]{6}$/i.test(value.backgroundColor) &&
-  ["blue", "olive", "silver"].includes(value.appearance) &&
+  ["blue", "olive", "silver", "classic"].includes(value.appearance) &&
   (value.fontSize === undefined ||
     ["normal", "large", "extra-large"].includes(value.fontSize)) &&
   [
@@ -402,6 +403,16 @@ const getDesktopSystemIcons = () => ({
 const saveDesktopSystemIcons = (settings) =>
   writeJsonStorage(DESKTOP_SYSTEM_ICONS_KEY, settings);
 
+const getDesktopSystemNames = () =>
+  readJsonStorage(DESKTOP_SYSTEM_NAMES_KEY, {}, (value) =>
+    Object.values(value || {}).every(
+      (name) => typeof name === "string" && name.trim().length > 0,
+    ),
+  );
+
+const saveDesktopSystemNames = (settings) =>
+  writeJsonStorage(DESKTOP_SYSTEM_NAMES_KEY, settings);
+
 const saveDisplaySettings = (settings) => {
   try {
     localStorage.setItem(DISPLAY_SETTINGS_KEY, JSON.stringify(settings));
@@ -434,6 +445,9 @@ const getSimulatedMonitorSize = (resolution = activeMonitorResolution) => {
   };
 };
 
+const getTaskbarHeight = () =>
+  document.documentElement.dataset.xpAppearance === "classic" ? 28 : 30;
+
 // The selected XP resolution becomes a real, bounded monitor inside the
 // browser. On a smaller browser it is honestly limited to the available
 // viewport instead of pretending that off-screen space is usable.
@@ -463,7 +477,7 @@ const applySimulatedMonitor = (resolution, { reflow = true } = {}) => {
       Math.round((window.innerHeight - monitor.height) / 2),
     );
     desktop.style.width = `${monitor.width}px`;
-    desktop.style.height = `${Math.max(1, monitor.height - TASKBAR_HEIGHT)}px`;
+    desktop.style.height = `${Math.max(1, monitor.height - getTaskbarHeight())}px`;
     desktop.style.left = `${left}px`;
     desktop.style.top = `${top}px`;
     taskbar.style.width = `${monitor.width}px`;
@@ -3346,9 +3360,9 @@ const createSystemWindowContent = (shortcutId, win) => {
                     <div class="appearance-message"><strong>Message Box</strong><i>×</i><button type="button" tabindex="-1">OK</button></div>
                 </div>
                 <label class="display-control-label" for="display-window-style">Windows and buttons:</label>
-                <select id="display-window-style" disabled><option>Windows XP style</option></select>
+                <select id="display-window-style" disabled><option value="xp">Windows XP style</option><option value="classic">Windows Classic style</option></select>
                 <label class="display-control-label" for="display-appearance">Color scheme:</label>
-                <select id="display-appearance"><option value="blue">Default (blue)</option><option value="olive">Olive green</option><option value="silver">Silver</option></select>
+                <select id="display-appearance"><option value="blue">Default (blue)</option><option value="olive">Olive green</option><option value="silver">Silver</option><option value="classic">Windows Standard</option></select>
                 <label class="display-control-label" for="display-font-size">Font size:</label>
                         <select id="display-font-size"><option value="normal">Normal</option><option value="large">Large Fonts</option><option value="extra-large">Extra Large Fonts</option></select>
                 <div class="display-appearance-actions">
@@ -4720,12 +4734,14 @@ const wireDisplayProperties = (win) => {
     saverWait: content.querySelector("#display-saver-wait"),
     saverLogin: content.querySelector(".display-saver-login"),
     appearance: content.querySelector("#display-appearance"),
+    windowStyle: content.querySelector("#display-window-style"),
     fontSize: content.querySelector("#display-font-size"),
     resolution: content.querySelector("#display-resolution"),
     resolutionSlider: content.querySelector("#display-resolution-slider"),
     preview: content.querySelector(".display-preview-surface"),
     saverPreview: content.querySelector(".screen-saver-preview"),
     appearancePreview: content.querySelector(".appearance-preview"),
+    themeSample: content.querySelector(".display-theme-sample"),
     resolutionPreview: content.querySelector(".display-resolution-preview"),
     resolutionValue: content.querySelector(".display-resolution-value"),
     status: content.querySelector(".display-status"),
@@ -4744,9 +4760,9 @@ const wireDisplayProperties = (win) => {
       backgroundColor: "#3a6ea5",
     },
     classic: {
-      appearance: "silver",
-      wallpaper: "ascent",
-      backgroundColor: "#4b6f8f",
+      appearance: "classic",
+      wallpaper: "none",
+      backgroundColor: "#3a6ea5",
     },
     olive: {
       appearance: "olive",
@@ -4771,6 +4787,9 @@ const wireDisplayProperties = (win) => {
     controls.saverWait.value = String(pending.screenSaverWait);
     controls.saverLogin.checked = pending.requireLoginOnResume;
     controls.appearance.value = pending.appearance;
+    controls.appearance.disabled = pending.appearance === "classic";
+    controls.windowStyle.value =
+      pending.appearance === "classic" ? "classic" : "xp";
     controls.fontSize.value = pending.fontSize;
     controls.resolution.value = pending.resolution;
     controls.resolutionSlider.value = String(
@@ -4786,6 +4805,9 @@ const wireDisplayProperties = (win) => {
       pending.backgroundColor;
     controls.saverPreview.dataset.saver = pending.screenSaver;
     controls.appearancePreview.dataset.appearance = pending.appearance;
+    controls.themeSample.dataset.appearance = pending.appearance;
+    controls.themeSample.style.backgroundColor = pending.backgroundColor;
+    controls.themeSample.style.backgroundImage = displayBackground(pending);
     controls.resolutionPreview.dataset.resolution = pending.resolution;
     const monitor = getSimulatedMonitorSize(pending.resolution);
     controls.resolutionValue.textContent =
@@ -10154,7 +10176,7 @@ const buildDesktopIcons = () => {
     const label = document.createElement("span");
     label.className = "icon-label";
     label.textContent = system
-      ? formatGameTitle(id)
+      ? getDesktopSystemNames()[id] || formatGameTitle(id)
       : node.ext === ".game"
         ? node.name.slice(0, -node.ext.length)
         : node.name;
@@ -10249,6 +10271,37 @@ const beginDesktopRename = (id) => {
   });
   input.addEventListener("blur", () => finish(true), { once: true });
   document.addEventListener("pointerdown", onOutsidePointerDown, true);
+};
+
+const beginSystemDesktopRename = (id) => {
+  const icon = document.querySelector(
+    `.desktop-icon[data-desktop-id="${CSS.escape(id)}"]`,
+  );
+  const label = icon?.querySelector(".icon-label");
+  if (!icon || !label) return;
+  const input = document.createElement("input");
+  input.className = "desktop-rename";
+  input.value = label.textContent;
+  label.replaceWith(input);
+  input.focus();
+  input.select();
+  let finished = false;
+  const finish = (save) => {
+    if (finished) return;
+    finished = true;
+    const name = input.value.trim();
+    if (save && name) {
+      saveDesktopSystemNames({ ...getDesktopSystemNames(), [id]: name });
+    }
+    refreshDesktop();
+  };
+  input.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== "Escape") return;
+    event.preventDefault();
+    event.stopPropagation();
+    finish(event.key === "Enter");
+  });
+  input.addEventListener("blur", () => finish(true), { once: true });
 };
 
 const addDesktopMenuItem = (
@@ -10357,6 +10410,24 @@ const renderDesktopContextMenu = (menu, itemId = null) => {
     addDesktopMenuItem(menu, "Create Shortcut", "create-recycle-shortcut");
     addDesktopSeparator(menu);
     addDesktopMenuItem(menu, "Properties", "recycle-properties");
+  } else if (itemId === "__my-computer") {
+    addDesktopMenuItem(menu, "Open", "open", { defaultItem: true });
+    addDesktopMenuItem(menu, "Explore", "explore-my-computer");
+    addDesktopMenuItem(menu, "Search...", "search-my-computer");
+    addDesktopMenuItem(menu, "Manage", "manage-my-computer");
+    addDesktopSeparator(menu);
+    addDesktopMenuItem(menu, "Map Network Drive...", "map-network-drive");
+    addDesktopMenuItem(
+      menu,
+      "Disconnect Network Drive...",
+      "disconnect-network-drive",
+    );
+    addDesktopSeparator(menu);
+    addDesktopMenuItem(menu, "Create Shortcut", "create-computer-shortcut");
+    addDesktopMenuItem(menu, "Delete", "hide-my-computer");
+    addDesktopMenuItem(menu, "Rename", "rename-my-computer");
+    addDesktopSeparator(menu);
+    addDesktopMenuItem(menu, "Properties", "computer-properties");
   } else if (itemId) {
     addDesktopMenuItem(menu, "Open", "open");
     addDesktopSeparator(menu);
@@ -10533,6 +10604,45 @@ const setupDesktopContextMenu = () => {
       pasteIntoFolder(fs.DESKTOP);
     } else if (action === "open" && itemId) {
       openDesktopItem(itemId);
+    } else if (action === "explore-my-computer") {
+      openDesktopItem("__my-computer");
+    } else if (action === "search-my-computer") {
+      openSearchDialog();
+    } else if (action === "manage-my-computer") {
+      XPDialogs.alert(
+        "Computer Management is not available in this offline recreation.",
+        "Computer Management",
+        "info",
+      );
+    } else if (
+      action === "map-network-drive" ||
+      action === "disconnect-network-drive"
+    ) {
+      XPDialogs.alert(
+        "This Windows XP network feature is not available in Astro Flash.",
+        action === "map-network-drive"
+          ? "Map Network Drive"
+          : "Disconnect Network Drive",
+        "info",
+      );
+    } else if (action === "create-computer-shortcut") {
+      const shortcut = fileOps.createFile(
+        fs.DESKTOP,
+        "Shortcut to My Computer.game",
+        { app: "__my-computer" },
+      );
+      refreshDesktop();
+      selectDesktopIcon(shortcut.id);
+    } else if (action === "hide-my-computer") {
+      saveDesktopSystemIcons({
+        ...getDesktopSystemIcons(),
+        "__my-computer": false,
+      });
+      refreshDesktop();
+    } else if (action === "rename-my-computer") {
+      beginSystemDesktopRename("__my-computer");
+    } else if (action === "computer-properties") {
+      openSystemProperties();
     } else if (action === "explore" && itemId === "__recycle-bin") {
       openDesktopItem(itemId);
     } else if (action === "empty-recycle-bin") {

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -127,6 +127,45 @@ test("desktop icons select and launch their actual destinations", async () => {
   ).not.toBeNull();
 });
 
+test("My Computer exposes the native desktop shell menu and opens Properties", async () => {
+  const shell = await login(await loadShell());
+  const icon = shell.document.querySelector<HTMLButtonElement>(
+    '[data-desktop-id="__my-computer"]',
+  )!;
+  icon.dispatchEvent(
+    new shell.window.MouseEvent("contextmenu", {
+      bubbles: true,
+      clientX: 40,
+      clientY: 30,
+    }),
+  );
+
+  const menu = shell.document.getElementById("desktop-context-menu")!;
+  expect(menu.hidden).toBeFalse();
+  const items = [...menu.querySelectorAll<HTMLButtonElement>("[data-action]")];
+  expect(items.map((item) => item.textContent!.trim())).toEqual([
+    "Open",
+    "Explore",
+    "Search...",
+    "Manage",
+    "Map Network Drive...",
+    "Disconnect Network Drive...",
+    "Create Shortcut",
+    "Delete",
+    "Rename",
+    "Properties",
+  ]);
+  expect(items.every((item) => !item.disabled)).toBeTrue();
+  expect(items[0].classList.contains("context-default")).toBeTrue();
+
+  menu
+    .querySelector<HTMLButtonElement>('[data-action="computer-properties"]')!
+    .click();
+  expect(
+    shell.document.querySelector(".system-properties-dialog"),
+  ).not.toBeNull();
+});
+
 test("Control Panel navigation opens applets and switches their tabs", async () => {
   const shell = await login(await loadShell());
   clickStartAction(shell, "controlPanel");
@@ -206,6 +245,59 @@ test("Display Properties applies and persists a selected wallpaper", async () =>
       .style.getPropertyValue("--desktop-background"),
   ).toContain("ascent.jpg");
   expect(apply.disabled).toBeTrue();
+});
+
+test("Windows Classic applies the native Classic appearance and solid desktop", async () => {
+  const shell = await login(await loadShell());
+  clickStartAction(shell, "controlPanel");
+  const controlPanel = shell.document.querySelector<HTMLElement>(
+    '.xp-window[data-game="__control-panel"]',
+  )!;
+  controlPanel
+    .querySelector<HTMLButtonElement>(
+      '[data-control-panel-category="appearance"]',
+    )!
+    .click();
+  controlPanel
+    .querySelector<HTMLButtonElement>('[data-control-panel-action="display"]')!
+    .click();
+
+  const display = shell.document.querySelector<HTMLElement>(
+    '.xp-window[data-game="__display-properties"]',
+  )!;
+  const theme = display.querySelector<HTMLSelectElement>("#display-theme")!;
+  theme.value = "classic";
+  theme.dispatchEvent(new shell.window.Event("change", { bubbles: true }));
+
+  expect(
+    display.querySelector<HTMLElement>(".display-theme-sample")!.dataset
+      .appearance,
+  ).toBe("classic");
+  expect(
+    display.querySelector<HTMLSelectElement>("#display-window-style")!.value,
+  ).toBe("classic");
+  expect(
+    display.querySelector<HTMLSelectElement>("#display-appearance")!.value,
+  ).toBe("classic");
+
+  display
+    .querySelector<HTMLButtonElement>('[data-display-action="apply"]')!
+    .click();
+  const saved = JSON.parse(
+    shell.window.localStorage.getItem("displaySettings")!,
+  );
+  expect(saved).toMatchObject({
+    theme: "classic",
+    appearance: "classic",
+    wallpaper: "none",
+    backgroundColor: "#3a6ea5",
+  });
+  expect(shell.document.documentElement.dataset.xpAppearance).toBe("classic");
+  expect(
+    shell.document
+      .getElementById("desktop")!
+      .style.getPropertyValue("--desktop-background"),
+  ).toBe("none");
 });
 
 test("Run executes a shell command and closes after success", async () => {


### PR DESCRIPTION
## What changed

- replace the generic My Computer desktop context menu with the native Windows XP command set and wire the supported actions
- implement Windows Classic as a distinct visual style instead of mapping it to Silver Luna
- match the XP VM's solid desktop, Classic taskbar/Start button, window frames, caption buttons, Start menu, Explorer task pane, and Display Properties previews
- preserve renamed system-icon labels and add behavioral regression coverage for the menu and Classic theme application

## Root cause

Windows Classic was previously mapped to the Silver Luna appearance with an unrelated wallpaper, so only colors changed while Luna window, taskbar, and shell components remained active. My Computer also fell through to the generic protected-file menu.

## Validation

- compared directly against the authenticated Windows XP SP3 golden VM at 1024×768
- `bun run test` — 79 tests passing
- `bun run quality`
- `bun run build`
