### PR TITLE
Default Pinball music to off

### DIFF
--- a/native/pinball/SpaceCadetPinball/options.cpp
+++ b/native/pinball/SpaceCadetPinball/options.cpp
@@ -65,7 +65,7 @@ void options::init()
 	}
 
 	Options.Sounds = 1;
-	Options.Music = 1;
+	Options.Music = 0;
 	Options.FullScreen = 0;
 	Options.LeftFlipperKeyDft = SDLK_z;
 	Options.RightFlipperKeyDft = SDLK_SLASH;


### PR DESCRIPTION
## Summary

- default the XP Pinball Music option to disabled for new profiles
- rebuild the shipped WebAssembly runtime with the updated native default
- keep Sound enabled by default and preserve stored Music preferences

## Why

Windows XP 3D Pinball starts with Music disabled. The native port initialized the fallback Music value to enabled, so first-time users did not get the XP default.

The existing `get_int("Music", Options.Music)` load path remains unchanged. A user’s saved Music choice still overrides the fallback on later launches.

## Validation

- `bun run quality`
- `bun test tests/pinball.test.ts` — 3 tests pass
- `bun run build:pinball-runtime`
- `bun run build`
