### PR TITLE
Align README description with project about

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Astro Flash Collection
 
-A Windows XP-style desktop for playing classic browser games with Ruffle,
-js-dos, ScummVM, and embedded web runtimes.
+Boot Windows XP in your browser and play classic games with Ruffle, js-dos,
+ScummVM, and embedded web runtimes.
 
 [Open Astro Flash Collection](https://flash.4st.li/)
 

--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,42 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Boot Windows XP in your browser and play classic games with Ruffle, js-dos, ScummVM, and embedded web runtimes."
+    />
+    <meta name="theme-color" content="#245EDC" />
+    <meta name="application-name" content="Astro Flash Collection" />
+    <link rel="canonical" href="https://flash.4st.li/" />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Astro Flash Collection" />
+    <meta property="og:title" content="Astro Flash Collection" />
+    <meta
+      property="og:description"
+      content="Boot Windows XP in your browser and play classic games."
+    />
+    <meta property="og:url" content="https://flash.4st.li/" />
+    <meta
+      property="og:image"
+      content="https://flash.4st.li/assets/xp/bliss.jpg"
+    />
+    <meta property="og:image:width" content="800" />
+    <meta property="og:image:height" content="600" />
+    <meta
+      property="og:image:alt"
+      content="Windows XP Bliss desktop wallpaper"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Astro Flash Collection" />
+    <meta
+      name="twitter:description"
+      content="Boot Windows XP in your browser and play classic games."
+    />
+    <meta
+      name="twitter:image"
+      content="https://flash.4st.li/assets/xp/bliss.jpg"
+    />
     <title>Astro Flash Collection</title>
     <script src="js/ruffle.js"></script>
     <script src="vendor/fflate/0.8.3/index.js"></script>


### PR DESCRIPTION
## Summary
- Rewrite the README opener to match the GitHub about: boot Windows XP in the browser and play classic games
- Keep the runtime list (Ruffle, js-dos, ScummVM, embedded web) as supporting detail
- Add description, Open Graph, Twitter card, theme-color, and canonical meta tags on the main site

## Test plan
- [ ] Confirm README renders correctly on GitHub
- [ ] Confirm the opener matches the repository about text intent
- [ ] View page source on a local build and confirm meta tags are present
- [ ] Confirm assets/xp/bliss.jpg is content-hashed in the built index.html og/twitter image URLs
- [ ] Optional: check a link preview debugger after deploy