### PR TITLE
Cancel stale Pages workflow runs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pages-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

- add workflow-level concurrency keyed by pull request number or branch ref
- cancel the entire older run when a newer commit targets the same PR or branch
- retain independent CI runs for different pull requests

## Why

The previous concurrency setting applied only to the final Pages deployment job. Older builds and Worker deployments continued after newer commits or main merges made them stale.

## Validation

- parsed pages.yml as YAML
- bun run quality
- git diff --check