### PR TITLE
Fix Solitaire layout on mobile

### DIFF
--- a/site/apps/solitaire/index.js
+++ b/site/apps/solitaire/index.js
@@ -24,6 +24,7 @@ export const solitaireApplication = defineApplication({
     width: 592,
     height: 438,
     className: "xp-native-solitaire-window",
+    fitToWorkArea: true,
     resizable: true,
     maximizable: true,
   },

--- a/site/js/apps/programs.js
+++ b/site/js/apps/programs.js
@@ -122,6 +122,7 @@ const openXPProgram = (programId, options = {}) => {
   el.querySelector(".window-content").replaceWith(mounted.element);
   document.getElementById("desktop").appendChild(el);
   openWindows.set(programId, win);
+  fitNativeProgramToWorkArea(win);
   if (program.window.maximizable === false) {
     const maximize = el.querySelector(".maximize-btn");
     if (maximize) {

--- a/site/js/shell/bootstrap.js
+++ b/site/js/shell/bootstrap.js
@@ -187,6 +187,10 @@ window.addEventListener("resize", () => {
   }
 });
 
+window.visualViewport?.addEventListener("resize", () => {
+  window.dispatchEvent(new Event("resize"));
+});
+
 window.addEventListener("hashchange", () => {
   if (!loggedIn) return;
 

--- a/site/js/shell/window-manager.js
+++ b/site/js/shell/window-manager.js
@@ -84,12 +84,48 @@ const clampWindowPosition = (win, left, top) => {
   };
 };
 
+const fitNativeProgramToWorkArea = (win) => {
+  const preferred = win.application?.window;
+  if (!preferred?.fitToWorkArea || win.maximized) return false;
+
+  const { width: desktopWidth, height: desktopHeight } = getDesktopSize();
+  const viewport = window.visualViewport;
+  const taskbarHeight = document
+    .getElementById("taskbar")
+    ?.getBoundingClientRect().height;
+  const visibleWidth = viewport?.width
+    ? Math.min(desktopWidth, Math.floor(viewport.width))
+    : desktopWidth;
+  const visibleHeight = viewport?.height
+    ? Math.min(
+        desktopHeight,
+        Math.max(0, Math.floor(viewport.height - (taskbarHeight || 0)),
+      ),
+    )
+    : desktopHeight;
+  if (
+    visibleWidth <= 0 ||
+    visibleHeight <= 0 ||
+    (visibleWidth >= preferred.width && visibleHeight >= preferred.height)
+  )
+    return false;
+
+  Object.assign(win.el.style, {
+    left: "0px",
+    top: "0px",
+    width: `${visibleWidth}px`,
+    height: `${visibleHeight}px`,
+  });
+  return true;
+};
+
 const keepWindowsInWorkArea = () => {
   const { width: desktopWidth, height: desktopHeight } = getDesktopSize();
   if (desktopWidth === 0 || desktopHeight === 0) return;
 
   openWindows.forEach((win) => {
     if (win.maximized) return;
+    if (fitNativeProgramToWorkArea(win)) return;
     const el = win.el;
     el.style.width = `${Math.min(el.offsetWidth, desktopWidth)}px`;
     el.style.height = `${Math.min(el.offsetHeight, desktopHeight)}px`;
@@ -864,6 +900,7 @@ const toggleMaximize = (gameId) => {
       win.el.style.top = `${position.top}px`;
     }
     win.maximized = false;
+    fitNativeProgramToWorkArea(win);
   }
   updateMaximizeButton(win);
   focusWindow(gameId);

--- a/site/js/shell/window-manager.js
+++ b/site/js/shell/window-manager.js
@@ -99,9 +99,8 @@ const fitNativeProgramToWorkArea = (win) => {
   const visibleHeight = viewport?.height
     ? Math.min(
         desktopHeight,
-        Math.max(0, Math.floor(viewport.height - (taskbarHeight || 0)),
-      ),
-    )
+        Math.max(0, Math.floor(viewport.height - (taskbarHeight || 0))),
+      )
     : desktopHeight;
   if (
     visibleWidth <= 0 ||

--- a/tests/solitaire.test.ts
+++ b/tests/solitaire.test.ts
@@ -40,6 +40,33 @@ const launchSolitaire = (shell) => {
 };
 
 describe("Windows XP Solitaire through BoxedWine", () => {
+  test("uses the complete phone work area when its native bounds do not fit", async () => {
+    const shell = await login(await loadShell());
+    const desktop = shell.document.getElementById("desktop");
+    Object.defineProperties(desktop, {
+      clientWidth: { configurable: true, value: 390 },
+      clientHeight: { configurable: true, value: 814 },
+    });
+
+    const solitaireWindow = launchSolitaire(shell);
+
+    expect(solitaireWindow.style.left).toBe("0px");
+    expect(solitaireWindow.style.top).toBe("0px");
+    expect(solitaireWindow.style.width).toBe("390px");
+    expect(solitaireWindow.style.height).toBe("814px");
+
+    Object.defineProperties(desktop, {
+      clientWidth: { configurable: true, value: 844 },
+      clientHeight: { configurable: true, value: 360 },
+    });
+    shell.window.dispatchEvent(new shell.window.Event("resize"));
+
+    expect(solitaireWindow.style.left).toBe("0px");
+    expect(solitaireWindow.style.top).toBe("0px");
+    expect(solitaireWindow.style.width).toBe("844px");
+    expect(solitaireWindow.style.height).toBe("360px");
+  });
+
   test("launches the native executable in a resizable XP shell window", async () => {
     const shell = await login(await loadShell());
     shell.window.ASTRO_GAME_ROOTS = {
@@ -100,8 +127,12 @@ describe("Windows XP Solitaire through BoxedWine", () => {
     expect(frame.src).toBe("about:blank");
   });
 
-  test("resizes the emulator framebuffer to the real client area", async () => {
+  test("resizes the emulator framebuffer and pointer space in CSS pixels", async () => {
     const shell = await login(await loadShell());
+    Object.defineProperty(shell.window, "devicePixelRatio", {
+      configurable: true,
+      value: 3,
+    });
     let resize;
     let observed;
     let disconnected = false;


### PR DESCRIPTION
## Summary
- Fit Solitaire to the visible shell work area when its native window cannot fit on a phone viewport.
- Send real CSS-pixel client/framebuffer sizes through the existing BoxedWine resize bridge, without scaling the iframe or canvas.
- Watch visual-viewport size changes and cover portrait and landscape behavior with behavioral tests.

## Root cause
The generic work-area clamp preserved only a reachable title bar. After orientation changes, Solitaire could remain mostly outside the phone work area even though its outer size was reduced.

## Validation
- bun test tests/solitaire.test.ts
- bun run typecheck
- bun run lint
- bun run build

Browser checks: production currently clips after portrait-to-landscape (374x360 window at top 188, bottom 548 in a 360px work area). The built fix is 390x814 in portrait and 844x360 in landscape; iframe clients are 384x783 and 838x329, with no transform scaling. Desktop stays 592x438, maximizes to 1366x738, then restores to 592x438.

## BoxedWine limitation
When the available client area is smaller than Solitaire's native layout, BoxedWine applies the logical client/framebuffer resize. Windows XP Solitaire keeps native-pixel cards and does not provide a responsive card-layout mode, so a very small client area can still contain game content that does not reflow.