### PR TITLE
Fix desktop properties controls and icon navigation

### DIFF
--- a/site/css/main.css
+++ b/site/css/main.css
@@ -5712,6 +5712,11 @@ html[data-xp-menu-shadows="false"] .desktop-context-menu {
 .display-customize {
   width: 133px;
   margin-top: 7px;
+  padding: 0 8px;
+  white-space: nowrap;
+  font:
+    11px/21px Tahoma,
+    sans-serif;
 }
 
 .display-customize:disabled {
@@ -6763,16 +6768,17 @@ html[data-xp-menu-shadows="false"] .desktop-context-menu {
 }
 
 .help-btn {
-  border: 1px solid #fff;
-  background: linear-gradient(#6aaeff, #1664df);
-  box-shadow: inset 0 0 0 1px #0b4fc1;
+  background-image: url("../assets/xp/icons/CaptionButton.png");
 }
 
 .help-btn::after {
   content: "?";
+  inset: 1px 3px 3px;
+  display: grid;
+  place-items: center;
   color: #fff;
   font:
-    bold 17px Tahoma,
+    bold 15px/17px Tahoma,
     sans-serif;
   text-shadow: 1px 1px #124ba0;
 }

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -9781,6 +9781,27 @@ const selectDesktopIcon = (desktopId, additive = false) => {
   });
 };
 
+const findDesktopIconInDirection = (currentIcon, icons, key) => {
+  const currentRect = currentIcon.getBoundingClientRect();
+  const currentX = currentRect.left + currentRect.width / 2;
+  const currentY = currentRect.top + currentRect.height / 2;
+  const horizontal = key === "ArrowLeft" || key === "ArrowRight";
+  const sign = key === "ArrowLeft" || key === "ArrowUp" ? -1 : 1;
+
+  return icons
+    .filter((icon) => icon !== currentIcon)
+    .map((icon) => {
+      const rect = icon.getBoundingClientRect();
+      const dx = rect.left + rect.width / 2 - currentX;
+      const dy = rect.top + rect.height / 2 - currentY;
+      const primary = (horizontal ? dx : dy) * sign;
+      const perpendicular = Math.abs(horizontal ? dy : dx);
+      return { icon, primary, score: primary + perpendicular * 2 };
+    })
+    .filter(({ primary }) => primary > 1)
+    .sort((a, b) => a.score - b.score || a.primary - b.primary)[0]?.icon;
+};
+
 const clearDesktopSelection = () => {
   document.querySelectorAll(".desktop-icon.selected").forEach((icon) => {
     icon.classList.remove("selected");
@@ -12295,13 +12316,13 @@ document.addEventListener("keydown", (e) => {
       desktopIcon &&
       ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key)
     ) {
-      const current = desktopIcons.indexOf(desktopIcon);
-      const direction = e.key === "ArrowLeft" || e.key === "ArrowUp" ? -1 : 1;
-      const target =
-        desktopIcons[
-          (current + direction + desktopIcons.length) % desktopIcons.length
-        ];
       e.preventDefault();
+      const target = findDesktopIconInDirection(
+        desktopIcon,
+        desktopIcons,
+        e.key,
+      );
+      if (!target) return;
       if (!e.ctrlKey && !e.shiftKey)
         selectDesktopIcon(target.dataset.desktopId);
       if (e.shiftKey) target.classList.add("selected");

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -127,6 +127,59 @@ test("desktop icons select and launch their actual destinations", async () => {
   ).not.toBeNull();
 });
 
+test("desktop arrow keys move between icons by screen direction", async () => {
+  const shell = await login(await loadShell());
+  const ids = [
+    "__my-computer",
+    "__my-documents",
+    "__internet-games",
+    "__astro-settings",
+  ];
+  const icons = ids.map((id) =>
+    shell.document.querySelector<HTMLButtonElement>(
+      `[data-desktop-id="${id}"]`,
+    ),
+  );
+  const positions = [
+    [8, 8],
+    [8, 88],
+    [90, 8],
+    [90, 88],
+  ];
+  icons.forEach((icon, index) => {
+    const [left, top] = positions[index];
+    icon!.getBoundingClientRect = () => ({
+      left,
+      top,
+      right: left + 76,
+      bottom: top + 74,
+      width: 76,
+      height: 74,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    });
+  });
+
+  const press = (key: string) => {
+    shell.document.dispatchEvent(
+      new shell.window.KeyboardEvent("keydown", { key, bubbles: true }),
+    );
+  };
+  icons[0]!.click();
+  icons[0]!.focus();
+
+  press("ArrowRight");
+  expect(shell.document.activeElement).toBe(icons[2]);
+  press("ArrowDown");
+  expect(shell.document.activeElement).toBe(icons[3]);
+  press("ArrowLeft");
+  expect(shell.document.activeElement).toBe(icons[1]);
+  press("ArrowUp");
+  expect(shell.document.activeElement).toBe(icons[0]);
+  expect(icons[0]!.classList.contains("selected")).toBeTrue();
+});
+
 test("My Computer exposes the native desktop shell menu and opens Properties", async () => {
   const shell = await login(await loadShell());
   const icon = shell.document.querySelector<HTMLButtonElement>(


### PR DESCRIPTION
## What changed

- render the Display Properties Help button with the authentic XP caption-button frame and corrected glyph alignment
- keep “Customize Desktop...” at the native fixed size and prevent enlarged shell text from wrapping outside it
- navigate desktop icons by their on-screen direction instead of DOM order
- add a behavioral regression covering all four arrow directions

## Root cause

The Help button used a separate CSS-drawn skin, the Customize button inherited scalable UI typography, and desktop keyboard navigation treated every arrow as previous/next in document order.

## Validation

- `bun run test` — 80 tests pass
- `bun run quality`
- `bun run build`
- visually verified Display Properties and horizontal icon navigation in the local browser