### PR TITLE
Fix offline cache coverage

### DIFF
--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -450,13 +450,18 @@
       ).href;
 
     const cacheEntry = async (id, entry, progress) => {
+      const cache = await environment.caches.open(bundledCacheName);
       if (
         records[id]?.revision === entry.revision &&
-        Array.isArray(records[id].files)
+        Array.isArray(records[id].files) &&
+        (
+          await Promise.all(
+            entry.files.map((file) => cache.match(absoluteUrl(file.url))),
+          )
+        ).every(Boolean)
       ) {
         return;
       }
-      const cache = await environment.caches.open(bundledCacheName);
       const previousFiles = records[id]?.files || [];
       const previousUrls = new Set(previousFiles.map(absoluteUrl));
       let loaded = 0;

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -108,6 +108,7 @@ async function makeSource(root: string): Promise<void> {
     "assets/icons/game.png": "icon",
     "assets/icons/SOURCES.json": "{}",
     "assets/xp/bliss.jpg": "wallpaper",
+    "assets/xp/Chess.bmp": "bitmap",
     "assets/xp/about.png": "about",
     "assets/xp/icons/paint.png": "paint",
     "assets/xp/sounds/startup.wav": "sound",
@@ -344,6 +345,7 @@ describe("build metadata", () => {
     expect(await Bun.file(join(root, "css", "main.css")).exists()).toBeFalse();
     expect(PRECACHE_FILE_SUFFIXES.has(".ttf")).toBeTrue();
     expect(PRECACHE_FILE_SUFFIXES.has(".bmp")).toBeTrue();
+    expect(PRECACHE_FILE_SUFFIXES.has(".data")).toBeTrue();
 
     const metadata = JSON.parse(await readFile(paths.versionJson, "utf8"));
     expect(metadata.offlineBytes).toBeGreaterThan(0);
@@ -421,6 +423,21 @@ describe("build metadata", () => {
 });
 
 describe("Workbox and artifact validation", () => {
+  test("precaches bitmap artwork and Pinball data", async () => {
+    const root = await makeTemporaryDirectory();
+    await writeFiles(root, {
+      "js/offline-worker.12345678.js": "offline worker",
+      "assets/xp/Chess.12345678.bmp": "bitmap",
+      "apps/pinball/runtime/SpaceCadetPinball.data": "pinball data",
+    });
+
+    await generateServiceWorker(root);
+
+    const worker = await readFile(join(root, "sw.js"), "utf8");
+    expect(worker).toContain("assets/xp/Chess.12345678.bmp");
+    expect(worker).toContain("apps/pinball/runtime/SpaceCadetPinball.data");
+  });
+
   test("accepts a generated worker with its runtime", async () => {
     const root = await makeTemporaryDirectory();
     await writeFiles(root, {

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -90,6 +90,9 @@ test("offline updates", async () => {
     async put(key, response) {
       this.values.set(String(key), response);
     }
+    async match(key) {
+      return this.values.get(String(key));
+    }
     async delete(key) {
       return this.values.delete(String(key));
     }
@@ -284,6 +287,11 @@ test("offline updates", async () => {
   ]);
   assert.strictEqual(manager.getSnapshot().downloadedGameBytes, 14);
   assert.strictEqual(initial.bundledCache.values.size, 2);
+
+  const bikeUrl = "https://flash.example/swf/bike-mania.bike-1/main.swf";
+  await initial.bundledCache.delete(bikeUrl);
+  await manager.downloadGame("bike-mania");
+  assert.strictEqual(initial.bundledCache.values.has(bikeUrl), true);
 
   await manager.downloadGame("doom");
   assert.strictEqual(manager.getSnapshot().downloadedGameIds.length, 2);

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -22,7 +22,7 @@ import {
 import { fileURLToPath } from "node:url";
 
 import { generateSW } from "workbox-build";
-import workboxConfig from "../workbox-config";
+import workboxConfig, { PRECACHE_EXTENSIONS } from "../workbox-config";
 
 const PROJECT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 export const SOURCE_DIR = join(PROJECT_DIR, "site");
@@ -47,30 +47,9 @@ const JS_DOS_RUNTIME_FILES = [
   "emulators/wlibzip.js",
   "emulators/wlibzip.wasm",
 ];
-export const PRECACHE_FILE_SUFFIXES = new Set([
-  ".ttf",
-  ".woff",
-  ".woff2",
-  ".css",
-  ".ico",
-  ".svg",
-  ".bmp",
-  ".mp3",
-  ".wav",
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".cur",
-  ".json",
-  ".html",
-  ".js",
-  ".mjs",
-  ".wasm",
-  ".swf",
-  ".jsdos",
-  ".xml",
-  ".phtml",
-]);
+export const PRECACHE_FILE_SUFFIXES = new Set(
+  PRECACHE_EXTENSIONS.map((extension) => `.${extension}`),
+);
 const APP_VERSION_PATTERN = /const APP_VERSION = "[^"]+";/g;
 
 type WorkboxGenerator = typeof generateSW;

--- a/workbox-config.ts
+++ b/workbox-config.ts
@@ -2,11 +2,35 @@ import { join, resolve } from "node:path";
 
 const outputDirectory = resolve(process.env.SITE_OUTPUT_DIR || "dist");
 
+export const PRECACHE_EXTENSIONS = [
+  "ttf",
+  "woff",
+  "woff2",
+  "css",
+  "ico",
+  "svg",
+  "bmp",
+  "mp3",
+  "wav",
+  "png",
+  "jpg",
+  "jpeg",
+  "cur",
+  "json",
+  "html",
+  "js",
+  "mjs",
+  "wasm",
+  "data",
+  "swf",
+  "jsdos",
+  "xml",
+  "phtml",
+] as const;
+
 export default {
   globDirectory: `${outputDirectory}/`,
-  globPatterns: [
-    "**/*.{ttf,woff,woff2,css,ico,svg,mp3,wav,png,jpg,jpeg,cur,json,html,js,mjs,wasm,swf,jsdos,xml,phtml}",
-  ],
+  globPatterns: [`**/*.{${PRECACHE_EXTENSIONS.join(",")}}`],
   globIgnores: [
     "version.json",
     "swf/**",


### PR DESCRIPTION
## Summary

- precache BMP artwork and the Pinball data bundle
- use one shared extension list for Workbox and offline-size metadata
- verify optional game files still exist in Cache Storage before skipping downloads
- add regression coverage for generated precache entries and evicted game files

## Root cause

The Workbox glob omitted `.bmp` and `.data`, while the offline-size calculation maintained a separate extension list. Optional download records also trusted local storage without checking whether Cache Storage still contained every response.

## Impact

Windows XP bitmap artwork and Pinball now work after a complete offline load. Games with evicted or manually cleared cache entries download their missing files again.

## Validation

- `bun test tests/deploy.test.ts tests/offline.test.ts tests/offline-worker.test.ts`
- `bun run typecheck`
- ESLint on all changed files
- production build and generated `sw.js` inspection