### PR TITLE
Fix more Windows XP programs

### DIFF
--- a/site/css/main.css
+++ b/site/css/main.css
@@ -14111,6 +14111,18 @@ html[data-xp-appearance="classic"] .start-program-flyout button:focus-visible {
   background: transparent;
 }
 
+.xp-minesweeper-menu label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-left: 7px;
+}
+
+.xp-minesweeper-menu select {
+  height: 20px;
+  font: inherit;
+}
+
 .xp-minesweeper-panel {
   display: flex;
   align-items: center;
@@ -14596,6 +14608,53 @@ html[data-xp-appearance="classic"] .start-program-flyout button:focus-visible {
 
 .xp-mail-list tbody tr:hover {
   background: #e8f0ff;
+}
+
+.xp-mail-list tbody tr.selected {
+  background: #316ac5;
+  color: #fff;
+}
+
+.xp-task-form {
+  display: grid;
+  gap: 8px;
+  margin: 0 0 10px;
+  padding: 10px;
+  border: 1px solid #7f9db9;
+  background: #fff;
+}
+
+.xp-task-form[hidden] {
+  display: none;
+}
+
+.xp-task-form label {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  align-items: center;
+}
+
+.xp-task-form > div {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.xp-task-list {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+}
+
+.xp-task-list th,
+.xp-task-list td {
+  padding: 5px 8px;
+  border: 1px solid #aca899;
+  text-align: left;
+}
+
+.xp-task-list td:last-child {
+  white-space: nowrap;
 }
 
 .xp-mail-preview {

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -14293,6 +14293,251 @@ html[data-xp-appearance="classic"] .start-program-flyout button:focus-visible {
   outline-offset: -4px;
 }
 
+.xp-freecell {
+  padding: 0;
+  overflow: hidden;
+  background: #087b3d;
+}
+
+.xp-freecell-menu {
+  display: flex;
+  height: 24px;
+  align-items: center;
+  border-bottom: 1px solid #808080;
+  background: #ece9d8;
+}
+
+.xp-freecell-menu button {
+  height: 22px;
+  padding: 1px 8px;
+  border: 0;
+  background: transparent;
+}
+
+.xp-freecell-menu span {
+  margin-left: auto;
+  padding-right: 8px;
+}
+
+.xp-freecell-board {
+  display: grid;
+  height: calc(100% - 24px);
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 105px 1fr;
+  gap: 12px;
+  box-sizing: border-box;
+  padding: 12px;
+}
+
+.xp-freecell-cells,
+.xp-freecell-foundations {
+  display: grid;
+  grid-template-columns: repeat(4, 70px);
+  gap: 8px;
+}
+
+.xp-freecell-foundations {
+  justify-content: end;
+}
+
+.xp-freecell-cells button,
+.xp-freecell-foundations button,
+.xp-freecell-cascade button {
+  box-sizing: border-box;
+  width: 70px;
+  height: 96px;
+  min-width: 0;
+  padding: 5px;
+  border: 1px solid #111;
+  border-radius: 5px;
+}
+
+.xp-freecell-cells .empty,
+.xp-freecell-foundations .empty {
+  border-color: rgba(255, 255, 255, 0.45);
+  background: rgba(0, 0, 0, 0.08);
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 32px;
+}
+
+.xp-freecell-cascades {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(8, 70px);
+  justify-content: space-between;
+}
+
+.xp-freecell-cascade {
+  position: relative;
+  min-height: 290px;
+}
+
+.xp-freecell-cascade button {
+  position: absolute;
+  top: calc(var(--card-index) * 32px);
+  left: 0;
+}
+
+.xp-freecell .selected {
+  outline: 3px solid #ffd800;
+  outline-offset: -4px;
+}
+
+.xp-hyperterminal-connect {
+  display: grid;
+  gap: 10px;
+  max-width: 420px;
+  margin: 20px auto;
+}
+
+.xp-hyperterminal-connect fieldset {
+  display: grid;
+  gap: 9px;
+  padding: 16px;
+}
+
+.xp-hyperterminal-connect label {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  align-items: center;
+}
+
+.xp-hyperterminal-connect > div {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.xp-hyperterminal-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: -10px -10px 0;
+  padding: 6px;
+  border-bottom: 1px solid #aca899;
+}
+
+.xp-hyperterminal-toolbar button {
+  margin-left: auto;
+}
+
+.xp-hyperterminal-screen {
+  box-sizing: border-box;
+  height: calc(100% - 60px);
+  margin: 0 -10px;
+  padding: 8px;
+  overflow: auto;
+  background: #000;
+  color: #c0c0c0;
+  font:
+    13px "Courier New",
+    monospace;
+  white-space: pre-wrap;
+}
+
+.xp-hyperterminal-prompt {
+  display: flex;
+  margin: 0 -10px -10px;
+  padding: 5px;
+  background: #c0c0c0;
+}
+
+.xp-hyperterminal-prompt input {
+  min-width: 0;
+  flex: 1;
+}
+
+.xp-defrag-volume {
+  border: 1px solid #7f9db9;
+  background: #fff;
+}
+
+.xp-defrag-volume table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.xp-defrag-volume th,
+.xp-defrag-volume td {
+  padding: 5px 8px;
+  border-right: 1px solid #aca899;
+  text-align: left;
+}
+
+.xp-defrag-volume tr.selected {
+  background: #316ac5;
+  color: #fff;
+}
+
+.xp-defrag-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  padding: 10px 0;
+}
+
+.xp-defrag-legend span {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.xp-defrag-legend i,
+.xp-defrag-map i {
+  display: block;
+  border: 1px solid #666;
+}
+
+.xp-defrag-legend i {
+  width: 13px;
+  height: 9px;
+}
+
+.xp-defrag-map {
+  padding: 8px 12px;
+  border: 1px solid #7f9db9;
+  background: #fff;
+}
+
+.xp-defrag-map h3 {
+  margin: 6px 0;
+  font-size: 12px;
+  font-weight: normal;
+}
+
+.xp-defrag-map > div {
+  display: grid;
+  grid-template-columns: repeat(16, 1fr);
+  height: 48px;
+  border: 2px inset #fff;
+}
+
+.xp-defrag-map i.fragmented,
+.xp-defrag-legend i.fragmented {
+  background: #d90000;
+}
+
+.xp-defrag-map i.contiguous,
+.xp-defrag-legend i.contiguous {
+  background: #0034d8;
+}
+
+.xp-defrag-map i.system,
+.xp-defrag-legend i.system {
+  background: #009200;
+}
+
+.xp-defrag-map i.free,
+.xp-defrag-legend i.free {
+  background: #fff;
+}
+
+.xp-defrag-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .xp-mail-toolbar {
   display: flex;
   gap: 4px;

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -7602,28 +7602,40 @@ const createXPProgramContent = (programId) => {
 
   if (programId === "__minesweeper") {
     content.className += " xp-minesweeper";
-    content.innerHTML = `<div class="xp-minesweeper-menu"><button type="button">Game</button><button type="button">Help</button></div><div class="xp-minesweeper-panel"><output data-mines aria-label="Mines remaining">010</output><button type="button" data-reset aria-label="New game">🙂</button><output data-time aria-label="Elapsed time">000</output></div><div class="xp-minesweeper-board" role="grid" aria-label="Minesweeper board"></div>`;
+    content.innerHTML = `<div class="xp-minesweeper-menu"><label>Game <select aria-label="Difficulty"><option value="beginner">Beginner</option><option value="intermediate">Intermediate</option><option value="expert">Expert</option></select></label><button type="button">Help</button></div><div class="xp-minesweeper-panel"><output data-mines aria-label="Mines remaining">010</output><button type="button" data-reset aria-label="New game">🙂</button><output data-time aria-label="Elapsed time">000</output></div><div class="xp-minesweeper-board" role="grid" aria-label="Minesweeper board"></div>`;
     const board = content.querySelector(".xp-minesweeper-board");
     const mineCounter = content.querySelector("[data-mines]");
     const timeCounter = content.querySelector("[data-time]");
     const reset = content.querySelector("[data-reset]");
-    const mineIndexes = new Set([2, 8, 19, 25, 33, 48, 56, 63, 75, 79]);
+    const difficulty = content.querySelector("[aria-label='Difficulty']");
+    const levels = {
+      beginner: { rows: 9, columns: 9, mines: 10 },
+      intermediate: { rows: 16, columns: 16, mines: 40 },
+      expert: { rows: 16, columns: 30, mines: 99 },
+    };
+    let level = levels.beginner;
+    let mineIndexes = null;
     let flags = 0;
     let elapsed = 0;
     let timer = null;
     let finished = false;
     const neighbors = (index) => {
-      const row = Math.floor(index / 9);
-      const column = index % 9;
+      const row = Math.floor(index / level.columns);
+      const column = index % level.columns;
       const result = [];
       for (let rowOffset = -1; rowOffset <= 1; rowOffset += 1) {
         for (let columnOffset = -1; columnOffset <= 1; columnOffset += 1) {
           if (!rowOffset && !columnOffset) continue;
           const nextRow = row + rowOffset;
           const nextColumn = column + columnOffset;
-          if (nextRow < 0 || nextRow > 8 || nextColumn < 0 || nextColumn > 8)
+          if (
+            nextRow < 0 ||
+            nextRow >= level.rows ||
+            nextColumn < 0 ||
+            nextColumn >= level.columns
+          )
             continue;
-          result.push(nextRow * 9 + nextColumn);
+          result.push(nextRow * level.columns + nextColumn);
         }
       }
       return result;
@@ -7640,6 +7652,16 @@ const createXPProgramContent = (programId) => {
         timeCounter.textContent = String(elapsed).padStart(3, "0");
       }, 1000);
     };
+    const placeMines = (firstIndex) => {
+      const excluded = new Set([firstIndex, ...neighbors(firstIndex)]);
+      mineIndexes = new Set();
+      while (mineIndexes.size < level.mines) {
+        const candidate = Math.floor(
+          Math.random() * (level.rows * level.columns),
+        );
+        if (!excluded.has(candidate)) mineIndexes.add(candidate);
+      }
+    };
     const reveal = (index) => {
       const cell = board.children[index];
       if (
@@ -7648,6 +7670,7 @@ const createXPProgramContent = (programId) => {
         cell.dataset.flagged
       )
         return;
+      if (!mineIndexes) placeMines(index);
       startTimer();
       cell.classList.add("revealed");
       if (mineIndexes.has(index)) {
@@ -7671,7 +7694,10 @@ const createXPProgramContent = (programId) => {
       } else {
         neighbors(index).forEach(reveal);
       }
-      if (board.querySelectorAll(".revealed:not(.mine)").length === 71) {
+      if (
+        board.querySelectorAll(".revealed:not(.mine)").length ===
+        level.rows * level.columns - level.mines
+      ) {
         reset.textContent = "😎";
         finished = true;
         stopTimer();
@@ -7682,11 +7708,20 @@ const createXPProgramContent = (programId) => {
       elapsed = 0;
       flags = 0;
       finished = false;
+      mineIndexes = null;
+      level = levels[difficulty.value];
       timeCounter.textContent = "000";
-      mineCounter.textContent = "010";
+      mineCounter.textContent = String(level.mines).padStart(3, "0");
       reset.textContent = "🙂";
       board.replaceChildren();
-      for (let index = 0; index < 81; index += 1) {
+      board.style.gridTemplateColumns = `repeat(${level.columns}, 18px)`;
+      const owner = content.closest(".xp-window");
+      if (owner) {
+        const desktop = getDesktopSize();
+        owner.style.width = `${Math.min(level.columns * 18 + 22, desktop.width - 16)}px`;
+        owner.style.height = `${Math.min(level.rows * 18 + 108, desktop.height - 16)}px`;
+      }
+      for (let index = 0; index < level.rows * level.columns; index += 1) {
         const cell = document.createElement("button");
         cell.type = "button";
         cell.setAttribute("role", "gridcell");
@@ -7696,16 +7731,20 @@ const createXPProgramContent = (programId) => {
           event.preventDefault();
           if (finished || cell.classList.contains("revealed")) return;
           const flagged = cell.dataset.flagged === "true";
-          if (!flagged && flags === 10) return;
+          if (!flagged && flags === level.mines) return;
           cell.dataset.flagged = flagged ? "" : "true";
           cell.textContent = flagged ? "" : "⚑";
           flags += flagged ? -1 : 1;
-          mineCounter.textContent = String(10 - flags).padStart(3, "0");
+          mineCounter.textContent = String(level.mines - flags).padStart(
+            3,
+            "0",
+          );
         });
         board.appendChild(cell);
       }
     };
     reset.addEventListener("click", initialize);
+    difficulty.addEventListener("change", initialize);
     initialize();
     return content;
   }
@@ -8214,6 +8253,68 @@ const createXPProgramContent = (programId) => {
     return content;
   }
 
+  if (program.kind === "tasks") {
+    content.innerHTML = `<div class="xp-program-toolbar"><button type="button" data-task-new>Add Scheduled Task</button></div><form class="xp-task-form" hidden><label>Task name: <input name="name" aria-label="Task name" required></label><label>Program: <select name="program" aria-label="Program"><option>Disk Cleanup</option><option>Notepad</option><option>System Information</option></select></label><label>Schedule: <select name="schedule" aria-label="Schedule"><option>Daily</option><option>Weekly</option><option>When I log on</option></select></label><div><button type="submit">Finish</button><button type="button" data-task-cancel>Cancel</button></div></form><table class="xp-task-list"><thead><tr><th>Name</th><th>Schedule</th><th>Next Run Time</th><th></th></tr></thead><tbody></tbody></table><p class="xp-program-status" aria-live="polite">Use Add Scheduled Task to schedule a program.</p>`;
+    const form = content.querySelector(".xp-task-form");
+    const body = content.querySelector("tbody");
+    const status = content.querySelector(".xp-program-status");
+    const tasks = [];
+    const renderTasks = () => {
+      body.replaceChildren();
+      tasks.forEach((task, index) => {
+        const row = document.createElement("tr");
+        row.dataset.task = String(index);
+        [task.name, task.schedule, task.nextRun].forEach((value) => {
+          const cell = document.createElement("td");
+          cell.textContent = value;
+          row.appendChild(cell);
+        });
+        const actions = document.createElement("td");
+        actions.innerHTML = `<button type="button" data-task-run>Run</button><button type="button" data-task-delete>Delete</button>`;
+        row.appendChild(actions);
+        body.appendChild(row);
+      });
+    };
+    content.querySelector("[data-task-new]").addEventListener("click", () => {
+      form.hidden = false;
+      form.elements.name.focus();
+    });
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      tasks.push({
+        name: form.elements.name.value.trim(),
+        program: form.elements.program.value,
+        schedule: form.elements.schedule.value,
+        nextRun:
+          form.elements.schedule.value === "When I log on"
+            ? "At next logon"
+            : "Tomorrow at 9:00 AM",
+      });
+      status.textContent = `${form.elements.name.value.trim()} was scheduled.`;
+      form.reset();
+      form.hidden = true;
+      renderTasks();
+    });
+    form.querySelector("[data-task-cancel]").addEventListener("click", () => {
+      form.reset();
+      form.hidden = true;
+    });
+    body.addEventListener("click", (event) => {
+      const row = event.target.closest("[data-task]");
+      if (!row) return;
+      const index = Number(row.dataset.task);
+      if (event.target.closest("[data-task-run]")) {
+        status.textContent = `${tasks[index].name} ran ${tasks[index].program}.`;
+      } else if (event.target.closest("[data-task-delete]")) {
+        const [removed] = tasks.splice(index, 1);
+        status.textContent = `${removed.name} was deleted.`;
+        renderTasks();
+      }
+    });
+    renderTasks();
+    return content;
+  }
+
   if (program.kind === "information") {
     content.innerHTML = `<div class="xp-system-information"><aside><button type="button" class="selected" data-info-section="summary">System Summary</button><button type="button" data-info-section="hardware">Hardware Resources</button><button type="button" data-info-section="components">Components</button><button type="button" data-info-section="software">Software Environment</button></aside><table><tbody></tbody></table></div>`;
     const sections = {
@@ -8285,20 +8386,61 @@ const createXPProgramContent = (programId) => {
   }
 
   if (program.kind === "browser") {
-    content.innerHTML = `<div class="xp-browser-toolbar"><button type="button">Back</button><label>Address <input value="about:blank" aria-label="Address"></label><button type="button" data-go>Go</button></div><div class="xp-browser-page"><h1>${program.title}</h1><p>This offline recreation can display local pages without connecting to the internet.</p></div>`;
-    const navigate = () => {
-      const address = content.querySelector("input").value;
-      const page = content.querySelector(".xp-browser-page");
+    const homeAddress =
+      programId === "__msn" ? "http://www.msn.com/" : "about:home";
+    content.innerHTML = `<div class="xp-browser-toolbar"><button type="button" data-browser-back disabled>Back</button><button type="button" data-browser-forward disabled>Forward</button><button type="button" data-browser-home>Home</button><button type="button" data-browser-refresh>Refresh</button><label>Address <input value="${homeAddress}" aria-label="Address"></label><button type="button" data-go>Go</button></div><div class="xp-browser-page"></div>`;
+    const input = content.querySelector("input");
+    const page = content.querySelector(".xp-browser-page");
+    const back = content.querySelector("[data-browser-back]");
+    const forward = content.querySelector("[data-browser-forward]");
+    let history = [homeAddress];
+    let historyIndex = 0;
+    const render = (address) => {
+      input.value = address;
+      page.replaceChildren();
       const heading = document.createElement("h1");
       const message = document.createElement("p");
-      heading.textContent = address;
-      message.textContent = "The requested page is not available offline.";
-      page.replaceChildren(heading, message);
+      if (address === "about:home") {
+        heading.textContent = "Welcome to Internet Explorer";
+        message.textContent =
+          "Browse local pages or enter an address while this recreation is offline.";
+      } else if (address === "http://www.msn.com/") {
+        heading.textContent = "MSN";
+        message.textContent = "MSN is not available while working offline.";
+      } else {
+        heading.textContent = address;
+        message.textContent = "The requested page is not available offline.";
+      }
+      page.append(heading, message);
+      back.disabled = historyIndex === 0;
+      forward.disabled = historyIndex === history.length - 1;
     };
-    content.querySelector("[data-go]").addEventListener("click", navigate);
-    content.querySelector("input").addEventListener("keydown", (event) => {
+    const navigate = (address = input.value.trim()) => {
+      if (!address) return;
+      history = history.slice(0, historyIndex + 1);
+      history.push(address);
+      historyIndex = history.length - 1;
+      render(address);
+    };
+    content
+      .querySelector("[data-go]")
+      .addEventListener("click", () => navigate());
+    input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") navigate();
     });
+    back.addEventListener("click", () => {
+      if (historyIndex > 0) render(history[--historyIndex]);
+    });
+    forward.addEventListener("click", () => {
+      if (historyIndex < history.length - 1) render(history[++historyIndex]);
+    });
+    content
+      .querySelector("[data-browser-home]")
+      .addEventListener("click", () => navigate(homeAddress));
+    content
+      .querySelector("[data-browser-refresh]")
+      .addEventListener("click", () => render(history[historyIndex]));
+    render(homeAddress);
     return content;
   }
 
@@ -8308,6 +8450,7 @@ const createXPProgramContent = (programId) => {
       Inbox: [
         {
           from: "Outlook Express Team",
+          email: "outlook-express@example.com",
           subject: "Welcome to Outlook Express 6",
           body: "Outlook Express is ready to manage mail stored on this computer.",
         },
@@ -8319,7 +8462,14 @@ const createXPProgramContent = (programId) => {
     };
     const folderPane = content.querySelector(".xp-mail-folders");
     const workspace = content.querySelector(".xp-mail-workspace");
+    const replyButton = content.querySelector("[data-mail-reply]");
+    const deleteButton = content.querySelector("[data-mail-delete]");
     let currentFolder = "Inbox";
+    let selectedMessage = null;
+    const updateMailActions = () => {
+      replyButton.disabled = !selectedMessage;
+      deleteButton.disabled = !selectedMessage;
+    };
     const renderFolders = () => {
       folderPane.replaceChildren();
       Object.entries(folders).forEach(([name, messages]) => {
@@ -8332,6 +8482,8 @@ const createXPProgramContent = (programId) => {
       });
     };
     const renderFolder = () => {
+      selectedMessage = null;
+      updateMailActions();
       renderFolders();
       workspace.innerHTML = `<table class="xp-mail-list"><thead><tr><th>From</th><th>Subject</th></tr></thead><tbody></tbody></table><article class="xp-mail-preview"><p>Select a message to read it.</p></article>`;
       const body = workspace.querySelector("tbody");
@@ -8346,9 +8498,12 @@ const createXPProgramContent = (programId) => {
         body.appendChild(row);
       });
     };
-    const openComposer = () => {
+    const openComposer = (initial = {}) => {
       workspace.innerHTML = `<form class="xp-mail-compose"><label>To: <input name="to" type="email" aria-label="To" required></label><label>Subject: <input name="subject" aria-label="Subject"></label><textarea name="body" aria-label="Message body"></textarea><div><button type="submit">Send</button><button type="button" data-save-draft>Save Draft</button></div></form>`;
       const form = workspace.querySelector("form");
+      form.elements.to.value = initial.to || "";
+      form.elements.subject.value = initial.subject || "";
+      form.elements.body.value = initial.body || "";
       const storeMessage = (folder) => {
         folders[folder].push({
           from: "Administrator",
@@ -8377,7 +8532,17 @@ const createXPProgramContent = (programId) => {
     workspace.addEventListener("click", (event) => {
       const row = event.target.closest("[data-message]");
       if (!row) return;
-      const message = folders[currentFolder][Number(row.dataset.message)];
+      selectedMessage = {
+        index: Number(row.dataset.message),
+        message: folders[currentFolder][Number(row.dataset.message)],
+      };
+      workspace
+        .querySelectorAll("[data-message]")
+        .forEach((candidate) =>
+          candidate.classList.toggle("selected", candidate === row),
+        );
+      updateMailActions();
+      const { message } = selectedMessage;
       workspace.querySelector(".xp-mail-preview").innerHTML =
         `<h3></h3><p class="xp-mail-from"></p><div class="xp-mail-body"></div>`;
       workspace.querySelector("h3").textContent = message.subject;
@@ -8387,7 +8552,25 @@ const createXPProgramContent = (programId) => {
     });
     content
       .querySelector("[data-mail-new]")
-      .addEventListener("click", openComposer);
+      .addEventListener("click", () => openComposer());
+    replyButton.addEventListener("click", () => {
+      if (!selectedMessage) return;
+      const { message } = selectedMessage;
+      openComposer({
+        to: message.email || message.to || "",
+        subject: message.subject?.startsWith("Re:")
+          ? message.subject
+          : `Re: ${message.subject || ""}`,
+        body: `\n\n----- Original Message -----\n${message.body || ""}`,
+      });
+    });
+    deleteButton.addEventListener("click", () => {
+      if (!selectedMessage) return;
+      const [message] = folders[currentFolder].splice(selectedMessage.index, 1);
+      if (currentFolder !== "Deleted Items")
+        folders["Deleted Items"].push(message);
+      renderFolder();
+    });
     renderFolder();
     return content;
   }

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -351,7 +351,7 @@ const XP_NATIVE_PROGRAMS = Object.freeze({
   __hyperterminal: {
     title: "HyperTerminal",
     icon: "CommandPrompt.png",
-    kind: "terminal",
+    kind: "hyperterminal",
   },
   "__network-connections": {
     title: "Network Connections",
@@ -7460,6 +7460,43 @@ const createXPProgramContent = (programId) => {
     return content;
   }
 
+  if (program.kind === "hyperterminal") {
+    content.innerHTML = `<form class="xp-hyperterminal-connect"><fieldset><legend>Connect To</legend><label>Name: <input name="name" value="My Connection" aria-label="Connection name"></label><label>Country/region: <select name="country" aria-label="Country or region"><option>Argentina (54)</option><option>United States of America (1)</option></select></label><label>Area code: <input name="area" aria-label="Area code"></label><label>Phone number: <input name="phone" aria-label="Phone number" required></label></fieldset><div><button type="submit">Dial</button><button type="button" data-hyperterminal-cancel>Cancel</button></div><p class="xp-program-status" aria-live="polite"></p></form>`;
+    const form = content.querySelector("form");
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const phone = form.elements.phone.value.trim();
+      if (!phone) return;
+      content.innerHTML = `<div class="xp-hyperterminal-toolbar"><span>Connected to </span><b></b><button type="button" data-disconnect>Disconnect</button></div><div class="xp-hyperterminal-screen" aria-live="polite">ATDT${phone}\nCONNECT 57600\n</div><form class="xp-hyperterminal-prompt"><input aria-label="Terminal input" autocomplete="off"><button type="submit">Send</button></form>`;
+      content.querySelector(".xp-hyperterminal-toolbar b").textContent =
+        form.elements.name.value || phone;
+      const screen = content.querySelector(".xp-hyperterminal-screen");
+      const prompt = content.querySelector(".xp-hyperterminal-prompt");
+      prompt.addEventListener("submit", (promptEvent) => {
+        promptEvent.preventDefault();
+        const input = prompt.querySelector("input");
+        if (!input.value) return;
+        screen.textContent += `${input.value}\n`;
+        input.value = "";
+      });
+      content
+        .querySelector("[data-disconnect]")
+        .addEventListener("click", () => {
+          screen.textContent += "\nNO CARRIER";
+          prompt.querySelector("input").disabled = true;
+          prompt.querySelector("button").disabled = true;
+        });
+      prompt.querySelector("input").focus();
+    });
+    form
+      .querySelector("[data-hyperterminal-cancel]")
+      .addEventListener("click", () => {
+        form.querySelector(".xp-program-status").textContent =
+          "The connection was cancelled.";
+      });
+    return content;
+  }
+
   if (program.kind === "editor") {
     content.innerHTML = `<div class="xp-editor-toolbar"><button type="button" data-editor-command="bold"><b>B</b></button><button type="button" data-editor-command="italic"><i>I</i></button><button type="button" data-editor-command="underline"><u>U</u></button></div><div class="xp-editor-page" contenteditable="true" role="textbox" aria-label="Document"></div>`;
     const page = content.querySelector(".xp-editor-page");
@@ -7820,12 +7857,16 @@ const createXPProgramContent = (programId) => {
       if (!button || !selected) return;
       const card = selectedCard();
       const foundation = foundations.get(button.dataset.suit) || [];
+      const isSingleCard =
+        selected.source === "waste" ||
+        selected.card === tableau[selected.column].length - 1;
       if (
+        isSingleCard &&
         card?.suit === button.dataset.suit &&
         card.rank === foundation.length + 1
       ) {
-        removeSelected();
-        foundation.push(card);
+        const moved = removeSelected();
+        foundation.push(Array.isArray(moved) ? moved[0] : moved);
         foundations.set(card.suit, foundation);
         score.textContent = String(Number(score.textContent) + 10);
         selected = null;
@@ -7857,6 +7898,172 @@ const createXPProgramContent = (programId) => {
       render();
     };
     content.querySelector("[data-new-game]").addEventListener("click", newGame);
+    newGame();
+    return content;
+  }
+
+  if (programId === "__freecell") {
+    content.className += " xp-freecell";
+    content.innerHTML = `<div class="xp-freecell-menu"><button type="button" data-freecell-new>Game</button><button type="button">Help</button><span data-freecell-status>Game in progress</span></div><div class="xp-freecell-board"><div class="xp-freecell-cells" aria-label="Free cells"></div><div class="xp-freecell-foundations" aria-label="Foundations"></div><div class="xp-freecell-cascades" aria-label="Cascades"></div></div>`;
+    const suits = ["♠", "♥", "♦", "♣"];
+    const redSuits = new Set(["♥", "♦"]);
+    const rankLabel = (rank) =>
+      rank === 1
+        ? "A"
+        : rank === 11
+          ? "J"
+          : rank === 12
+            ? "Q"
+            : rank === 13
+              ? "K"
+              : String(rank);
+    const freeCellElement = content.querySelector(".xp-freecell-cells");
+    const foundationElement = content.querySelector(".xp-freecell-foundations");
+    const cascadeElement = content.querySelector(".xp-freecell-cascades");
+    const status = content.querySelector("[data-freecell-status]");
+    let freeCells = Array(4).fill(null);
+    let foundations = new Map();
+    let cascades = [];
+    let selected = null;
+    const renderCard = (button, card) => {
+      button.className = `xp-playing-card face-up${redSuits.has(card.suit) ? " red" : ""}`;
+      button.innerHTML = `<span>${rankLabel(card.rank)}</span><b>${card.suit}</b>`;
+      button.setAttribute(
+        "aria-label",
+        `${rankLabel(card.rank)} of ${card.suit}`,
+      );
+    };
+    const selectedCard = () =>
+      selected?.source === "cell"
+        ? freeCells[selected.index]
+        : cascades[selected?.index]?.at(-1);
+    const removeSelected = () => {
+      const card = selectedCard();
+      if (selected.source === "cell") freeCells[selected.index] = null;
+      else cascades[selected.index].pop();
+      return card;
+    };
+    const validCascadeMove = (card, destination) => {
+      const top = destination.at(-1);
+      return (
+        !top ||
+        (top.rank === card.rank + 1 &&
+          redSuits.has(top.suit) !== redSuits.has(card.suit))
+      );
+    };
+    const render = () => {
+      freeCellElement.replaceChildren();
+      freeCells.forEach((card, index) => {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.dataset.cell = String(index);
+        button.className = "xp-freecell-slot empty";
+        if (card) renderCard(button, card);
+        else button.setAttribute("aria-label", `Empty free cell ${index + 1}`);
+        if (selected?.source === "cell" && selected.index === index)
+          button.classList.add("selected");
+        freeCellElement.appendChild(button);
+      });
+      foundationElement.replaceChildren();
+      suits.forEach((suit) => {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.dataset.suit = suit;
+        button.className = "xp-freecell-foundation empty";
+        const pile = foundations.get(suit) || [];
+        if (pile.length) renderCard(button, pile.at(-1));
+        else button.textContent = suit;
+        foundationElement.appendChild(button);
+      });
+      cascadeElement.replaceChildren();
+      cascades.forEach((cascade, cascadeIndex) => {
+        const column = document.createElement("div");
+        column.className = "xp-freecell-cascade";
+        column.dataset.cascade = String(cascadeIndex);
+        cascade.forEach((card, cardIndex) => {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.style.setProperty("--card-index", cardIndex);
+          renderCard(button, card);
+          if (
+            selected?.source === "cascade" &&
+            selected.index === cascadeIndex &&
+            cardIndex === cascade.length - 1
+          )
+            button.classList.add("selected");
+          column.appendChild(button);
+        });
+        cascadeElement.appendChild(column);
+      });
+      const remaining = cascades.reduce(
+        (total, pile) => total + pile.length,
+        0,
+      );
+      if (!remaining && freeCells.every((card) => !card))
+        status.textContent = "You won!";
+    };
+    freeCellElement.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-cell]");
+      if (!button) return;
+      const index = Number(button.dataset.cell);
+      if (selected && !freeCells[index]) {
+        freeCells[index] = removeSelected();
+        selected = null;
+      } else if (freeCells[index]) {
+        selected = { source: "cell", index };
+      }
+      render();
+    });
+    cascadeElement.addEventListener("click", (event) => {
+      const column = event.target.closest("[data-cascade]");
+      if (!column) return;
+      const index = Number(column.dataset.cascade);
+      if (selected) {
+        const card = selectedCard();
+        if (card && validCascadeMove(card, cascades[index])) {
+          cascades[index].push(removeSelected());
+          selected = null;
+          render();
+          return;
+        }
+      }
+      if (cascades[index].length) selected = { source: "cascade", index };
+      render();
+    });
+    foundationElement.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-suit]");
+      if (!button || !selected) return;
+      const card = selectedCard();
+      const pile = foundations.get(button.dataset.suit) || [];
+      if (card?.suit === button.dataset.suit && card.rank === pile.length + 1) {
+        pile.push(removeSelected());
+        foundations.set(button.dataset.suit, pile);
+        selected = null;
+        render();
+      }
+    });
+    const newGame = () => {
+      const deck = suits.flatMap((suit) =>
+        Array.from({ length: 13 }, (_, index) => ({
+          suit,
+          rank: index + 1,
+        })),
+      );
+      for (let index = deck.length - 1; index > 0; index -= 1) {
+        const target = Math.floor(Math.random() * (index + 1));
+        [deck[index], deck[target]] = [deck[target], deck[index]];
+      }
+      cascades = Array.from({ length: 8 }, () => []);
+      deck.forEach((card, index) => cascades[index % 8].push(card));
+      freeCells = Array(4).fill(null);
+      foundations = new Map();
+      selected = null;
+      status.textContent = "Game in progress";
+      render();
+    };
+    content
+      .querySelector("[data-freecell-new]")
+      .addEventListener("click", newGame);
     newGame();
     return content;
   }
@@ -7933,6 +8140,60 @@ const createXPProgramContent = (programId) => {
     return content;
   }
 
+  if (programId === "__disk-defragmenter") {
+    content.innerHTML = `<div class="xp-defrag-volume"><table><thead><tr><th>Volume</th><th>File System</th><th>Capacity</th><th>Free Space</th><th>% Free Space</th></tr></thead><tbody><tr class="selected"><td>(C:)</td><td>NTFS</td><td>20.00 GB</td><td>12.34 GB</td><td>61%</td></tr></tbody></table></div><div class="xp-defrag-legend"><span><i class="fragmented"></i> Fragmented files</span><span><i class="contiguous"></i> Contiguous files</span><span><i class="system"></i> System files</span><span><i class="free"></i> Free space</span></div><section class="xp-defrag-map"><h3>Estimated disk usage before defragmentation:</h3><div data-defrag-before></div><h3>Estimated disk usage after defragmentation:</h3><div data-defrag-after></div></section><p class="xp-program-status" aria-live="polite">Select a volume and click Analyze.</p><div class="xp-defrag-actions"><button type="button" data-defrag-analyze>Analyze</button><button type="button" data-defrag-run disabled>Defragment</button></div>`;
+    const before = content.querySelector("[data-defrag-before]");
+    const after = content.querySelector("[data-defrag-after]");
+    const status = content.querySelector(".xp-program-status");
+    const runButton = content.querySelector("[data-defrag-run]");
+    const blocks = [
+      "contiguous",
+      "contiguous",
+      "fragmented",
+      "free",
+      "system",
+      "fragmented",
+      "contiguous",
+      "free",
+      "fragmented",
+      "free",
+      "contiguous",
+      "free",
+      "system",
+      "free",
+      "free",
+      "contiguous",
+    ];
+    const renderMap = (target, layout) => {
+      target.replaceChildren(
+        ...layout.map((type) => {
+          const block = document.createElement("i");
+          block.className = type;
+          return block;
+        }),
+      );
+    };
+    renderMap(before, blocks);
+    renderMap(after, Array(16).fill("free"));
+    content
+      .querySelector("[data-defrag-analyze]")
+      .addEventListener("click", () => {
+        status.textContent =
+          "Analysis is complete. You should defragment this volume.";
+        runButton.disabled = false;
+      });
+    runButton.addEventListener("click", () => {
+      renderMap(after, [
+        ...Array(7).fill("contiguous"),
+        ...Array(2).fill("system"),
+        ...Array(7).fill("free"),
+      ]);
+      status.textContent = "Defragmentation is complete for Local Disk (C:).";
+      runButton.disabled = true;
+    });
+    return content;
+  }
+
   if (program.kind === "disk") {
     content.innerHTML = `<div class="xp-disk-header"><img src="${XP_ICON_PATHS[program.icon]}" alt=""><div><b>${program.title}</b><p>Local Disk (C:)</p></div></div><fieldset><legend>Files to delete</legend><label><input type="checkbox" data-size="18" checked> Downloaded Program Files <span>18 KB</span></label><label><input type="checkbox" data-size="1536" checked> Temporary Internet Files <span>1,536 KB</span></label><label><input type="checkbox" data-size="64"> Recycle Bin <span>64 KB</span></label><label><input type="checkbox" data-size="2944" checked> Temporary files <span>2,944 KB</span></label></fieldset><p>You can free up <b data-disk-total>4,498 KB</b> of disk space.</p><button type="button" data-disk-clean>OK</button><p class="xp-program-status" aria-live="polite"></p>`;
     const updateTotal = () => {
@@ -7954,7 +8215,61 @@ const createXPProgramContent = (programId) => {
   }
 
   if (program.kind === "information") {
-    content.innerHTML = `<div class="xp-system-information"><aside><button type="button" class="selected">System Summary</button><button type="button">Hardware Resources</button><button type="button">Components</button><button type="button">Software Environment</button></aside><table><tbody><tr><th>OS Name</th><td>Microsoft Windows XP Professional</td></tr><tr><th>Version</th><td>5.1.2600 Service Pack 3 Build 2600</td></tr><tr><th>System Manufacturer</th><td>Astro VM</td></tr><tr><th>System Type</th><td>X86-based PC</td></tr><tr><th>Total Physical Memory</th><td>512.00 MB</td></tr><tr><th>Display</th><td>${window.innerWidth} × ${window.innerHeight}</td></tr></tbody></table></div>`;
+    content.innerHTML = `<div class="xp-system-information"><aside><button type="button" class="selected" data-info-section="summary">System Summary</button><button type="button" data-info-section="hardware">Hardware Resources</button><button type="button" data-info-section="components">Components</button><button type="button" data-info-section="software">Software Environment</button></aside><table><tbody></tbody></table></div>`;
+    const sections = {
+      summary: [
+        ["OS Name", "Microsoft Windows XP Professional"],
+        ["Version", "5.1.2600 Service Pack 3 Build 2600"],
+        ["System Manufacturer", "Astro VM"],
+        ["System Type", "X86-based PC"],
+        ["Total Physical Memory", "512.00 MB"],
+        ["Display", `${window.innerWidth} × ${window.innerHeight}`],
+      ],
+      hardware: [
+        ["Conflicts/Sharing", "No hardware conflicts detected"],
+        ["DMA", "Direct memory access controller"],
+        ["IRQs", "System timer — IRQ 0"],
+        ["Memory", "0x00000000–0x1FFFFFFF"],
+      ],
+      components: [
+        ["Display", "Standard VGA Graphics Adapter"],
+        ["Multimedia", "Audio Codecs"],
+        ["Network", "Local Area Connection"],
+        ["Storage", "Local Disk (C:)"],
+      ],
+      software: [
+        ["System Drivers", "All drivers are running"],
+        ["Environment Variables", "TEMP, PATH, USERPROFILE"],
+        ["Running Tasks", "explorer.exe, services.exe"],
+        ["Startup Programs", "Windows Messenger"],
+      ],
+    };
+    const body = content.querySelector("tbody");
+    const renderSection = (section) => {
+      body.replaceChildren();
+      sections[section].forEach(([name, value]) => {
+        const row = document.createElement("tr");
+        const heading = document.createElement("th");
+        const cell = document.createElement("td");
+        heading.textContent = name;
+        cell.textContent = value;
+        row.append(heading, cell);
+        body.appendChild(row);
+      });
+      content
+        .querySelectorAll("[data-info-section]")
+        .forEach((button) =>
+          button.classList.toggle(
+            "selected",
+            button.dataset.infoSection === section,
+          ),
+        );
+    };
+    content.querySelector("aside").addEventListener("click", (event) => {
+      const button = event.target.closest("[data-info-section]");
+      if (button) renderSection(button.dataset.infoSection);
+    });
+    renderSection("summary");
     return content;
   }
 
@@ -8162,16 +8477,20 @@ const openXPProgram = (programId) => {
     media: [600, 420],
     disk: [430, 420],
     information: [700, 500],
+    hyperterminal: [560, 420],
     mail: [720, 520],
     messenger: [500, 460],
     solitaire: [720, 520],
+    freecell: [760, 540],
   };
   const [preferredWidth, preferredHeight] =
     programId === "__minesweeper"
       ? preferredSizes.minesweeper
       : programId === "__solitaire"
         ? preferredSizes.solitaire
-        : preferredSizes[program.kind] || [640, 470];
+        : programId === "__freecell"
+          ? preferredSizes.freecell
+          : preferredSizes[program.kind] || [640, 470];
   if (programId === "__minesweeper") {
     el.style.minWidth = `${preferredWidth}px`;
     el.style.minHeight = `${preferredHeight}px`;

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -575,6 +575,18 @@ test("All Programs exposes system applications and games in the XP hierarchy", a
   expect(mineCells).toHaveLength(81);
   mineCells[40]!.click();
   expect(mineCells[40]!.classList.contains("revealed")).toBeTrue();
+  const difficulty = minesweeperWindow.querySelector<HTMLSelectElement>(
+    '[aria-label="Difficulty"]',
+  )!;
+  difficulty.value = "intermediate";
+  difficulty.dispatchEvent(new shell.window.Event("change", { bubbles: true }));
+  const intermediateCells =
+    minesweeperWindow.querySelectorAll<HTMLButtonElement>(
+      ".xp-minesweeper-board [role='gridcell']",
+    );
+  expect(intermediateCells).toHaveLength(256);
+  intermediateCells[128]!.click();
+  expect(intermediateCells[128]!.classList.contains("revealed")).toBeTrue();
 
   shell.document.getElementById("start-button")!.click();
   shell.document.getElementById("all-programs-button")!.click();
@@ -643,6 +655,16 @@ test("Outlook Express composes mail and Windows Messenger sends local messages",
   const outlook = shell.document.querySelector(
     '.xp-window[data-game="__outlook-express"]',
   )!;
+  outlook.querySelector<HTMLTableRowElement>("[data-message]")!.click();
+  const reply = outlook.querySelector<HTMLButtonElement>("[data-mail-reply]")!;
+  expect(reply.disabled).toBeFalse();
+  reply.click();
+  expect(
+    outlook.querySelector<HTMLInputElement>('[name="subject"]')!.value,
+  ).toBe("Re: Welcome to Outlook Express 6");
+  expect(outlook.querySelector<HTMLInputElement>('[name="to"]')!.value).toBe(
+    "outlook-express@example.com",
+  );
   outlook.querySelector<HTMLButtonElement>("[data-mail-new]")!.click();
   const form = outlook.querySelector<HTMLFormElement>(".xp-mail-compose")!;
   form.elements.namedItem("to")!.value = "friend@example.com";
@@ -654,6 +676,11 @@ test("Outlook Express composes mail and Windows Messenger sends local messages",
   );
   expect(outlook.querySelector(".xp-mail-list")!.textContent).toContain(
     "Hello from XP",
+  );
+  outlook.querySelector<HTMLTableRowElement>("[data-message]")!.click();
+  outlook.querySelector<HTMLButtonElement>("[data-mail-delete]")!.click();
+  expect(outlook.querySelector(".xp-mail-folders")!.textContent).toContain(
+    "Deleted Items (1)",
   );
 
   openRootProgram("windows-messenger");
@@ -677,6 +704,34 @@ test("Outlook Express composes mail and Windows Messenger sends local messages",
   expect(
     messenger.querySelector(".xp-messenger-history")!.textContent,
   ).toContain("Administrator says: Are you there?");
+});
+
+test("Internet Explorer maintains working navigation history", async () => {
+  const shell = await login(await loadShell());
+  shell.document.getElementById("start-button")!.click();
+  shell.document.getElementById("all-programs-button")!.click();
+  shell.document
+    .getElementById("start-menu-flyouts")!
+    .querySelector<HTMLButtonElement>('[data-program-id="internet-explorer"]')!
+    .click();
+  const browser = shell.document.querySelector(
+    '.xp-window[data-game="__internet-explorer"]',
+  )!;
+  const address = browser.querySelector<HTMLInputElement>(
+    'input[aria-label="Address"]',
+  )!;
+  const go = browser.querySelector<HTMLButtonElement>("[data-go]")!;
+  address.value = "http://first.example/";
+  go.click();
+  address.value = "http://second.example/";
+  go.click();
+  browser.querySelector<HTMLButtonElement>("[data-browser-back]")!.click();
+  expect(address.value).toBe("http://first.example/");
+  expect(browser.querySelector(".xp-browser-page h1")!.textContent).toBe(
+    "http://first.example/",
+  );
+  browser.querySelector<HTMLButtonElement>("[data-browser-forward]")!.click();
+  expect(address.value).toBe("http://second.example/");
 });
 
 test("restored XP utilities expose dedicated working controls", async () => {
@@ -812,6 +867,25 @@ test("FreeCell and restored system tools perform their primary workflows", async
   expect(
     hyperTerminal.querySelector(".xp-hyperterminal-screen")!.textContent,
   ).toContain("HELLO XP");
+
+  openProgram(["accessories", "system-tools"], "scheduled-tasks");
+  const scheduledTasks = shell.document.querySelector(
+    '.xp-window[data-game="__scheduled-tasks"]',
+  )!;
+  scheduledTasks.querySelector<HTMLButtonElement>("[data-task-new]")!.click();
+  const taskForm =
+    scheduledTasks.querySelector<HTMLFormElement>(".xp-task-form")!;
+  taskForm.elements.namedItem("name")!.value = "Daily Cleanup";
+  taskForm.dispatchEvent(
+    new shell.window.Event("submit", { bubbles: true, cancelable: true }),
+  );
+  expect(scheduledTasks.querySelector(".xp-task-list")!.textContent).toContain(
+    "Daily Cleanup",
+  );
+  scheduledTasks.querySelector<HTMLButtonElement>("[data-task-run]")!.click();
+  expect(
+    scheduledTasks.querySelector(".xp-program-status")!.textContent,
+  ).toContain("Daily Cleanup ran Disk Cleanup");
 });
 
 test("Taskbar Properties applies Classic Start menu independently and switches previews", async () => {

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -722,6 +722,98 @@ test("restored XP utilities expose dedicated working controls", async () => {
   );
 });
 
+test("FreeCell and restored system tools perform their primary workflows", async () => {
+  const shell = await login(await loadShell());
+  const openProgram = (folders: string[], programId: string) => {
+    shell.document.getElementById("start-button")!.click();
+    shell.document.getElementById("all-programs-button")!.click();
+    const flyouts = shell.document.getElementById("start-menu-flyouts")!;
+    for (const folder of folders) {
+      flyouts
+        .querySelector<HTMLButtonElement>(`[data-program-id="${folder}"]`)!
+        .click();
+    }
+    flyouts
+      .querySelector<HTMLButtonElement>(`[data-program-id="${programId}"]`)!
+      .click();
+  };
+
+  openProgram(["games"], "freecell");
+  const freeCell = shell.document.querySelector(
+    '.xp-window[data-game="__freecell"]',
+  )!;
+  expect(freeCell.querySelectorAll(".xp-freecell-cascade")).toHaveLength(8);
+  expect(
+    freeCell.querySelectorAll(".xp-freecell-cascade .xp-playing-card"),
+  ).toHaveLength(52);
+  freeCell
+    .querySelector<HTMLButtonElement>(
+      ".xp-freecell-cascade:first-child button:last-child",
+    )!
+    .click();
+  freeCell
+    .querySelector<HTMLButtonElement>('.xp-freecell-cells [data-cell="0"]')!
+    .click();
+  expect(
+    freeCell
+      .querySelector('.xp-freecell-cells [data-cell="0"]')!
+      .classList.contains("empty"),
+  ).toBeFalse();
+  expect(
+    freeCell.querySelectorAll(".xp-freecell-cascade .xp-playing-card"),
+  ).toHaveLength(51);
+
+  openProgram(["accessories", "system-tools"], "disk-defragmenter");
+  const defrag = shell.document.querySelector(
+    '.xp-window[data-game="__disk-defragmenter"]',
+  )!;
+  expect(defrag.querySelector("[data-disk-clean]")).toBeNull();
+  const defragment =
+    defrag.querySelector<HTMLButtonElement>("[data-defrag-run]")!;
+  expect(defragment.disabled).toBeTrue();
+  defrag.querySelector<HTMLButtonElement>("[data-defrag-analyze]")!.click();
+  expect(defragment.disabled).toBeFalse();
+  defragment.click();
+  expect(defrag.querySelector(".xp-program-status")!.textContent).toContain(
+    "Defragmentation is complete",
+  );
+
+  openProgram(["accessories", "system-tools"], "system-information");
+  const information = shell.document.querySelector(
+    '.xp-window[data-game="__system-information"]',
+  )!;
+  information
+    .querySelector<HTMLButtonElement>('[data-info-section="components"]')!
+    .click();
+  expect(information.querySelector("table")!.textContent).toContain(
+    "Standard VGA Graphics Adapter",
+  );
+
+  openProgram(["accessories", "communications"], "hyperterminal");
+  const hyperTerminal = shell.document.querySelector(
+    '.xp-window[data-game="__hyperterminal"]',
+  )!;
+  const connection = hyperTerminal.querySelector<HTMLFormElement>(
+    ".xp-hyperterminal-connect",
+  )!;
+  connection.elements.namedItem("phone")!.value = "5550100";
+  connection.dispatchEvent(
+    new shell.window.Event("submit", { bubbles: true, cancelable: true }),
+  );
+  const terminalInput = hyperTerminal.querySelector<HTMLInputElement>(
+    ".xp-hyperterminal-prompt input",
+  )!;
+  terminalInput.value = "HELLO XP";
+  terminalInput
+    .closest("form")!
+    .dispatchEvent(
+      new shell.window.Event("submit", { bubbles: true, cancelable: true }),
+    );
+  expect(
+    hyperTerminal.querySelector(".xp-hyperterminal-screen")!.textContent,
+  ).toContain("HELLO XP");
+});
+
 test("Taskbar Properties applies Classic Start menu independently and switches previews", async () => {
   const shell = await login(await loadShell());
   const { document, window } = shell;


### PR DESCRIPTION
## What changed

### Games

- implement playable FreeCell with cascades, free cells, foundations, legal moves, and new games
- prevent Solitaire foundation moves from discarding trailing tableau cards
- randomize Minesweeper boards after the first safe click
- add Beginner, Intermediate, and Expert Minesweeper difficulties with correctly sized boards and mine counts

### Applications

- replace the incorrect Disk Cleanup clone used by Disk Defragmenter with a dedicated analyze/defragment workflow and disk maps
- replace HyperTerminal's Command Prompt clone with a connection dialog and interactive terminal session
- make every System Information navigation section render relevant details
- implement Scheduled Tasks creation, execution, and deletion
- add working Internet Explorer Back, Forward, Home, Refresh, and address history
- enable Outlook Express Reply and Delete, including valid reply addressing and Deleted Items behavior

### Tests

- add interaction-level regression coverage for every restored workflow

## Why

Several All Programs entries were present but opened an unrelated app, did nothing, or had inert primary controls. Minesweeper also reused one fixed board, Outlook's Reply/Delete controls were disabled, Internet Explorer's navigation was inert, and Solitaire allowed an unsafe move that could remove multiple cards while placing only one.

## Impact

More of the stock Windows XP All Programs tree now behaves like actual stateful applications instead of placeholders while preserving the existing XP shell and ISO-sourced assets.

## Validation

- `bun run typecheck`
- `bun test` — 88 tests passed
- `bun run validate:javascript`
- `bun run validate:icons`
- `bun run verify:xp-assets`
- `bun run quality`
- verified FreeCell, Disk Defragmenter, HyperTerminal, Internet Explorer, Outlook Express, Minesweeper, and Scheduled Tasks in the in-app browser
