### PR TITLE
Add production preview for offline updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ immediately when `dist/` is already current. Use
 `bun run dev -- --rebuild` to force a rebuild or `--no-sync` to serve the
 existing output unchanged.
 
+To test production service-worker and offline-update behavior with automatic
+rebuilds, run:
+
+```bash
+bun run preview
+```
+
+Preview serves the real production worker and gives each changed build a new
+local version. It intentionally does not reload the page after rebuilding; use
+**Settings > Updates > Check for Updates** to exercise the update flow.
+
 ## Project layout
 
 - `site/` — authored static site

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "test": "bun run typecheck && bun test && bun run validate:javascript && bun run validate:icons",
     "build": "bun tools/deploy.ts",
     "dev": "bun tools/dev-server.ts",
+    "preview": "bun tools/dev-server.ts --production",
     "deploy:worker": "wrangler deploy --config worker/wrangler.toml",
     "extract:xp-assets": "bun tools/extract-xp-assets.ts",
     "compare:xp-ui": "bun tools/compare-xp-ui.ts",

--- a/tests/dev-server.test.ts
+++ b/tests/dev-server.test.ts
@@ -8,6 +8,7 @@ import {
   DEV_RELOAD_PATH,
   computeSourceFingerprint,
   createDevelopmentLiveReload,
+  createPreviewVersion,
   createRequestHandler,
   ensureDevelopmentBuild,
   watchDevelopmentBuild,
@@ -30,6 +31,15 @@ afterEach(async () => {
 });
 
 describe("development build synchronization", () => {
+  test("derives preview versions from the build fingerprint", () => {
+    expect(
+      createPreviewVersion(
+        "abcdef0123456789",
+        new Date("2026-08-02T12:00:00.000Z"),
+      ),
+    ).toBe("26.08.02-abcdef0");
+  });
+
   test("fingerprints build inputs but ignores unrelated files", async () => {
     const project = await makeTemporaryDirectory();
     await mkdir(join(project, "site"), { recursive: true });
@@ -120,6 +130,25 @@ describe("development build synchronization", () => {
       await readFile(join(output, DEV_BUILD_STATE), "utf8"),
     );
     expect(state.fingerprint).toBe("second");
+  });
+
+  test("passes a fingerprint-based version to preview builds", async () => {
+    const root = await makeTemporaryDirectory();
+    const versions: string[] = [];
+
+    await ensureDevelopmentBuild({
+      outputDir: join(root, "dist"),
+      fingerprint: async () => "1234567890abcdef",
+      releaseKey: async () => "ruffle-v1",
+      version: (fingerprint) => `preview-${fingerprint.slice(0, 7)}`,
+      builder: async ({ outputDir, version }) => {
+        versions.push(version as string);
+        await mkdir(outputDir as string, { recursive: true });
+        await writeFile(join(outputDir as string, "index.html"), "built");
+      },
+    });
+
+    expect(versions).toEqual(["preview-1234567"]);
   });
 });
 
@@ -232,6 +261,19 @@ describe("Bun request handler", () => {
     expect(worker).toContain("self.registration.unregister()");
     expect(response.headers.get("cache-control")).toContain("no-store");
     liveReload.close();
+  });
+
+  test("serves production HTML and service worker unchanged for preview", async () => {
+    const root = await makeTemporaryDirectory();
+    await writeFile(join(root, "index.html"), "<body>site</body>");
+    await writeFile(join(root, "sw.js"), "self.productionWorker = true;");
+    const handler = createRequestHandler(root);
+
+    const page = await handler(new Request("http://localhost/"));
+    expect(await page.text()).toBe("<body>site</body>");
+
+    const worker = await handler(new Request("http://localhost/sw.js"));
+    expect(await worker.text()).toBe("self.productionWorker = true;");
   });
 });
 

--- a/tools/dev-server.ts
+++ b/tools/dev-server.ts
@@ -129,6 +129,7 @@ interface EnsureDevelopmentBuildOptions {
   fingerprint?: () => Promise<string>;
   releaseKey?: () => Promise<string>;
   builder?: (options: BuildOptions) => Promise<void>;
+  version?: (fingerprint: string) => string;
 }
 
 interface EnsureDevelopmentBuildResult {
@@ -293,6 +294,7 @@ export async function ensureDevelopmentBuild({
   fingerprint = () => computeSourceFingerprint(projectDir),
   releaseKey = currentRuffleReleaseKey,
   builder,
+  version,
 }: EnsureDevelopmentBuildOptions = {}): Promise<EnsureDevelopmentBuildResult> {
   const resolvedOutput = resolve(outputDir);
   const [sourceFingerprint, ruffleRelease, previousState] = await Promise.all([
@@ -324,6 +326,7 @@ export async function ensureDevelopmentBuild({
   const selectedBuilder = builder ?? (await import("./deploy")).build;
   await selectedBuilder({
     outputDir: resolvedOutput,
+    ...(version ? { version: version(sourceFingerprint) } : {}),
     ...(canReuseRuffle
       ? {
           download: (destinationJsDir: string) =>
@@ -345,6 +348,14 @@ export async function ensureDevelopmentBuild({
     `Development build synchronized in ${((performance.now() - startedAt) / 1000).toFixed(2)}s${canReuseRuffle ? " (reused Ruffle)" : ""}.`,
   );
   return { rebuilt: true, reusedRuffle: canReuseRuffle };
+}
+
+export function createPreviewVersion(
+  fingerprint: string,
+  date = new Date(),
+): string {
+  const [year, month, day] = date.toISOString().slice(0, 10).split("-");
+  return `${year.slice(2)}.${month}.${day}-${fingerprint.slice(0, 7)}`;
 }
 
 function noCacheHeaders(extra: HeadersInit = {}): Headers {
@@ -528,6 +539,7 @@ interface ServerArguments {
   force: boolean;
   hostname: string;
   port: number;
+  production: boolean;
   sync: boolean;
 }
 
@@ -537,6 +549,7 @@ function parseArguments(arguments_: string[]): ServerArguments {
     force: false,
     hostname: "127.0.0.1",
     port: 8000,
+    production: false,
     sync: true,
   };
   for (let index = 0; index < arguments_.length; index += 1) {
@@ -547,6 +560,10 @@ function parseArguments(arguments_: string[]): ServerArguments {
     }
     if (argument === "--no-sync") {
       parsed.sync = false;
+      continue;
+    }
+    if (argument === "--production") {
+      parsed.production = true;
       continue;
     }
     if (
@@ -579,10 +596,12 @@ function parseArguments(arguments_: string[]): ServerArguments {
 if (import.meta.main) {
   try {
     const arguments_ = parseArguments(Bun.argv.slice(2));
+    const version = arguments_.production ? createPreviewVersion : undefined;
     if (arguments_.sync) {
       await ensureDevelopmentBuild({
         outputDir: arguments_.directory,
         force: arguments_.force,
+        version,
       });
     } else if (
       !(await Bun.file(join(arguments_.directory, "index.html")).exists())
@@ -591,7 +610,9 @@ if (import.meta.main) {
         `${arguments_.directory} is not built; omit --no-sync or run \`bun run build\``,
       );
     }
-    const liveReload = createDevelopmentLiveReload();
+    const liveReload = arguments_.production
+      ? undefined
+      : createDevelopmentLiveReload();
     const server = Bun.serve({
       hostname: arguments_.hostname,
       port: arguments_.port,
@@ -608,7 +629,16 @@ if (import.meta.main) {
     if (arguments_.sync) {
       await watchDevelopmentBuild({
         outputDir: arguments_.directory,
-        onReload: () => liveReload.reload(),
+        rebuild: () =>
+          ensureDevelopmentBuild({
+            outputDir: arguments_.directory,
+            version,
+          }),
+        onReload: () => {
+          if (liveReload) liveReload.reload();
+          else
+            console.log("Preview update built; check for updates in the app.");
+        },
       });
       console.log("Watching source files for changes.");
     }


### PR DESCRIPTION
## Summary

- add `bun run preview` as a production-like local development mode
- automatically build stale sources and watch for changes while serving the real service worker
- generate fingerprint-based local versions so rebuilt previews exercise the normal offline update flow
- keep live reload and the development cleanup worker limited to `bun run dev`
- document the workflow and cover preview versioning and serving behavior with tests

## Why

`bun run dev` intentionally disables offline behavior, while manually building and serving multiple versions makes offline-update testing cumbersome. The preview mode provides the same automatic build/watch ergonomics without changing production service-worker behavior.

## Validation

- `bun run quality`
- `bun run test` (84 tests passed)
- preview CLI startup smoke test