### PR TITLE
Version the BoxedWine runner page

### DIFF
--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -124,6 +124,8 @@ async function makeSource(root: string): Promise<void> {
       '<script src="boxedwine-shell.js"></script>',
       '<script async src="boxedwine.js"></script>',
     ].join("\n"),
+    "apps/core/boxedwine.js":
+      "new URL(`${RUNTIME_ROOT}index.html`, document.baseURI);",
     "swf/bike-mania/main.swf": "swf",
     "iframe/doom/index.html": "doom ../../dos/doom/doom.jsdos",
     "iframe/inside-the-firewall/index.html": "firewall",
@@ -274,13 +276,21 @@ describe("build metadata", () => {
     expect(capture).toContain(`${hashedAssets.flashUrlRouterJs}"`);
     const manifest = JSON.parse(await readFile(paths.offlineGamesJson, "utf8"));
     const boxedWineIndex = await readFile(
-      join(root, "vendor", "boxedwine", "26R1", "index.html"),
+      join(root, "apps", "core", "boxedwine.js"),
       "utf8",
     );
-    const boxedWineJavaScript = boxedWineIndex.match(
+    const boxedWineRunner = boxedWineIndex.match(
+      /index\.[a-f0-9]{8}\.html/,
+    )?.[0];
+    expect(boxedWineRunner).toBeDefined();
+    const boxedWineRunnerMarkup = await readFile(
+      join(root, "vendor", "boxedwine", "26R1", boxedWineRunner!),
+      "utf8",
+    );
+    const boxedWineJavaScript = boxedWineRunnerMarkup.match(
       /boxedwine\.[a-f0-9]{8}\.js/,
     )?.[0];
-    const boxedWineShell = boxedWineIndex.match(
+    const boxedWineShell = boxedWineRunnerMarkup.match(
       /boxedwine-shell\.[a-f0-9]{8}\.js/,
     )?.[0];
     expect(boxedWineJavaScript).toBeDefined();

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -534,7 +534,18 @@ export async function updateHtml(
       "Could not version the BoxedWine JavaScript reference",
     );
     await writeFile(indexPath, boxedWineIndex);
+    const indexName = `index.${await getShortHash(indexPath)}.html`;
+    const integrationPath = join(paths.root, "apps", "core", "boxedwine.js");
+    let integration = await readFile(integrationPath, "utf8");
+    integration = await replaceExactlyOnce(
+      integration,
+      /`\$\{RUNTIME_ROOT\}index\.html`/g,
+      `\`\${RUNTIME_ROOT}${indexName}\``,
+      "Could not version the BoxedWine runner reference",
+    );
+    await writeFile(integrationPath, integration);
     await Promise.all([
+      rename(indexPath, join(boxedWineRoot, indexName)),
       rename(wasmPath, join(boxedWineRoot, wasmName)),
       rename(javaScriptPath, join(boxedWineRoot, javaScriptName)),
       rename(shellPath, join(boxedWineRoot, shellName)),


### PR DESCRIPTION
## Summary

- Content-hash the BoxedWine runner HTML page.
- Rewrite the Solitaire integration to open that unique runner URL.
- Prevent an old service worker from serving cached runner markup that requests removed stable runtime filenames.

## Production verification

- After #118 deployed, direct requests confirmed the new hashed JavaScript and WASM existed and returned HTTP 200.
- A browser profile controlled by the previous worker still served cached `index.html`, which requested removed `boxedwine.js` and `boxedwine.wasm` and failed at `Downloading...`.
- The fixed artifact now points `apps/core/boxedwine.js` to `index.c296ff67.html`; the stable runner page is absent. The runner points only to the matching content-hashed BoxedWine shell, JavaScript, and WASM.

## Checks

- `bun test tests/deploy.test.ts tests/solitaire.test.ts` — 20 pass, 0 fail, 158 assertions.
- `bun run typecheck`
- `bun run quality`
- `bun run build`
