### PR TITLE
Add .gitattributes for consistent LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- Add a root `.gitattributes` with `* text=auto eol=lf` so Git normalizes text files to LF on checkout and commit.
- Avoids mixed CRLF/LF noise across platforms and keeps diffs cleaner.

## Test plan
- [ ] Confirm `.gitattributes` is present at the repo root
- [ ] On a fresh clone/checkout, verify text files use LF (`file` / editor line-ending indicators)
- [ ] Make a trivial text edit and confirm no unexpected line-ending-only diffs