### PR TITLE
Harden offline update recovery

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -9,6 +9,8 @@
     />
     <meta name="theme-color" content="#245EDC" />
     <meta name="application-name" content="Astro Flash Collection" />
+    <meta name="astro-version" content="development" />
+    <script src="js/startup-recovery.js"></script>
     <link rel="canonical" href="https://flash.4st.li/" />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <meta property="og:type" content="website" />

--- a/site/js/shell/bootstrap.js
+++ b/site/js/shell/bootstrap.js
@@ -160,11 +160,14 @@ document.addEventListener(
   true,
 );
 
-gameLibraryInitialization = initializeGameLibrary();
+const gameLibraryStartup = initializeGameLibrary();
+gameLibraryInitialization = Promise.race([
+  gameLibraryStartup,
+  new Promise((resolve) => setTimeout(resolve, 5000)),
+]);
 
-window.addEventListener("load", async () => {
+document.addEventListener("DOMContentLoaded", () => {
   initializeOfflineMode();
-  await gameLibraryInitialization;
   setupScreenFlow();
   setupDesktopContextMenu();
   setupWindowSystemMenu();
@@ -173,6 +176,7 @@ window.addEventListener("load", async () => {
   document
     .getElementById("start-button")
     .addEventListener("click", toggleStartMenu);
+  window.__ASTRO_STARTUP_READY__?.();
 });
 
 window.addEventListener("resize", () => {

--- a/site/js/startup-recovery.js
+++ b/site/js/startup-recovery.js
@@ -1,0 +1,108 @@
+"use strict";
+
+(function exposeStartupRecovery(root, factory) {
+  const createStartupRecovery = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = { createStartupRecovery };
+  } else {
+    createStartupRecovery(root);
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, () => {
+  const RECOVERY_KEY = "astroFlashStartupRecovery";
+  const RECOVERY_PARAMETER = "__astro_recovery";
+  const SHELL_CACHE_PREFIX = "astro-flash-";
+
+  const createStartupRecovery = (
+    environment,
+    { startupTimeout = 12_000, retryTimeout = 30_000 } = {},
+  ) => {
+    let ready = false;
+    let watchdog;
+
+    const scheduleRecovery = (delay) => {
+      environment.clearTimeout(watchdog);
+      watchdog = environment.setTimeout(recover, delay);
+    };
+
+    const versionFromHtml = (html) => {
+      const document = new environment.DOMParser().parseFromString(
+        html,
+        "text/html",
+      );
+      return document
+        .querySelector('meta[name="astro-version"]')
+        ?.getAttribute("content");
+    };
+
+    const recover = async () => {
+      if (ready || environment.sessionStorage.getItem(RECOVERY_KEY)) return;
+      if (environment.navigator.onLine === false) {
+        scheduleRecovery(retryTimeout);
+        return;
+      }
+
+      try {
+        const nonce = environment.Date.now();
+        const versionResponse = await environment.fetch(
+          `version.json?t=${nonce}`,
+          { cache: "no-store" },
+        );
+        if (!versionResponse.ok) throw new Error("Version check failed");
+        const metadata = await versionResponse.json();
+        if (typeof metadata.version !== "string") {
+          throw new Error("Version metadata is invalid");
+        }
+
+        const recoveryUrl = new environment.URL(environment.location.href);
+        recoveryUrl.searchParams.set(
+          RECOVERY_PARAMETER,
+          `${metadata.version}-${nonce}`,
+        );
+        const htmlResponse = await environment.fetch(recoveryUrl.href, {
+          cache: "no-store",
+        });
+        if (!htmlResponse.ok) throw new Error("Recovery page failed");
+        if (versionFromHtml(await htmlResponse.text()) !== metadata.version) {
+          throw new Error("Recovery page version is inconsistent");
+        }
+
+        const registrations =
+          (await environment.navigator.serviceWorker?.getRegistrations?.()) ||
+          [];
+        await Promise.all(
+          registrations.map((registration) => registration.unregister()),
+        );
+        if (environment.caches) {
+          const names = await environment.caches.keys();
+          await Promise.all(
+            names
+              .filter((name) => name.startsWith(SHELL_CACHE_PREFIX))
+              .map((name) => environment.caches.delete(name)),
+          );
+        }
+        environment.sessionStorage.setItem(RECOVERY_KEY, String(nonce));
+        environment.location.replace(recoveryUrl.href);
+      } catch (error) {
+        environment.console.error("Automatic startup recovery failed:", error);
+        scheduleRecovery(retryTimeout);
+      }
+    };
+
+    const markReady = () => {
+      ready = true;
+      environment.clearTimeout(watchdog);
+      environment.sessionStorage.removeItem(RECOVERY_KEY);
+      const url = new environment.URL(environment.location.href);
+      if (url.searchParams.has(RECOVERY_PARAMETER)) {
+        url.searchParams.delete(RECOVERY_PARAMETER);
+        environment.history.replaceState(null, "", url.href);
+      }
+    };
+
+    environment.__ASTRO_STARTUP_READY__ = markReady;
+    scheduleRecovery(startupTimeout);
+    return { markReady, recover };
+  };
+
+  return createStartupRecovery;
+});

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import {
   mkdir,
   mkdtemp,
@@ -56,6 +57,8 @@ async function writeFiles(
 async function makeSource(root: string): Promise<void> {
   await writeFiles(root, {
     "index.html": [
+      '<meta name="astro-version" content="development" />',
+      '<script src="js/startup-recovery.js"></script>',
       '<script src="js/ruffle.js?v=old"></script>',
       '<script src="vendor/fflate/index.js?v=old"></script>',
       '<script src="js/games.js?v=old"></script>',
@@ -92,6 +95,7 @@ async function makeSource(root: string): Promise<void> {
     "js/dialogs.js": "dialogs",
     "js/offline.js": "offline",
     "js/offline-worker.js": "offline worker",
+    "js/startup-recovery.js": "startup recovery",
     "apps/index.js": "application registry",
     "apps/catalog.js": 'const icon = "assets/xp/icons/paint.png";',
     "js/shell/desktop.js": "desktop shell",
@@ -260,6 +264,14 @@ describe("build metadata", () => {
     const main = await readFile(join(root, hashedAssets.mainJs), "utf8");
     const html = await readFile(paths.html, "utf8");
     expect(main).toContain('const APP_VERSION = "26.07.28-abcdef1";');
+    expect(html).toContain(
+      '<meta name="astro-version" content="26.07.28-abcdef1" />',
+    );
+    expect(html).toContain("startup recovery");
+    expect(html).not.toContain('src="js/startup-recovery.js"');
+    expect(
+      await Bun.file(join(root, "js", "startup-recovery.js")).exists(),
+    ).toBeFalse();
     expect(html).toContain(`${hashedAssets.mainJs}"`);
     expect(html).toContain(`${hashedAssets.flashUrlRouterJs}"`);
     expect(html).toContain(`${hashedAssets.storagePolicyJs}"`);
@@ -436,6 +448,11 @@ describe("Workbox and artifact validation", () => {
     const worker = await readFile(join(root, "sw.js"), "utf8");
     expect(worker).toContain("assets/xp/Chess.12345678.bmp");
     expect(worker).toContain("apps/pinball/runtime/SpaceCadetPinball.data");
+    expect(worker).toContain(
+      `integrity:"sha384-${createHash("sha384")
+        .update("bitmap")
+        .digest("base64")}"`,
+    );
   });
 
   test("accepts a generated worker with its runtime", async () => {

--- a/tests/helpers/shell-harness.ts
+++ b/tests/helpers/shell-harness.ts
@@ -244,7 +244,7 @@ export async function loadShell() {
 
   if (scriptErrors.length) throw scriptErrors[0];
 
-  window.dispatchEvent(new window.Event("load"));
+  document.dispatchEvent(new window.Event("DOMContentLoaded"));
   await flushShell();
   return { window, document, offlineDownloads };
 }

--- a/tests/startup-recovery.test.ts
+++ b/tests/startup-recovery.test.ts
@@ -1,0 +1,138 @@
+// @ts-nocheck
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const recoveryPath = require.resolve("../site/js/startup-recovery.js");
+const { createStartupRecovery } = require(recoveryPath);
+const windows = [];
+
+afterEach(() => {
+  windows.splice(0).forEach((window) => window.close());
+  delete require.cache[recoveryPath];
+});
+
+const makeEnvironment = ({ htmlVersion = "26.08.12-abcdef1" } = {}) => {
+  const window = new Window({ url: "https://flash.example/" });
+  windows.push(window);
+  const values = new Map();
+  const timers = [];
+  const deletedCaches = [];
+  const errors = [];
+  let unregisters = 0;
+  let replacement = null;
+  let historyReplacement = null;
+  const environment = {
+    URL,
+    DOMParser: window.DOMParser,
+    Date: { now: () => 1_800_000_000_000 },
+    caches: {
+      keys: async () => [
+        "astro-flash-precache-v2",
+        "astro-bundled-games-v1",
+        "astro-installed-games-v1",
+      ],
+      delete: async (name) => {
+        deletedCaches.push(name);
+        return true;
+      },
+    },
+    clearTimeout() {},
+    console: { error: (...values) => errors.push(values) },
+    fetch: async (url, options) => {
+      expect(options).toEqual({ cache: "no-store" });
+      if (String(url).startsWith("version.json?")) {
+        return new Response(JSON.stringify({ version: "26.08.12-abcdef1" }));
+      }
+      return new Response(
+        `<meta name="astro-version" content="${htmlVersion}" />`,
+      );
+    },
+    history: {
+      replaceState: (_state, _title, url) => {
+        historyReplacement = url;
+      },
+    },
+    location: {
+      href: "https://flash.example/",
+      replace: (url) => {
+        replacement = url;
+      },
+    },
+    navigator: {
+      onLine: true,
+      serviceWorker: {
+        getRegistrations: async () => [
+          {
+            unregister: async () => {
+              unregisters += 1;
+              return true;
+            },
+          },
+        ],
+      },
+    },
+    sessionStorage: {
+      getItem: (key) => values.get(key) ?? null,
+      removeItem: (key) => values.delete(key),
+      setItem: (key, value) => values.set(key, String(value)),
+    },
+    setTimeout: (callback, delay) => {
+      timers.push({ callback, delay });
+      return timers.length;
+    },
+  };
+  return {
+    deletedCaches,
+    environment,
+    errors,
+    getHistoryReplacement: () => historyReplacement,
+    getReplacement: () => replacement,
+    getUnregisters: () => unregisters,
+    timers,
+    values,
+  };
+};
+
+test("silently reloads a verified release and preserves user game caches", async () => {
+  const recovery = makeEnvironment();
+  createStartupRecovery(recovery.environment);
+
+  expect(recovery.timers[0].delay).toBe(12_000);
+  await recovery.timers[0].callback();
+
+  expect(recovery.getUnregisters()).toBe(1);
+  expect(recovery.deletedCaches).toEqual(["astro-flash-precache-v2"]);
+  expect(recovery.getReplacement()).toContain(
+    "__astro_recovery=26.08.12-abcdef1-1800000000000",
+  );
+  expect(recovery.values.has("astroFlashStartupRecovery")).toBeTrue();
+  expect(recovery.errors).toEqual([]);
+});
+
+test("does not clear caches when the recovery page version is inconsistent", async () => {
+  const recovery = makeEnvironment({ htmlVersion: "stale" });
+  createStartupRecovery(recovery.environment);
+
+  await recovery.timers[0].callback();
+
+  expect(recovery.getUnregisters()).toBe(0);
+  expect(recovery.deletedCaches).toEqual([]);
+  expect(recovery.getReplacement()).toBeNull();
+  expect(recovery.timers[1].delay).toBe(30_000);
+  expect(recovery.errors).toHaveLength(1);
+});
+
+test("a successful startup cancels recovery and cleans its URL", () => {
+  const recovery = makeEnvironment();
+  recovery.environment.location.href =
+    "https://flash.example/?__astro_recovery=old#game";
+  recovery.values.set("astroFlashStartupRecovery", "previous");
+  const manager = createStartupRecovery(recovery.environment);
+
+  manager.markReady();
+
+  expect(recovery.values.has("astroFlashStartupRecovery")).toBeFalse();
+  expect(recovery.getHistoryReplacement()).toBe("https://flash.example/#game");
+});

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -21,7 +21,7 @@ import {
 } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { generateSW } from "workbox-build";
+import { generateSW, type ManifestTransform } from "workbox-build";
 import workboxConfig, { PRECACHE_EXTENSIONS } from "../workbox-config";
 
 const PROJECT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -53,6 +53,33 @@ export const PRECACHE_FILE_SUFFIXES = new Set(
 const APP_VERSION_PATTERN = /const APP_VERSION = "[^"]+";/g;
 
 type WorkboxGenerator = typeof generateSW;
+
+export function createIntegrityManifestTransform(
+  outputDir: string,
+): ManifestTransform {
+  const root = resolve(outputDir);
+  return async (entries) => ({
+    manifest: await Promise.all(
+      entries.map(async (entry) => {
+        const relativeUrl = decodeURIComponent(entry.url.split(/[?#]/, 1)[0])
+          .replace(/^\/+/, "")
+          .split("/")
+          .join(sep);
+        const path = resolve(root, relativeUrl);
+        if (path !== root && !path.startsWith(`${root}${sep}`)) {
+          throw new Error(
+            `Precache entry escapes the build output: ${entry.url}`,
+          );
+        }
+        const integrity = `sha384-${createHash("sha384")
+          .update(await readFile(path))
+          .digest("base64")}`;
+        return { ...entry, integrity };
+      }),
+    ),
+    warnings: [],
+  });
+}
 
 interface OfflineFile {
   bytes: number;
@@ -316,6 +343,24 @@ export async function updateHtml(
     "Could not update APP_VERSION in output js/main.js",
   );
   await writeFile(paths.mainJs, mainJavaScript);
+
+  let html = await readFile(paths.html, "utf8");
+  html = await replaceExactlyOnce(
+    html,
+    /<meta name="astro-version" content="[^"]+" \/>/g,
+    `<meta name="astro-version" content="${version}" />`,
+    "Could not update the deployment version in output index.html",
+  );
+  const startupRecoveryPath = join(paths.js, "startup-recovery.js");
+  const startupRecovery = await readFile(startupRecoveryPath, "utf8");
+  html = await replaceExactlyOnce(
+    html,
+    /<script src="js\/startup-recovery\.js"><\/script>/g,
+    `<script>\n${startupRecovery}\n</script>`,
+    "Could not inline startup recovery in output index.html",
+  );
+  await writeFile(paths.html, html);
+  await rm(startupRecoveryPath);
 
   const staticPaths = [
     ...(await walkFiles(join(paths.root, "assets"))),
@@ -810,6 +855,7 @@ export async function generateServiceWorker(
     ...workboxConfig,
     globDirectory: `${resolve(outputDir)}/`,
     importScripts: [`js/${offlineWorkerNames[0]}`],
+    manifestTransforms: [createIntegrityManifestTransform(outputDir)],
     swDest: join(resolve(outputDir), "sw.js"),
   });
 


### PR DESCRIPTION
## Summary

- add SHA-384 integrity metadata to every Workbox precache entry so a mismatched response rejects the service-worker install
- inline an early startup watchdog that verifies `version.json` against fresh HTML before it clears the shell cache and reloads
- keep installed and bundled game caches during automatic recovery
- stop game-library initialization from holding the Windows boot screen indefinitely

## Validation

- `bun run test` (108 tests)
- `bun run quality`
- `bun run build --output /tmp/astro-flash-pr-build`
- verified 479 integrity values for 479 generated precache entries