### PR TITLE
Fix rendered XP Paint parity

### DIFF
--- a/site/apps/core/about-dialog.js
+++ b/site/apps/core/about-dialog.js
@@ -1,6 +1,6 @@
 export const showXPAboutDialog = (
   dialogs,
-  { title, product, version, copyright, icon },
+  { title, product, version, copyright, icon, licensedTo = "astro" },
 ) => {
   const dialog = dialogs.createDialog({ title, wide: true });
   dialog.el.classList.add("xp-about-dialog");
@@ -32,6 +32,9 @@ export const showXPAboutDialog = (
   licenseLink.rel = "noreferrer";
   licenseLink.textContent = "End-User License Agreement";
   license.append(licenseLink, " to:");
+  const licensee = document.createElement("span");
+  licensee.textContent = licensedTo;
+  license.append(licensee);
 
   const memory = document.createElement("p");
   memory.className = "xp-about-memory";

--- a/site/apps/paint/dialogs.js
+++ b/site/apps/paint/dialogs.js
@@ -14,6 +14,15 @@ const buttonRow = (dialogs, dialog, accept) => {
   dialog.defaultButton = ok;
 };
 
+const addHelpButton = (dialog) => {
+  const help = document.createElement("button");
+  help.type = "button";
+  help.className = "tb-btn help-btn";
+  help.title = "Help";
+  help.setAttribute("aria-label", "Help");
+  dialog.el.querySelector(".title-buttons").prepend(help);
+};
+
 const numericInput = (name, value, suffix = "%") =>
   `<label><span>${name}:</span><input name="${name.toLowerCase()}" type="number" value="${value}"><span>${suffix}</span></label>`;
 
@@ -24,6 +33,7 @@ export const showTransformDialog = (dialogs, kind) =>
       title: flip ? "Flip and Rotate" : "Stretch and Skew",
       onCancel: () => dialog.close(null),
     });
+    addHelpButton(dialog);
     dialog.el.classList.add("paint-transform-dialog");
     dialog.body.innerHTML = flip
       ? `<fieldset><legend>Flip or rotate</legend>
@@ -64,6 +74,7 @@ export const showAttributesDialog = (dialogs, { width, height }) =>
       title: "Attributes",
       onCancel: () => dialog.close(null),
     });
+    addHelpButton(dialog);
     dialog.el.classList.add("paint-attributes-dialog");
     dialog.body.innerHTML = `<p>Width: <input name="width" type="number" min="1" max="4096" value="${width}"></p>
       <p>Height: <input name="height" type="number" min="1" max="4096" value="${height}"></p>
@@ -84,6 +95,7 @@ export const showEditColorsDialog = (dialogs, colors, selected) =>
       title: "Edit Colors",
       onCancel: () => dialog.close(null),
     });
+    addHelpButton(dialog);
     dialog.el.classList.add("paint-edit-colors-dialog");
     const heading = document.createElement("div");
     heading.textContent = "Basic colors:";

--- a/site/apps/paint/index.js
+++ b/site/apps/paint/index.js
@@ -131,14 +131,14 @@ const MENU_ITEMS = {
     separator,
     disabled("scanner", "From Scanner or Camera..."),
     separator,
-    disabled("print-preview", "Print Preview"),
-    disabled("page-setup", "Page Setup..."),
-    disabled("print", "Print...", "Ctrl+P"),
+    ["print-preview", "Print Preview"],
+    ["page-setup", "Page Setup..."],
+    ["print", "Print...", "Ctrl+P"],
     separator,
-    disabled("send", "Send..."),
+    ["send", "Send..."],
     separator,
-    ["wallpaper-tiled", "Set As Background (Tiled)"],
-    ["wallpaper-centered", "Set As Background (Centered)"],
+    disabled("wallpaper-tiled", "Set As Background (Tiled)"),
+    disabled("wallpaper-centered", "Set As Background (Centered)"),
     separator,
     disabled("recent", "Recent File"),
     separator,
@@ -259,7 +259,7 @@ const mountPaint = (shell, instance) => {
   let fileId = null;
   let fileName = "untitled";
   let dirty = false;
-  let tool = "pencil";
+  let tool = "rect-select";
   const panelState = {
     toolbox: true,
     colorbox: true,
@@ -267,6 +267,12 @@ const mountPaint = (shell, instance) => {
     opaque: true,
   };
   const setTitle = () => shell.setTitle(`${fileName} - Paint`);
+  const updateFileCommandState = () => {
+    for (const command of ["wallpaper-tiled", "wallpaper-centered"]) {
+      const item = root.querySelector(`[data-paint-command="${command}"]`);
+      if (item) item.disabled = !fileId;
+    }
+  };
 
   const body = document.createElement("div");
   body.className = "paint-body";
@@ -290,7 +296,7 @@ const mountPaint = (shell, instance) => {
   const status = document.createElement("div");
   status.className = "paint-status";
   status.dataset.paintPanel = "status";
-  status.innerHTML = `<span data-paint-help>For Help, click Help Topics on the Help Menu.</span><span data-paint-position></span>`;
+  status.innerHTML = `<span data-paint-help>For Help, click Help Topics on the Help Menu.</span><span data-paint-position></span><span data-paint-size></span>`;
   const engine = createCanvasEngine({
     canvas,
     frame: canvasFrame,
@@ -411,6 +417,7 @@ const mountPaint = (shell, instance) => {
       fileName = file.name;
       dirty = false;
       setTitle();
+      updateFileCommandState();
     } catch {
       shell.showMessage(
         "Paint",
@@ -440,6 +447,7 @@ const mountPaint = (shell, instance) => {
     fileName = file.name;
     dirty = false;
     setTitle();
+    updateFileCommandState();
     return true;
   };
   const confirmSaveChanges = async () => {
@@ -462,14 +470,13 @@ const mountPaint = (shell, instance) => {
       fileName = "untitled";
       dirty = false;
       setTitle();
+      updateFileCommandState();
     } else if (command === "open") {
       if (!(await confirmSaveChanges())) return;
       const file = await shell.openFile({
         title: "Open",
         startFolder: shell.myPictures,
-        filter: (node) =>
-          node.type === "folder" ||
-          /\.(bmp|dib|gif|jpe?g|png)$/i.test(node.name),
+        filter: [".bmp", ".dib", ".gif", ".jpg", ".jpeg", ".png"],
       });
       if (file) await loadFile(file);
     } else if (command === "save") await save(false);
@@ -507,13 +514,18 @@ const mountPaint = (shell, instance) => {
       shell.setWallpaper(canvas.toDataURL());
     else if (command === "view-bitmap")
       root.classList.toggle("paint-bitmap-view");
+    else if (["print-preview", "page-setup", "print", "send"].includes(command))
+      shell.showMessage(
+        "Paint",
+        "This command is not available in this browser.",
+      );
     else if (command === "about")
       showXPAboutDialog(shell.dialogs, {
         title: "About Paint",
         product: "Microsoft ® Paint",
         version: "Version 5.1 (Build 2600.xpsp.080413-2111 : Service Pack 3)",
         copyright: "Copyright © 2007 Microsoft Corporation",
-        icon: shell.XP_ICON_PATHS["PaintLarge.png"],
+        icon: "assets/xp/icons/PaintLarge.png",
       });
     else if (command === "help")
       shell.showMessage(
@@ -543,6 +555,7 @@ const mountPaint = (shell, instance) => {
 
   root.append(createMenuBar(run, (command) => panelState[command]));
   root.append(body, colors, status);
+  updateFileCommandState();
   const removeScrollbars = installPaintScrollbars(
     workspaceShell,
     workspace,

--- a/site/apps/paint/scrollbars.js
+++ b/site/apps/paint/scrollbars.js
@@ -44,6 +44,9 @@ const createScrollbar = (shell, viewport, axis) => {
   };
   const update = () => {
     const { maximum, thumbLength, travel } = metrics();
+    bar.hidden = maximum === 0;
+    shell.classList.toggle(`has-${axis}-scrollbar`, maximum > 0);
+    thumb.hidden = maximum === 0;
     const position = maximum ? (travel * viewport[scrollKey]) / maximum : 0;
     thumb.style[sizeKey] = `${thumbLength}px`;
     thumb.style[positionKey] = `${position}px`;
@@ -100,6 +103,9 @@ export const installPaintScrollbars = (shell, viewport, canvas) => {
   const observer = new ResizeObserver(update);
   observer.observe(viewport);
   observer.observe(canvas);
-  requestAnimationFrame(update);
+  requestAnimationFrame(() => {
+    update();
+    requestAnimationFrame(update);
+  });
   return () => observer.disconnect();
 };

--- a/site/css/apps/common.css
+++ b/site/css/apps/common.css
@@ -7,7 +7,7 @@
 .xp-about-banner {
   display: block;
   width: calc(100% + 18px);
-  height: 105px;
+  height: 72px;
   margin: 0 -9px 12px;
   object-fit: fill;
   image-rendering: auto;
@@ -27,10 +27,14 @@
   object-fit: contain;
 }
 .xp-about-license {
-  margin: 9px 0 38px 46px;
+  margin: 9px 0 29px 46px;
   font:
     11px/14px Tahoma,
     sans-serif;
+}
+.xp-about-license span {
+  display: block;
+  margin: 8px 0 0 15px;
 }
 .xp-about-memory {
   margin: 0 3px 17px 46px;

--- a/site/css/apps/paint.css
+++ b/site/css/apps/paint.css
@@ -46,6 +46,9 @@
   background: #fff;
   box-shadow: 2px 2px 3px #777;
 }
+.paint-menu-group:first-child .paint-menu {
+  min-width: 228px;
+}
 .paint-menu button {
   display: grid;
   grid-template-columns: 16px 1fr auto;
@@ -88,7 +91,7 @@
   grid-template-columns: repeat(2, 25px);
   grid-auto-rows: 25px;
   align-content: start;
-  flex: 0 0 52px;
+  flex: 0 0 56px;
   padding: 3px 2px;
   border-right: 2px groove #fff;
   background: #ece9d8;
@@ -286,7 +289,7 @@
 
 /* The ISO-matched Paint tool sprite wins over CSS fallbacks above. */
 .paint-tool::after {
-  inset: auto;
+  inset: 4px auto auto 4px;
   border: 0;
   border-radius: 0;
   background-color: transparent;
@@ -309,11 +312,17 @@
 }
 .paint-workspace {
   position: absolute;
-  inset: 0 var(--paint-scrollbar-size) var(--paint-scrollbar-size) 0;
+  inset: 0;
   overflow: auto;
   padding: 3px 20px 20px 3px;
   background: #808080;
   scrollbar-width: none;
+}
+.paint-workspace-shell.has-vertical-scrollbar .paint-workspace {
+  right: var(--paint-scrollbar-size);
+}
+.paint-workspace-shell.has-horizontal-scrollbar .paint-workspace {
+  bottom: var(--paint-scrollbar-size);
 }
 .paint-workspace::-webkit-scrollbar {
   display: none;
@@ -326,6 +335,8 @@
   padding: 0;
   border-right: 3px solid #c0c0c0;
   border-bottom: 3px solid #c0c0c0;
+  outline: 1px dotted #174f9b;
+  outline-offset: -1px;
   line-height: 0;
 }
 .paint-canvas {
@@ -362,7 +373,7 @@
 }
 .paint-color-box {
   display: flex;
-  flex: 0 0 44px;
+  flex: 0 0 50px;
   align-items: center;
   gap: 1px;
   padding: 3px 4px;
@@ -446,7 +457,7 @@
   margin: 3px 0;
 }
 .paint-edit-colors-dialog {
-  width: 246px;
+  width: 220px;
 }
 .paint-edit-colors-dialog .dlg-body {
   padding: 8px;
@@ -483,7 +494,7 @@
 }
 .paint-edit-colors-dialog .dlg-body > button {
   width: 100%;
-  margin-bottom: 7px;
+  margin-bottom: 2px;
 }
 .paint-edit-colors-dialog .dlg-buttons {
   justify-content: flex-start;
@@ -501,8 +512,8 @@
 }
 .paint-status {
   display: grid;
-  grid-template-columns: 1fr 120px;
-  flex: 0 0 20px;
+  grid-template-columns: 1fr 120px 120px;
+  flex: 0 0 24px;
   gap: 2px;
   padding: 2px;
   border-top: 1px solid #aca899;
@@ -518,6 +529,10 @@
   z-index: 2;
   display: flex;
   background: #f7f7f5;
+}
+.paint-scrollbar[hidden],
+.paint-scroll-thumb[hidden] {
+  display: none;
 }
 .paint-scrollbar.vertical {
   top: 0;
@@ -598,12 +613,13 @@
   min-height: 0;
 }
 .paint-scrollbar.vertical .paint-scroll-track {
-  background: url("/assets/xp/paint/ScrollShaftVertical.png") 0 0 / 17px 68px
-    repeat-y;
+  background:
+    repeating-linear-gradient(0deg, transparent 0 1px, #f1f1ed 1px 2px), #fafaf8;
 }
 .paint-scrollbar.horizontal .paint-scroll-track {
-  background: url("/assets/xp/paint/ScrollShaftHorizontal.png") 0 0 / 17px 68px
-    repeat-x;
+  background:
+    repeating-linear-gradient(90deg, transparent 0 1px, #f1f1ed 1px 2px),
+    #fafaf8;
 }
 .paint-scroll-thumb {
   position: absolute;
@@ -615,14 +631,13 @@
   left: 1px;
   width: 15px;
   min-height: 8px;
-  background: url("/assets/xp/paint/ScrollThumbVertical.png") center / 15px 88px;
+  background: linear-gradient(90deg, #f8fbff, #c9daf2 45%, #f8fbff);
 }
 .paint-scrollbar.horizontal .paint-scroll-thumb {
   top: 1px;
   height: 15px;
   min-width: 8px;
-  background: url("/assets/xp/paint/ScrollThumbHorizontal.png") center / 22px
-    60px;
+  background: linear-gradient(180deg, #f8fbff, #c9daf2 45%, #f8fbff);
 }
 .paint-scroll-corner {
   position: absolute;

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -663,6 +663,11 @@ test("Paint mounts natively and owns supported picture file associations", async
   expect(paintWindow.querySelector(".paint-toolbox")).not.toBeNull();
   expect(paintWindow.querySelector("canvas.paint-canvas")).not.toBeNull();
   expect(paintWindow.querySelectorAll(".paint-scrollbar")).toHaveLength(2);
+  expect(
+    paintWindow.querySelector<HTMLButtonElement>(".paint-tool.selected")!
+      .dataset.tool,
+  ).toBe("rect-select");
+  expect(paintWindow.querySelectorAll(".paint-status span")).toHaveLength(3);
   expect(paintWindow.classList.contains("xp-native-paint-window")).toBeTrue();
   expect(paintWindow.style.width).toBe("760px");
   expect(paintWindow.style.height).toBe("560px");
@@ -684,6 +689,26 @@ test("Paint mounts natively and owns supported picture file associations", async
   expect(
     paintWindow.querySelector('[data-paint-command="wallpaper-tiled"]'),
   ).not.toBeNull();
+  paintWindow
+    .querySelector<HTMLButtonElement>('[data-paint-command="open"]')!
+    .click();
+  await flushShell();
+  const openDialog = shell.document.querySelector<HTMLElement>(
+    '.xp-dialog[aria-label="Open"]',
+  )!;
+  expect(
+    [...openDialog.querySelectorAll<HTMLElement>(".dlg-file-item")].some(
+      (item) => item.textContent?.trim().endsWith("sample.png"),
+    ),
+  ).toBeTrue();
+  openDialog
+    .querySelectorAll<HTMLButtonElement>(".dlg-buttons button")[1]
+    .click();
+  menuButton("File").click();
+  paintWindow
+    .querySelector<HTMLButtonElement>('[data-paint-command="new"]')!
+    .click();
+  await flushShell();
 
   menuButton("Colors").click();
   paintWindow
@@ -692,6 +717,7 @@ test("Paint mounts natively and owns supported picture file associations", async
   const editColors = shell.document.querySelector<HTMLElement>(
     ".paint-edit-colors-dialog",
   )!;
+  expect(editColors.querySelector(".help-btn")).not.toBeNull();
   expect(
     editColors.querySelectorAll(".paint-edit-color-grid button"),
   ).toHaveLength(48);


### PR DESCRIPTION
## Summary
- fix Paint scrollbar visibility and rendering against the XP VM
- align toolbox, canvas, palette, status bar, menus, and utility dialogs
- restore the native default selection tool and About Paint assets
- fix Paint image filtering so saved BMPs reopen from My Pictures

## Verification
- compared restored, maximized, overflow, File menu, Edit Colors, and About Paint states in the in-app browser against XP VM captures
- exercised all 16 Paint tools in the browser
- saved and reopened a BMP through the real Paint file dialogs
- `bun run test` (90 passed)
- `bun run quality`
- `bun run verify:xp-assets`
- `bun run build`