### PR TITLE
Fix BoxedWine production runtime cache mismatch

### DIFF
--- a/site/js/offline-worker.js
+++ b/site/js/offline-worker.js
@@ -229,7 +229,12 @@
     event.respondWith(
       caches.open(BUNDLED_GAME_CACHE).then(async (cache) => {
         const cached = await cache.match(event.request, { ignoreSearch: true });
-        return cached || fetch(event.request);
+        try {
+          return await fetch(event.request);
+        } catch (error) {
+          if (cached) return cached;
+          throw error;
+        }
       }),
     );
   });

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -116,6 +116,14 @@ async function makeSource(root: string): Promise<void> {
     "vendor/js-dos/js-dos.js": "js-dos",
     "vendor/js-dos/emulators/wdosbox.wasm": "wasm",
     "vendor/webtorrent/webtorrent.min.js": "webtorrent",
+    "vendor/boxedwine/26R1/boxedwine-shell.js": "boxedwine shell",
+    "vendor/boxedwine/26R1/boxedwine.js":
+      "return locateFile('boxedwine.wasm');",
+    "vendor/boxedwine/26R1/boxedwine.wasm": "boxedwine wasm",
+    "vendor/boxedwine/26R1/index.html": [
+      '<script src="boxedwine-shell.js"></script>',
+      '<script async src="boxedwine.js"></script>',
+    ].join("\n"),
     "swf/bike-mania/main.swf": "swf",
     "iframe/doom/index.html": "doom ../../dos/doom/doom.jsdos",
     "iframe/inside-the-firewall/index.html": "firewall",
@@ -265,6 +273,34 @@ describe("build metadata", () => {
     expect(capture).toContain(`${hashedAssets.gamesJs}"`);
     expect(capture).toContain(`${hashedAssets.flashUrlRouterJs}"`);
     const manifest = JSON.parse(await readFile(paths.offlineGamesJson, "utf8"));
+    const boxedWineIndex = await readFile(
+      join(root, "vendor", "boxedwine", "26R1", "index.html"),
+      "utf8",
+    );
+    const boxedWineJavaScript = boxedWineIndex.match(
+      /boxedwine\.[a-f0-9]{8}\.js/,
+    )?.[0];
+    const boxedWineShell = boxedWineIndex.match(
+      /boxedwine-shell\.[a-f0-9]{8}\.js/,
+    )?.[0];
+    expect(boxedWineJavaScript).toBeDefined();
+    expect(boxedWineShell).toBeDefined();
+    expect(
+      await Bun.file(
+        join(root, "vendor", "boxedwine", "26R1", boxedWineJavaScript!),
+      ).exists(),
+    ).toBeTrue();
+    expect(
+      await Bun.file(
+        join(root, "vendor", "boxedwine", "26R1", boxedWineShell!),
+      ).exists(),
+    ).toBeTrue();
+    expect(
+      await readFile(
+        join(root, "vendor", "boxedwine", "26R1", boxedWineJavaScript!),
+        "utf8",
+      ),
+    ).toMatch(/locateFile\('boxedwine\.[a-f0-9]{8}\.wasm'\)/);
     for (const gameId of [
       "pink-panther-hokus-pokus",
       "pink-panther-passport-to-peril",
@@ -324,6 +360,10 @@ describe("build metadata", () => {
     expect(manifest.runtime.files.length).toBeGreaterThan(0);
     expect(metadata.bundledGameBytes).toBe(
       manifest.runtime.bytes +
+        Object.values(manifest.runtimes).reduce(
+          (total: number, runtime: any) => total + runtime.bytes,
+          0,
+        ) +
         Object.values(manifest.games).reduce(
           (total: number, game: any) => total + game.bytes,
           0,

--- a/tests/offline-worker.test.ts
+++ b/tests/offline-worker.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import { afterEach, expect, test } from "bun:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const workerPath = require.resolve("../site/js/offline-worker.js");
+const originalSelf = globalThis.self;
+const originalCaches = globalThis.caches;
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.self = originalSelf;
+  globalThis.caches = originalCaches;
+  globalThis.fetch = originalFetch;
+  delete require.cache[workerPath];
+});
+
+test("optional runtime assets prefer the network and fall back offline", async () => {
+  const listeners = new Map();
+  globalThis.self = {
+    location: { origin: "https://flash.example" },
+    addEventListener(type, listener) {
+      listeners.set(type, listener);
+    },
+  };
+  const stale = new Response("stale runtime");
+  globalThis.caches = {
+    open: async () => ({ match: async () => stale.clone() }),
+  };
+  globalThis.fetch = async () => new Response("current runtime");
+  require(workerPath);
+
+  const request = new Request(
+    "https://flash.example/vendor/boxedwine/26R1/boxedwine.12345678.wasm",
+  );
+  let responsePromise;
+  listeners.get("fetch")({
+    request,
+    respondWith(promise) {
+      responsePromise = promise;
+    },
+  });
+  expect(await (await responsePromise).text()).toBe("current runtime");
+
+  globalThis.fetch = async () => {
+    throw new TypeError("offline");
+  };
+  listeners.get("fetch")({
+    request,
+    respondWith(promise) {
+      responsePromise = promise;
+    },
+  });
+  expect(await (await responsePromise).text()).toBe("stale runtime");
+});

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -502,6 +502,44 @@ export async function updateHtml(
     }
     await writeFile(paths.captureHtml, capture);
   }
+
+  const boxedWineRoot = join(paths.root, "vendor", "boxedwine", "26R1");
+  if (await isDirectory(boxedWineRoot)) {
+    const wasmPath = join(boxedWineRoot, "boxedwine.wasm");
+    const javaScriptPath = join(boxedWineRoot, "boxedwine.js");
+    const shellPath = join(boxedWineRoot, "boxedwine-shell.js");
+    const indexPath = join(boxedWineRoot, "index.html");
+    const wasmName = `boxedwine.${await getShortHash(wasmPath)}.wasm`;
+    let javaScript = await readFile(javaScriptPath, "utf8");
+    javaScript = await replaceExactlyOnce(
+      javaScript,
+      /locateFile\((['"])boxedwine\.wasm\1\)/g,
+      `locateFile('${wasmName}')`,
+      "Could not version the BoxedWine WebAssembly reference",
+    );
+    await writeFile(javaScriptPath, javaScript);
+    const javaScriptName = `boxedwine.${await getShortHash(javaScriptPath)}.js`;
+    const shellName = `boxedwine-shell.${await getShortHash(shellPath)}.js`;
+    let boxedWineIndex = await readFile(indexPath, "utf8");
+    boxedWineIndex = await replaceExactlyOnce(
+      boxedWineIndex,
+      /boxedwine-shell\.js"/g,
+      `${shellName}"`,
+      "Could not version the BoxedWine shell reference",
+    );
+    boxedWineIndex = await replaceExactlyOnce(
+      boxedWineIndex,
+      /boxedwine\.js"/g,
+      `${javaScriptName}"`,
+      "Could not version the BoxedWine JavaScript reference",
+    );
+    await writeFile(indexPath, boxedWineIndex);
+    await Promise.all([
+      rename(wasmPath, join(boxedWineRoot, wasmName)),
+      rename(javaScriptPath, join(boxedWineRoot, javaScriptName)),
+      rename(shellPath, join(boxedWineRoot, shellName)),
+    ]);
+  }
   console.log(`  - Set deployment version to ${version}`);
   return hashedAssets;
 }


### PR DESCRIPTION
## Summary

- Content-hash the BoxedWine shell JavaScript, generated JavaScript, and WASM as one production runtime set.
- Make optional runtime requests prefer the current network response and use the cache only when offline.
- Prevent an old optional/offline cache entry from pairing incompatible BoxedWine JavaScript and WASM.

## Production failure and browser verification

- Production before, Solitaire not selected for offline use: startup failed with `WebAssembly.instantiate(): Import " + '"env" "__syscall_setsockopt"' + ": function import requires a callable`.
- Production before, Solitaire selected for offline use: the offline download fetched a revisioned, consistent runtime set, so startup worked.
- Fixed production build, Solitaire not selected for offline use: Solitaire started from Start > All Programs > Games with no console errors.
- Fixed production build, normal window: the native 586x438 BoxedWine logical screen displayed at 1:1 pixels with no letterboxing or second title bar.
- Fixed production build, maximize: the native green client area expanded across the full 1280x720 browser desktop work area; cards stayed at native pixels.
- Fixed production build, restore: the shell returned to the prior normal bounds and Solitaire reflowed back with no console errors.
- Artifact check: `index.html` loads `boxedwine-shell.fce89eb7.js` and `boxedwine.51944006.js`; that JavaScript loads `boxedwine.b1b5ad07.wasm`. The stable executable filenames are absent from the production artifact.

## XP VM comparison retained from #117

- XP VM: resize keeps 71x96 card faces at native pixels, moves the seven tableau columns, and expands the green playfield. Maximize fills the desktop work area. Restore returns to the previous normal bounds.
- Browser: the 655x506 normal shell, maximized work area, 645x495 smaller shell, restore, and repeated resize follow the same layout behavior. Stock clicks and tableau drag/drop stay at 1:1 pointer coordinates.

## Tests and checks

- `bun run test` — 101 pass, 0 fail, 2052 assertions; includes network-first/cache-fallback behavior and BoxedWine asset-set hashing.
- `bun run quality` — Prettier and ESLint pass.
- `bun run build` — production artifact validation passes.

## BoxedWine limitation

BoxedWine 26R1 still has no host-window-manager bridge that sends browser resize events to a Wine top-level window. The resize integration from #117 uses a guest launcher that polls at up to 50 ms and calls Win32 `SetWindowPos`. This PR does not change that workaround. It makes sure production always loads a compatible JavaScript/WASM runtime set before that integration starts.
