### PR TITLE
Fix XP cursor asset path

### DIFF
--- a/site/css/main.css
+++ b/site/css/main.css
@@ -176,7 +176,7 @@
     rgb(15, 97, 203) 88%
   );
   --chrome-font: "Tahoma", "Segoe UI", "Geneva", sans-serif;
-  --xp-cursor: url("../assets/xp/cursor.cur"), default;
+  --xp-cursor: url("/assets/xp/cursor.cur"), default;
 }
 
 * {


### PR DESCRIPTION
## What changed

- make the shared XP cursor URL root-relative
- preserve production content hashing while preventing consumers in nested stylesheets from resolving the cursor under `/css/assets/`

## Root cause

CSS custom-property URL tokens were resolved from consuming stylesheets such as taskbar and desktop CSS, producing a nonexistent `/css/assets/xp/cursor...cur` request.

## Validation

- `bun test tests/shell-behavior.test.ts` — 22 passed
- `bun run quality`
- `bun run build`
- verified the hashed cursor exists in the production artifact
- verified body, taskbar, Start, desktop icons, and login controls compute `/assets/xp/cursor...cur`
- browser console has no cursor warnings or errors