### PR TITLE
Fix Solitaire gameplay and layout

### DIFF
--- a/site/apps/solitaire/index.js
+++ b/site/apps/solitaire/index.js
@@ -503,6 +503,15 @@ const mountSolitaire = (context) => {
     render();
     return true;
   };
+  const renderSelection = () => {
+    const source = selected ? JSON.stringify(selected) : null;
+    for (const card of board.querySelectorAll("[data-solitaire-source]")) {
+      card.classList.toggle(
+        "selected",
+        source !== null && card.dataset.solitaireSource === source,
+      );
+    }
+  };
   const chooseOrMove = (source, destination = null) => {
     if (
       selected &&
@@ -512,7 +521,7 @@ const mountSolitaire = (context) => {
       return;
     }
     selected = source;
-    render();
+    renderSelection();
   };
 
   const playWinAnimation = () => {
@@ -708,7 +717,7 @@ const mountSolitaire = (context) => {
       commands.undo();
     } else if (event.key === "Escape" && selected) {
       selected = null;
-      render();
+      renderSelection();
     }
   });
 

--- a/site/css/apps/solitaire.css
+++ b/site/css/apps/solitaire.css
@@ -147,10 +147,6 @@ button.solitaire-pile {
   grid-column: 2;
 }
 
-.solitaire-foundation:nth-of-type(4) {
-  grid-column: 4;
-}
-
 .solitaire-card {
   position: absolute;
   top: 0;

--- a/tests/solitaire.test.ts
+++ b/tests/solitaire.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck -- the browser game model is intentionally authored as native JavaScript.
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   canPlaceOnFoundation,
@@ -7,6 +7,9 @@ import {
   createDeck,
   createSolitaireGame,
 } from "../site/apps/solitaire/model.js";
+import { cleanupShells, loadShell, login } from "./helpers/shell-harness";
+
+afterEach(cleanupShells);
 
 const card = (rank: number, suit: string, faceUp = true) => ({
   id: 1,
@@ -112,5 +115,64 @@ describe("Windows XP Solitaire rules", () => {
         { type: "foundation", suit: "hearts" },
       ),
     ).toBeFalse();
+  });
+});
+
+describe("Windows XP Solitaire shell integration", () => {
+  const launchSolitaire = (shell) => {
+    shell.document.getElementById("start-button").click();
+    shell.document.getElementById("all-programs-button").click();
+    const flyouts = shell.document.getElementById("start-menu-flyouts");
+    flyouts.querySelector('[data-program-id="games"]').click();
+    flyouts.querySelector('[data-program-id="solitaire"]').click();
+    return shell.document.querySelector('.xp-window[data-game="__solitaire"]');
+  };
+
+  test("auto-moves a card after the browser double-click sequence", async () => {
+    const shell = await login(await loadShell());
+    const originalRandom = Math.random;
+    let solitaireWindow;
+    try {
+      Math.random = () => 0;
+      solitaireWindow = launchSolitaire(shell);
+    } finally {
+      Math.random = originalRandom;
+    }
+
+    const ace = solitaireWindow.querySelector('[aria-label="Ace of clubs"]');
+    expect(ace).not.toBeNull();
+    ace.click();
+    ace.click();
+    ace.dispatchEvent(
+      new shell.window.MouseEvent("dblclick", { bubbles: true }),
+    );
+
+    expect(
+      solitaireWindow.querySelector(
+        '.solitaire-foundation[data-suit="clubs"] [aria-label="Ace of clubs"]',
+      ),
+    ).not.toBeNull();
+  });
+
+  test("persists options after close and reopen", async () => {
+    const shell = await login(await loadShell());
+    let solitaireWindow = launchSolitaire(shell);
+    solitaireWindow.querySelector(".solitaire-menu-trigger").click();
+    solitaireWindow.querySelector('[data-solitaire-command="options"]').click();
+    const options = shell.document.querySelector(".solitaire-options-dialog");
+    options.querySelector('input[name="solitaire-draw"][value="1"]').click();
+    options.querySelector('[data-option="timed"]').click();
+    options.querySelector('[data-action="ok"]').click();
+
+    solitaireWindow.querySelector(".close-btn").click();
+    expect(solitaireWindow.isConnected).toBeFalse();
+    solitaireWindow = launchSolitaire(shell);
+    solitaireWindow.querySelector(".solitaire-menu-trigger").click();
+    solitaireWindow.querySelector('[data-solitaire-command="options"]').click();
+    const reopened = shell.document.querySelector(".solitaire-options-dialog");
+    expect(
+      reopened.querySelector('input[name="solitaire-draw"][value="1"]').checked,
+    ).toBeTrue();
+    expect(reopened.querySelector('[data-option="timed"]').checked).toBeFalse();
   });
 });


### PR DESCRIPTION
## Summary

- keep the selected card element mounted so browser double-click events can reach Solitaire's auto-move handler
- remove the incorrect foundation grid override that wrapped three suit piles into a second row
- add shell-level behavioral coverage for double-click auto-move and persisted options after close/reopen

## Root cause

Selecting a card rendered the complete board again. During a browser double-click, the first click removed the original card element, so the final `dblclick` event never reached the handler.

The foundation rule used `:nth-of-type(4)`, but the mixed top-row element types made it select the second foundation. It forced that pile into an occupied grid column and moved the remaining piles to an implicit second row.

## User impact

Solitaire now supports normal single-click moves and double-click foundation moves. All four foundation piles remain aligned across the top row. Options persist when the window closes and reopens.

## Verification

- In-app browser: launch, F2 deal, legal tableau move, draw-one option, double-click Ace to foundation, close, reopen, and option persistence
- Browser console: no warnings or errors
- `bun test tests/solitaire.test.ts tests/shell-behavior.test.ts` (26 passed)
- `bun run test` (101 passed)
- `bun run quality`
- `bun run build`

## XP parity notes

- A fresh live-VM comparison was not possible because the configured XP QCOW2 disk was locked by another QEMU process, and its window was not available to the app-control interface.
- Existing browser-native drag behavior and the approximate win animation still differ from exact XP animation behavior. This change does not expand that scope.
