### PR TITLE
Complete offline update integrity

### DIFF
--- a/site/js/main.js
+++ b/site/js/main.js
@@ -12,6 +12,7 @@ const WELCOME_DURATION_MS = 1200;
 const APP_VERSION = "26.07.28-2";
 const offlineManager = window.AstroOffline.createManager({
   currentVersion: APP_VERSION,
+  gameManifestUrl: window.ASTRO_OFFLINE_MANIFEST_URL || "offline-games.json",
 });
 const gameDataManager = window.AstroGameData.createManager();
 

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -19,6 +19,7 @@
   const ACTIVE_VERSION_RELOAD_KEY = "astroFlashActiveVersionReload";
   const BUNDLED_GAME_CACHE = "astro-bundled-games-v1";
   const DEFAULT_CHECK_INTERVAL = 60 * 60 * 1000;
+  const UPDATE_RETRY_DELAY = 30 * 1000;
 
   const waitForWorker = (worker) =>
     new Promise((resolve, reject) => {
@@ -62,7 +63,9 @@
       .split("/")
       .some((part) => !part || part === "." || part === "..") &&
     Number.isInteger(file.bytes) &&
-    file.bytes >= 0;
+    file.bytes >= 0 &&
+    typeof file.integrity === "string" &&
+    /^sha384-[A-Za-z0-9+/]+={0,2}$/.test(file.integrity);
 
   const validateManifestEntry = (entry) =>
     entry &&
@@ -134,6 +137,24 @@
     let checkPromise = null;
     let reloadWhenControlled = false;
     let lifecycleListenersAttached = false;
+    let updateRetryTimer = null;
+    let bypassWorkerCdn = false;
+
+    const versionedServiceWorkerUrl = (version) => {
+      const separator = serviceWorkerUrl.includes("?") ? "&" : "?";
+      const versionedUrl = `${serviceWorkerUrl}${separator}v=${encodeURIComponent(version)}`;
+      return bypassWorkerCdn
+        ? `${versionedUrl}&retry=${environment.Date.now()}`
+        : versionedUrl;
+    };
+
+    const scheduleUpdateRetry = () => {
+      if (updateRetryTimer !== null) return;
+      updateRetryTimer = (environment.setTimeout || setTimeout)(() => {
+        updateRetryTimer = null;
+        void checkForUpdates().catch(() => {});
+      }, UPDATE_RETRY_DELAY);
+    };
 
     const requestWorkerVersion = (worker) =>
       new Promise((resolve) => {
@@ -245,15 +266,32 @@
       });
     };
 
-    const markWaitingUpdate = async (worker) => {
+    const markWaitingUpdate = async (worker, knownMetadata = null) => {
       if (!worker) return;
-      let metadata = null;
+      let metadata = knownMetadata;
       try {
-        metadata = await fetchVersion();
+        metadata ||= await fetchVersion();
         rememberVersionMetadata(metadata);
       } catch {
-        // A waiting worker is enough to prove that an update is ready.
+        scheduleUpdateRetry();
+        return false;
       }
+      const workerVersion = await requestWorkerVersion(worker);
+      if (workerVersion !== metadata.version) {
+        bypassWorkerCdn = true;
+        setState({
+          phase: "updating",
+          updateReady: false,
+          workerState: "waiting",
+          availableVersion: metadata.version,
+          availableRevision: metadata.revision,
+          downloadBytes: metadata.offlineBytes,
+          error: null,
+        });
+        scheduleUpdateRetry();
+        return false;
+      }
+      bypassWorkerCdn = false;
       setState({
         phase: "update-ready",
         updateReady: true,
@@ -263,6 +301,7 @@
         downloadBytes: metadata?.offlineBytes || state.downloadBytes,
         error: null,
       });
+      return true;
     };
 
     const reconcileActiveVersion = async (targetVersion) => {
@@ -349,22 +388,22 @@
       }
     };
 
-    const registerAndWait = async () => {
+    const registerAndWait = async (targetVersion) => {
       if (!navigatorObject.serviceWorker) {
         throw new Error(
           "Offline system files are not supported by this browser.",
         );
       }
       const nextRegistration = await navigatorObject.serviceWorker.register(
-        serviceWorkerUrl,
-        { updateViaCache: "none" },
+        versionedServiceWorkerUrl(targetVersion),
+        { scope: "./", updateViaCache: "none" },
       );
       trackRegistration(nextRegistration);
       if (nextRegistration.active) {
         setState({
-          phase: nextRegistration.waiting ? "update-ready" : "ready",
+          phase: nextRegistration.waiting ? "updating" : "ready",
           workerState: nextRegistration.waiting ? "waiting" : "active",
-          updateReady: Boolean(nextRegistration.waiting),
+          updateReady: false,
           error: null,
         });
         return nextRegistration;
@@ -379,6 +418,11 @@
         await waitForWorker(worker);
       } else {
         await navigatorObject.serviceWorker.ready;
+      }
+      const activeWorker = nextRegistration.active || worker;
+      if ((await requestWorkerVersion(activeWorker)) !== targetVersion) {
+        scheduleUpdateRetry();
+        throw new Error("The downloaded system version is inconsistent.");
       }
       setState({ phase: "ready", workerState: "active", error: null });
       await refreshStorageEstimate();
@@ -419,6 +463,10 @@
         throw new Error(`Offline game catalog failed (${response.status}).`);
       }
       manifest = validateGameManifest(await response.json());
+      if (manifest.version !== currentVersion) {
+        manifest = null;
+        throw new Error("The offline game catalog version is inconsistent.");
+      }
       setState({
         bundledGames: Object.entries(manifest.games).map(([id, entry]) => ({
           id,
@@ -470,6 +518,7 @@
         for (const file of entry.files) {
           const response = await environment.fetch(file.url, {
             cache: "no-store",
+            integrity: file.integrity,
           });
           if (!response.ok) {
             throw new Error(`Offline download failed (${response.status}).`);
@@ -668,16 +717,34 @@
         try {
           const metadata = await fetchVersion();
           rememberVersionMetadata(metadata);
-          if (!registration) await registerAndWait();
-          await registration.update();
+          await registerAndWait(metadata.version);
+          let waitingUpdateReady = false;
           if (registration.waiting) {
-            await markWaitingUpdate(registration.waiting);
+            waitingUpdateReady = await markWaitingUpdate(
+              registration.waiting,
+              metadata,
+            );
           } else if (registration.installing) {
             trackInstallingWorker(registration.installing, true);
           }
           const checkedAt = environment.Date.now();
           storage.setItem(LAST_CHECKED_KEY, String(checkedAt));
-          const updateAvailable = metadata.version !== currentVersion;
+          const activeWorkerVersion = await requestWorkerVersion(
+            registration?.active,
+          );
+          const updateAvailable =
+            metadata.version !== currentVersion ||
+            (activeWorkerVersion !== null &&
+              activeWorkerVersion !== metadata.version);
+          if (
+            activeWorkerVersion !== null &&
+            activeWorkerVersion !== metadata.version &&
+            !registration?.waiting &&
+            !registration?.installing
+          ) {
+            bypassWorkerCdn = true;
+            scheduleUpdateRetry();
+          }
           if (
             updateAvailable &&
             (await reconcileActiveVersion(metadata.version))
@@ -687,14 +754,14 @@
           }
           setState({
             phase: updateAvailable
-              ? registration?.waiting
+              ? waitingUpdateReady
                 ? "update-ready"
                 : "update-available"
               : "ready",
             availableVersion: updateAvailable ? metadata.version : null,
             availableRevision: updateAvailable ? metadata.revision : null,
             lastChecked: checkedAt,
-            updateReady: updateAvailable && Boolean(registration?.waiting),
+            updateReady: updateAvailable && waitingUpdateReady,
             workerState: registration?.waiting
               ? "waiting"
               : registration?.active
@@ -729,6 +796,14 @@
 
     const applyUpdate = async () => {
       if (registration?.waiting) {
+        const workerVersion = await requestWorkerVersion(registration.waiting);
+        if (
+          !state.availableVersion ||
+          workerVersion !== state.availableVersion
+        ) {
+          scheduleUpdateRetry();
+          throw new Error("The update is not ready to install.");
+        }
         reloadWhenControlled = true;
         setState({ phase: "applying", error: null });
         registration.waiting.postMessage({ type: "SKIP_WAITING" });
@@ -754,7 +829,6 @@
       await deleteShellCaches();
       registration = null;
       setState({ phase: "starting", updateReady: false });
-      await registerAndWait();
       await checkForUpdates();
       return snapshot();
     };
@@ -796,7 +870,15 @@
       attachLifecycleListeners();
       await refreshStorageEstimate();
       try {
-        await registerAndWait();
+        const existingRegistration =
+          await navigatorObject.serviceWorker?.getRegistration?.("./");
+        if (existingRegistration) trackRegistration(existingRegistration);
+        try {
+          await checkForUpdates();
+        } catch (error) {
+          if (!existingRegistration) throw error;
+          setState({ phase: "ready", workerState: "active", error: null });
+        }
         await loadGameManifest();
         const knownVersion = storage.getItem(DOWNLOAD_VERSION_KEY);
         if (
@@ -806,7 +888,6 @@
         ) {
           return snapshot();
         }
-        automaticCheck();
         void syncDownloadedGames().catch((error) => {
           setState({ gamePhase: "error", gameError: error.message });
         });

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -23,6 +23,7 @@ import {
   installWebtorrent,
   updateHtml,
   validateOutput,
+  versionOfflineGameManifest,
   writeOfflineGameManifest,
   writeVersionMetadata,
 } from "../tools/deploy";
@@ -259,6 +260,7 @@ describe("build metadata", () => {
 
     const hashedAssets = await updateHtml(paths, "26.07.28-abcdef1");
     await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
+    const offlineManifestName = await versionOfflineGameManifest(paths);
     await writeVersionMetadata(paths, "26.07.28-abcdef1");
 
     const main = await readFile(join(root, hashedAssets.mainJs), "utf8");
@@ -283,11 +285,21 @@ describe("build metadata", () => {
     expect(html).toContain(`${hashedAssets["entry:js/shell/desktop.js"]}"`);
     expect(html).toContain(`${hashedAssets["entry:apps/index.js"]}"`);
     expect(html).toContain(`${hashedAssets["entry:css/shell/desktop.css"]}"`);
+    expect(html).toContain(
+      `window.ASTRO_OFFLINE_MANIFEST_URL="${offlineManifestName}"`,
+    );
+    expect(offlineManifestName).toMatch(/^offline-games\.[a-f0-9]{8}\.json$/);
+    expect(await readFile(join(root, offlineManifestName), "utf8")).toBe(
+      await readFile(paths.offlineGamesJson, "utf8"),
+    );
     const capture = await readFile(paths.captureHtml, "utf8");
     expect(capture).toContain(`${hashedAssets.ruffle}"`);
     expect(capture).toContain(`${hashedAssets.gamesJs}"`);
     expect(capture).toContain(`${hashedAssets.flashUrlRouterJs}"`);
     const manifest = JSON.parse(await readFile(paths.offlineGamesJson, "utf8"));
+    expect(manifest.games["bike-mania"].files[0].integrity).toMatch(
+      /^sha384-[A-Za-z0-9+/]+={0,2}$/,
+    );
     const boxedWineIndex = await readFile(
       join(root, "apps", "core", "boxedwine.js"),
       "utf8",
@@ -427,6 +439,7 @@ describe("build metadata", () => {
     const hashedAssets = await updateHtml(paths, "26.07.28-abcdef1");
     await writeFile(join(root, hashedAssets.mainJs), "tampered");
     await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
+    await versionOfflineGameManifest(paths);
     await writeVersionMetadata(paths, "26.07.28-abcdef1");
     await expect(validateOutput(root)).rejects.toThrow(
       "invalid content hash for js/main.js",
@@ -497,6 +510,7 @@ describe("Workbox and artifact validation", () => {
     const paths = new BuildPaths(root);
     await updateHtml(paths, "26.07.28-abcdef1");
     await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
+    await versionOfflineGameManifest(paths);
     await writeVersionMetadata(paths, "26.07.28-abcdef1");
     await validateOutput(root);
 

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -163,6 +163,14 @@ test("offline updates", async () => {
       },
     },
   };
+  const testIntegrity = `sha384-${"A".repeat(64)}`;
+  for (const entry of [
+    manifest.runtime,
+    ...Object.values(manifest.runtimes),
+    ...Object.values(manifest.games),
+  ]) {
+    for (const file of entry.files) file.integrity = testIntegrity;
+  }
 
   const makeEnvironment = ({
     registration = new Registration({
@@ -190,6 +198,8 @@ test("offline updates", async () => {
     });
     const sessionStorage = new MemoryStorage(sessionValues);
     let reloads = 0;
+    const timers = [];
+    const fetches = [];
     const environment = new Events();
     Object.assign(environment, {
       navigator: {
@@ -210,6 +220,11 @@ test("offline updates", async () => {
         },
       },
       Date: { now: () => 1_800_000_000_000 },
+      clearTimeout() {},
+      setTimeout: (callback, delay) => {
+        timers.push({ callback, delay });
+        return timers.length;
+      },
       document: Object.assign(new Events(), { visibilityState: "visible" }),
       caches: {
         keys: async () => ["astro-flash-precache", BUNDLED_GAME_CACHE],
@@ -222,6 +237,7 @@ test("offline updates", async () => {
         },
       },
       fetch: async (url, options) => {
+        fetches.push({ options, url });
         assert.strictEqual(options.cache, "no-store");
         if (String(url).startsWith("version.json")) {
           return new Response(
@@ -243,11 +259,13 @@ test("offline updates", async () => {
       bundledCache,
       deletedCaches,
       environment,
+      fetches,
       getReloads: () => reloads,
       registration,
       serviceWorker,
       storage,
       sessionStorage,
+      timers,
     };
   };
 
@@ -275,13 +293,19 @@ test("offline updates", async () => {
   });
   await manager.initialize();
   assert.deepStrictEqual(initial.serviceWorker.registerCalls[0], [
-    "sw.js",
-    { updateViaCache: "none" },
+    `sw.js?v=${manifest.version}`,
+    { scope: "./", updateViaCache: "none" },
   ]);
   assert.strictEqual(manager.getSnapshot().phase, "ready");
   assert.strictEqual(manager.getSnapshot().bundledGames.length, 4);
 
   await manager.downloadGame("bike-mania");
+  assert.strictEqual(
+    initial.fetches.find(({ url }) =>
+      String(url).includes("bike-mania.bike-1/main.swf"),
+    ).options.integrity,
+    testIntegrity,
+  );
   assert.deepStrictEqual(manager.getSnapshot().downloadedGameIds, [
     "bike-mania",
   ]);
@@ -478,7 +502,7 @@ test("offline updates", async () => {
     updateManager.getSnapshot().availableVersion,
     "26.07.30-bbbbbbb",
   );
-  const waitingWorker = new Worker("installed");
+  const waitingWorker = new Worker("installed", "26.07.30-bbbbbbb");
   updateRegistration.waiting = waitingWorker;
   updateRegistration.dispatch("updatefound");
   await new Promise((resolve) => setImmediate(resolve));
@@ -486,6 +510,39 @@ test("offline updates", async () => {
   assert.deepStrictEqual(waitingWorker.messages, [{ type: "SKIP_WAITING" }]);
   update.serviceWorker.dispatch("controllerchange");
   assert.strictEqual(update.getReloads(), 1);
+
+  const staleWaitingRegistration = new Registration({
+    active: new Worker("activated", manifest.version),
+    waiting: new Worker("installed", "26.07.30-intermediate"),
+  });
+  const staleWaiting = makeEnvironment({
+    registration: staleWaitingRegistration,
+    remoteVersion: "26.07.30-bbbbbbb",
+  });
+  const staleWaitingManager = createManager({
+    currentVersion: manifest.version,
+    environment: staleWaiting.environment,
+  });
+  await staleWaitingManager.initialize();
+  assert.strictEqual(staleWaitingManager.getSnapshot().updateReady, false);
+  await assert.rejects(
+    staleWaitingManager.applyUpdate(),
+    /not ready to install/,
+  );
+  assert.deepStrictEqual(staleWaitingRegistration.waiting.messages, []);
+  staleWaitingRegistration.waiting = new Worker(
+    "installed",
+    "26.07.30-bbbbbbb",
+  );
+  const retry = staleWaiting.timers.find(({ delay }) => delay === 30_000);
+  assert.ok(retry);
+  retry.callback();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.match(
+    staleWaiting.serviceWorker.registerCalls.at(-1)[0],
+    /^sw\.js\?v=26\.07\.30-bbbbbbb&retry=1800000000000$/,
+  );
+  assert.strictEqual(staleWaitingManager.getSnapshot().updateReady, true);
 
   const activatedUpdate = makeEnvironment({
     registration: new Registration({

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -83,6 +83,7 @@ export function createIntegrityManifestTransform(
 
 interface OfflineFile {
   bytes: number;
+  integrity: string;
   url: string;
 }
 
@@ -599,8 +600,10 @@ async function offlineFileEntry(
   revision?: string,
 ): Promise<OfflineFile> {
   const relativePath = relative(root, path).split(sep).join("/");
+  const content = await readFile(path);
   return {
-    bytes: (await stat(path)).size,
+    bytes: content.byteLength,
+    integrity: `sha384-${createHash("sha384").update(content).digest("base64")}`,
     url: revision ? `${relativePath}?rev=${revision}` : relativePath,
   };
 }
@@ -785,6 +788,23 @@ export async function writeOfflineGameManifest(
   await writeFile(paths.offlineGamesJson, `${JSON.stringify(manifest)}\n`);
 }
 
+export async function versionOfflineGameManifest(
+  paths: BuildPaths,
+): Promise<string> {
+  const hash = await getShortHash(paths.offlineGamesJson);
+  const filename = `offline-games.${hash}.json`;
+  await cp(paths.offlineGamesJson, join(paths.root, filename));
+  const mapping = `<script>window.ASTRO_OFFLINE_MANIFEST_URL=${JSON.stringify(filename)};</script>`;
+  const html = await replaceExactlyOnce(
+    await readFile(paths.html, "utf8"),
+    /<script src="js\/offline\.[a-f0-9]{8}\.js"><\/script>/g,
+    `${mapping}\n    $&`,
+    "Could not inject the versioned offline game manifest",
+  );
+  await writeFile(paths.html, html);
+  return filename;
+}
+
 export async function writeVersionMetadata(
   paths: BuildPaths,
   version: string,
@@ -795,6 +815,7 @@ export async function writeVersionMetadata(
     const relativePath = relative(paths.root, path);
     if (
       path !== paths.versionJson &&
+      path !== paths.offlineGamesJson &&
       PRECACHE_FILE_SUFFIXES.has(extname(path).toLowerCase()) &&
       !isOptionalOfflinePath(relativePath)
     ) {
@@ -926,6 +947,20 @@ export async function validateOutput(outputDir: string): Promise<void> {
   }
 
   const html = await readFile(paths.html, "utf8");
+  const offlineManifestReference = html.match(
+    /window\.ASTRO_OFFLINE_MANIFEST_URL="(offline-games\.([a-f0-9]{8})\.json)"/,
+  );
+  if (!offlineManifestReference) {
+    throw new Error("Build output has no versioned offline game manifest");
+  }
+  const versionedOfflineManifest = join(outputDir, offlineManifestReference[1]);
+  if (
+    !(await isFile(versionedOfflineManifest)) ||
+    (await getShortHash(versionedOfflineManifest)) !==
+      offlineManifestReference[2]
+  ) {
+    throw new Error("Build output has an invalid offline manifest hash");
+  }
   for (const asset of [
     "js/ruffle.js",
     "js/games.js",
@@ -1081,6 +1116,12 @@ export async function validateOutput(outputDir: string): Promise<void> {
   ) {
     throw new Error("Build output has invalid offline game manifest");
   }
+  if (
+    (await readFile(versionedOfflineManifest, "utf8")) !==
+    (await readFile(paths.offlineGamesJson, "utf8"))
+  ) {
+    throw new Error("Build output has inconsistent offline game manifests");
+  }
   const gameRoots = Object.fromEntries(
     Object.entries(offlineManifest.games).map(([id, game]) => [id, game.root]),
   );
@@ -1100,9 +1141,18 @@ export async function validateOutput(outputDir: string): Promise<void> {
       throw new Error(`Build output has an invalid game package for ${id}`);
     }
     for (const file of game.files) {
-      if (!(await isFile(join(outputDir, file.url)))) {
+      const path = join(outputDir, file.url);
+      if (!(await isFile(path))) {
         throw new Error(
           `Build output references a missing game file: ${file.url}`,
+        );
+      }
+      const integrity = `sha384-${createHash("sha384")
+        .update(await readFile(path))
+        .digest("base64")}`;
+      if (file.integrity !== integrity) {
+        throw new Error(
+          `Build output has invalid game file integrity: ${file.url}`,
         );
       }
     }
@@ -1112,12 +1162,21 @@ export async function validateOutput(outputDir: string): Promise<void> {
     ...Object.values(offlineManifest.runtimes ?? {}),
   ]) {
     for (const file of runtime.files) {
+      const path = join(outputDir, file.url.split("?")[0]);
       if (
         !file.url.endsWith(`?rev=${runtime.revision}`) ||
-        !(await isFile(join(outputDir, file.url.split("?")[0])))
+        !(await isFile(path))
       ) {
         throw new Error(
           `Build output has an invalid runtime file: ${file.url}`,
+        );
+      }
+      const integrity = `sha384-${createHash("sha384")
+        .update(await readFile(path))
+        .digest("base64")}`;
+      if (file.integrity !== integrity) {
+        throw new Error(
+          `Build output has invalid runtime file integrity: ${file.url}`,
         );
       }
     }
@@ -1199,6 +1258,7 @@ export async function build({
     await installRuffleRuntime(paths.js);
     await updateHtml(paths, deploymentVersion);
     await writeOfflineGameManifest(paths, deploymentVersion);
+    await versionOfflineGameManifest(paths);
     await writeVersionMetadata(paths, deploymentVersion);
     await generate(stagingDir, deploymentVersion);
     await validateOutput(stagingDir);


### PR DESCRIPTION
## Summary

- bind service-worker registration URLs to the exact release version
- reject stale or intermediate waiting workers before activation and retry with a fresh cache key
- version the offline game manifest while retaining the unversioned migration copy
- add SHA-384 integrity metadata for every optional game and runtime file
- verify optional file integrity during download and validate all generated integrity values at build time

This closes the remaining gap where GitHub Fastly could return a stale `sw.js` even when Cloudflare correctly bypassed its own cache.

Cloudflare configuration was cleaned separately at the zone level. The request cache rules now use three non-duplicated policies: immutable/static, ten-minute mutable content, and dynamic/release-control bypass.

## Validation

- `bun run test` — 108 passed
- `bun run quality`
- production build and artifact validation
- live Cloudflare checks for all configured 4st.li hosts
- Flash `/`, `sw.js`, `version.json`, and `offline-games.json` return `cf-cache-status: DYNAMIC` and `Cache-Control: no-store`
