### PR TITLE
Deploy assets under versioned release paths

### DIFF
--- a/site/js/offline-worker.js
+++ b/site/js/offline-worker.js
@@ -19,6 +19,7 @@
   const SCUMMVM_DIRECTORY = "astro-flash-scummvm";
   let revcdosStorePromise;
   const scummvmStores = new Map();
+  const releasePath = (path) => path.replace(/^\/releases\/[^/]+(?=\/)/, "");
 
   const normalizeAssetPath = (path) =>
     decodeURIComponent(path)
@@ -209,21 +210,20 @@
     if (event.request.method !== "GET") return;
     const url = new URL(event.request.url);
     if (url.origin !== self.location.origin) return;
+    const path = releasePath(url.pathname);
+    if (path === url.pathname) return;
     if (REVCDOS_ROUTE.test(url.pathname)) {
       event.respondWith(serveRevcdosAsset(event.request, url));
       return;
     }
-    if (url.pathname.startsWith(SCUMMVM_ROUTE)) {
+    if (path.startsWith(SCUMMVM_ROUTE)) {
       event.respondWith(serveScummvmAsset(url));
       return;
     }
-    const isGameFile = OPTIONAL_PATHS.some((prefix) =>
-      url.pathname.startsWith(prefix),
-    );
+    const isGameFile = OPTIONAL_PATHS.some((prefix) => path.startsWith(prefix));
     const isRuffleRuntime =
-      url.pathname.startsWith("/js/") &&
-      (url.pathname.endsWith(".wasm") ||
-        /\/core\.ruffle\.[^/]+\.js$/.test(url.pathname));
+      path.startsWith("/js/") &&
+      (path.endsWith(".wasm") || /\/core\.ruffle\.[^/]+\.js$/.test(path));
     if (!isGameFile && !isRuffleRuntime) return;
 
     event.respondWith(

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -118,8 +118,8 @@
   const createManager = ({
     currentVersion,
     environment = globalThis,
-    serviceWorkerUrl = "sw.js",
-    versionUrl = "version.json",
+    serviceWorkerUrl = "/sw.js",
+    versionUrl = "/version.json",
     gameManifestUrl = "offline-games.json",
     cachePrefix = "astro-flash",
     bundledCacheName = BUNDLED_GAME_CACHE,
@@ -396,7 +396,7 @@
       }
       const nextRegistration = await navigatorObject.serviceWorker.register(
         versionedServiceWorkerUrl(targetVersion),
-        { scope: "./", updateViaCache: "none" },
+        { scope: "/", updateViaCache: "none" },
       );
       trackRegistration(nextRegistration);
       if (nextRegistration.active) {
@@ -824,7 +824,7 @@
       setState({ phase: "repairing", error: null });
       const currentRegistration =
         registration ||
-        (await navigatorObject.serviceWorker?.getRegistration("./"));
+        (await navigatorObject.serviceWorker?.getRegistration("/"));
       if (currentRegistration) await currentRegistration.unregister();
       await deleteShellCaches();
       registration = null;
@@ -871,7 +871,7 @@
       await refreshStorageEstimate();
       try {
         const existingRegistration =
-          await navigatorObject.serviceWorker?.getRegistration?.("./");
+          await navigatorObject.serviceWorker?.getRegistration?.("/");
         if (existingRegistration) trackRegistration(existingRegistration);
         try {
           await checkForUpdates();

--- a/site/js/startup-recovery.js
+++ b/site/js/startup-recovery.js
@@ -44,7 +44,7 @@
       try {
         const nonce = environment.Date.now();
         const versionResponse = await environment.fetch(
-          `version.json?t=${nonce}`,
+          `/version.json?t=${nonce}`,
           { cache: "no-store" },
         );
         if (!versionResponse.ok) throw new Error("Version check failed");

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -58,6 +58,7 @@ async function writeFiles(
 async function makeSource(root: string): Promise<void> {
   await writeFiles(root, {
     "index.html": [
+      "<head>",
       '<meta name="astro-version" content="development" />',
       '<script src="js/startup-recovery.js"></script>',
       '<script src="js/ruffle.js?v=old"></script>',
@@ -79,6 +80,7 @@ async function makeSource(root: string): Promise<void> {
       '<link rel="stylesheet" href="css/shell/desktop.css">',
       '<link rel="icon" href="favicon.ico">',
       '<img src="assets/xp/bliss.jpg">',
+      "</head>",
     ].join("\n"),
     "capture.html": [
       '<script src="js/ruffle.js?v=old"></script>',
@@ -260,8 +262,8 @@ describe("build metadata", () => {
 
     const hashedAssets = await updateHtml(paths, "26.07.28-abcdef1");
     await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
-    const offlineManifestName = await versionOfflineGameManifest(paths);
     await writeVersionMetadata(paths, "26.07.28-abcdef1");
+    const offlineManifestName = await versionOfflineGameManifest(paths);
 
     const main = await readFile(join(root, hashedAssets.mainJs), "utf8");
     const html = await readFile(paths.html, "utf8");
@@ -289,14 +291,13 @@ describe("build metadata", () => {
       `window.ASTRO_OFFLINE_MANIFEST_URL="${offlineManifestName}"`,
     );
     expect(offlineManifestName).toMatch(/^offline-games\.[a-f0-9]{8}\.json$/);
-    expect(await readFile(join(root, offlineManifestName), "utf8")).toBe(
-      await readFile(paths.offlineGamesJson, "utf8"),
-    );
     const capture = await readFile(paths.captureHtml, "utf8");
     expect(capture).toContain(`${hashedAssets.ruffle}"`);
     expect(capture).toContain(`${hashedAssets.gamesJs}"`);
     expect(capture).toContain(`${hashedAssets.flashUrlRouterJs}"`);
-    const manifest = JSON.parse(await readFile(paths.offlineGamesJson, "utf8"));
+    const manifest = JSON.parse(
+      await readFile(join(root, offlineManifestName), "utf8"),
+    );
     expect(manifest.games["bike-mania"].files[0].integrity).toMatch(
       /^sha384-[A-Za-z0-9+/]+={0,2}$/,
     );
@@ -439,8 +440,8 @@ describe("build metadata", () => {
     const hashedAssets = await updateHtml(paths, "26.07.28-abcdef1");
     await writeFile(join(root, hashedAssets.mainJs), "tampered");
     await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
-    await versionOfflineGameManifest(paths);
     await writeVersionMetadata(paths, "26.07.28-abcdef1");
+    await versionOfflineGameManifest(paths);
     await expect(validateOutput(root)).rejects.toThrow(
       "invalid content hash for js/main.js",
     );
@@ -456,11 +457,18 @@ describe("Workbox and artifact validation", () => {
       "apps/pinball/runtime/SpaceCadetPinball.data": "pinball data",
     });
 
-    await generateServiceWorker(root);
+    await generateServiceWorker(root, undefined, "26.07.28-abcdef1");
 
     const worker = await readFile(join(root, "sw.js"), "utf8");
-    expect(worker).toContain("assets/xp/Chess.12345678.bmp");
-    expect(worker).toContain("apps/pinball/runtime/SpaceCadetPinball.data");
+    expect(worker).toContain(
+      "releases/26.07.28-abcdef1/assets/xp/Chess.12345678.bmp",
+    );
+    expect(worker).toContain(
+      "releases/26.07.28-abcdef1/apps/pinball/runtime/SpaceCadetPinball.data",
+    );
+    expect(worker).toContain(
+      'importScripts("releases/26.07.28-abcdef1/js/offline-worker.12345678.js")',
+    );
     expect(worker).toContain(
       `integrity:"sha384-${createHash("sha384")
         .update("bitmap")
@@ -468,25 +476,31 @@ describe("Workbox and artifact validation", () => {
     );
   });
 
-  test("accepts a generated worker with its runtime", async () => {
+  test("generates a self-contained worker for the release directory", async () => {
     const root = await makeTemporaryDirectory();
     await writeFiles(root, {
       "js/offline-worker.12345678.js": "offline worker",
     });
-    const generator = async () => {
+    let configuration: any;
+    const generator = async (options: any) => {
+      configuration = options;
       await addGeneratedRuntime(root);
       return { count: 1, size: 1, warnings: [], filePaths: [] };
     };
     await generateServiceWorker(root, generator as any, "26.07.28-abcdef1");
+    expect(configuration.inlineWorkboxRuntime).toBeTrue();
+    expect(configuration.importScripts).toEqual([
+      "releases/26.07.28-abcdef1/js/offline-worker.12345678.js",
+    ]);
     expect(
       await Bun.file(join(root, "workbox-f9030226.js")).exists(),
-    ).toBeTrue();
+    ).toBeFalse();
     expect(await readFile(join(root, "sw.js"), "utf8")).toContain(
       'self.__ASTRO_FLASH_VERSION__="26.07.28-abcdef1"',
     );
   });
 
-  test("rejects a generated worker with a missing runtime", async () => {
+  test("removes an unused external Workbox runtime", async () => {
     const root = await makeTemporaryDirectory();
     await writeFiles(root, {
       "js/offline-worker.12345678.js": "offline worker",
@@ -498,9 +512,10 @@ describe("Workbox and artifact validation", () => {
       );
       return { count: 1, size: 1, warnings: [], filePaths: [] };
     };
-    expect(generateServiceWorker(root, generator as any)).rejects.toThrow(
-      "missing Workbox runtime",
-    );
+    await generateServiceWorker(root, generator as any);
+    expect(
+      await Bun.file(join(root, "workbox-deadbeef.js")).exists(),
+    ).toBeFalse();
   });
 
   test("accepts a complete artifact and rejects a missing representative game", async () => {
@@ -510,11 +525,13 @@ describe("Workbox and artifact validation", () => {
     const paths = new BuildPaths(root);
     await updateHtml(paths, "26.07.28-abcdef1");
     await writeOfflineGameManifest(paths, "26.07.28-abcdef1");
-    await versionOfflineGameManifest(paths);
     await writeVersionMetadata(paths, "26.07.28-abcdef1");
+    const offlineManifestName = await versionOfflineGameManifest(paths);
     await validateOutput(root);
 
-    const manifest = JSON.parse(await readFile(paths.offlineGamesJson, "utf8"));
+    const manifest = JSON.parse(
+      await readFile(join(root, offlineManifestName), "utf8"),
+    );
     await unlink(join(root, manifest.games["bike-mania"].root, "main.swf"));
     expect(validateOutput(root)).rejects.toThrow("missing game file");
   });
@@ -559,6 +576,18 @@ describe("atomic build", () => {
     }
     expect(await Bun.file(join(output, "stale.txt")).exists()).toBeFalse();
     expect(await Bun.file(join(output, "sw.js")).exists()).toBeTrue();
+    const release = join(output, "releases", "26.07.28-abcdef1");
+    expect(
+      await Bun.file(join(output, "apps", "core", "boxedwine.js")).exists(),
+    ).toBeFalse();
+    expect(
+      await Bun.file(join(release, "apps", "core", "boxedwine.js")).exists(),
+    ).toBeTrue();
+    expect(
+      await Bun.file(join(release, "offline-games.json")).exists(),
+    ).toBeFalse();
+    const rootHtml = await readFile(join(output, "index.html"), "utf8");
+    expect(rootHtml).toContain('<base href="/releases/26.07.28-abcdef1/" />');
     const metadata = JSON.parse(
       await readFile(join(output, "version.json"), "utf8"),
     );

--- a/tests/offline-worker.test.ts
+++ b/tests/offline-worker.test.ts
@@ -31,7 +31,7 @@ test("optional runtime assets prefer the network and fall back offline", async (
   require(workerPath);
 
   const request = new Request(
-    "https://flash.example/vendor/boxedwine/26R1/boxedwine.12345678.wasm",
+    "https://flash.example/releases/26.07.28-abcdef1/vendor/boxedwine/26R1/boxedwine.12345678.wasm",
   );
   let responsePromise;
   listeners.get("fetch")({

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -239,7 +239,7 @@ test("offline updates", async () => {
       fetch: async (url, options) => {
         fetches.push({ options, url });
         assert.strictEqual(options.cache, "no-store");
-        if (String(url).startsWith("version.json")) {
+        if (String(url).startsWith("/version.json")) {
           return new Response(
             JSON.stringify({
               version: remoteVersion,
@@ -293,8 +293,8 @@ test("offline updates", async () => {
   });
   await manager.initialize();
   assert.deepStrictEqual(initial.serviceWorker.registerCalls[0], [
-    `sw.js?v=${manifest.version}`,
-    { scope: "./", updateViaCache: "none" },
+    `/sw.js?v=${manifest.version}`,
+    { scope: "/", updateViaCache: "none" },
   ]);
   assert.strictEqual(manager.getSnapshot().phase, "ready");
   assert.strictEqual(manager.getSnapshot().bundledGames.length, 4);
@@ -540,7 +540,7 @@ test("offline updates", async () => {
   await new Promise((resolve) => setImmediate(resolve));
   assert.match(
     staleWaiting.serviceWorker.registerCalls.at(-1)[0],
-    /^sw\.js\?v=26\.07\.30-bbbbbbb&retry=1800000000000$/,
+    /^\/sw\.js\?v=26\.07\.30-bbbbbbb&retry=1800000000000$/,
   );
   assert.strictEqual(staleWaitingManager.getSnapshot().updateReady, true);
 

--- a/tests/startup-recovery.test.ts
+++ b/tests/startup-recovery.test.ts
@@ -42,7 +42,7 @@ const makeEnvironment = ({ htmlVersion = "26.08.12-abcdef1" } = {}) => {
     console: { error: (...values) => errors.push(values) },
     fetch: async (url, options) => {
       expect(options).toEqual({ cache: "no-store" });
-      if (String(url).startsWith("version.json?")) {
+      if (String(url).startsWith("/version.json?")) {
         return new Response(JSON.stringify({ version: "26.08.12-abcdef1" }));
       }
       return new Response(

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -32,6 +32,7 @@ export const RUFFLE_PACKAGE = "@ruffle-rs/ruffle";
 export const FFLATE_JS_PATH = "vendor/fflate/index.js";
 export const JS_DOS_ROOT_PATH = "vendor/js-dos";
 export const WEBTORRENT_JS_PATH = "vendor/webtorrent/webtorrent.min.js";
+export const RELEASES_PATH = "releases";
 const NODE_MODULES = join(PROJECT_DIR, "node_modules");
 const FFLATE_SOURCE = join(NODE_MODULES, "fflate");
 const JS_DOS_SOURCE = join(NODE_MODULES, "js-dos");
@@ -56,6 +57,7 @@ type WorkboxGenerator = typeof generateSW;
 
 export function createIntegrityManifestTransform(
   outputDir: string,
+  urlPrefix = "",
 ): ManifestTransform {
   const root = resolve(outputDir);
   return async (entries) => ({
@@ -74,7 +76,12 @@ export function createIntegrityManifestTransform(
         const integrity = `sha384-${createHash("sha384")
           .update(await readFile(path))
           .digest("base64")}`;
-        return { ...entry, integrity };
+        return {
+          ...entry,
+          integrity,
+          url:
+            entry.url === "index.html" ? entry.url : `${urlPrefix}${entry.url}`,
+        };
       }),
     ),
     warnings: [],
@@ -187,6 +194,33 @@ async function walkFiles(root: string): Promise<string[]> {
     }
   }
   return files;
+}
+
+function releaseRelativePath(version: string): string {
+  if (!/^[a-zA-Z0-9._-]+$/.test(version)) {
+    throw new Error(`Invalid release version: ${version}`);
+  }
+  return `${RELEASES_PATH}/${version}`;
+}
+
+export async function scopeReleaseReferences(
+  root: string,
+  version: string,
+): Promise<void> {
+  const releasePath = releaseRelativePath(version);
+  const referencePattern =
+    /(["'`(=]\s*)\/(apps|assets|css|dos|iframe|js|swf|vendor)\//g;
+  for (const path of await walkFiles(root)) {
+    if (
+      ![".css", ".html", ".js", ".mjs"].includes(extname(path)) ||
+      path.endsWith(`${sep}js${sep}offline-worker.js`)
+    ) {
+      continue;
+    }
+    const content = await readFile(path, "utf8");
+    const scoped = content.replace(referencePattern, `$1/${releasePath}/$2/`);
+    if (scoped !== content) await writeFile(path, scoped);
+  }
 }
 
 async function replaceExactlyOnce(
@@ -793,7 +827,7 @@ export async function versionOfflineGameManifest(
 ): Promise<string> {
   const hash = await getShortHash(paths.offlineGamesJson);
   const filename = `offline-games.${hash}.json`;
-  await cp(paths.offlineGamesJson, join(paths.root, filename));
+  await rename(paths.offlineGamesJson, join(paths.root, filename));
   const mapping = `<script>window.ASTRO_OFFLINE_MANIFEST_URL=${JSON.stringify(filename)};</script>`;
   const html = await replaceExactlyOnce(
     await readFile(paths.html, "utf8"),
@@ -864,6 +898,7 @@ export async function generateServiceWorker(
   version?: string,
 ): Promise<void> {
   console.log("Generating service worker...");
+  const releasePrefix = version ? `${releaseRelativePath(version)}/` : "";
   const offlineWorkerNames = (await readdir(join(outputDir, "js"))).filter(
     (name) => /^offline-worker\.[a-f0-9]{8}\.js$/.test(name),
   );
@@ -875,8 +910,11 @@ export async function generateServiceWorker(
   await generator({
     ...workboxConfig,
     globDirectory: `${resolve(outputDir)}/`,
-    importScripts: [`js/${offlineWorkerNames[0]}`],
-    manifestTransforms: [createIntegrityManifestTransform(outputDir)],
+    importScripts: [`${releasePrefix}js/${offlineWorkerNames[0]}`],
+    inlineWorkboxRuntime: true,
+    manifestTransforms: [
+      createIntegrityManifestTransform(outputDir, releasePrefix),
+    ],
     swDest: join(resolve(outputDir), "sw.js"),
   });
 
@@ -891,32 +929,9 @@ export async function generateServiceWorker(
     )};self.addEventListener("message",event=>{if(event.data?.type==="GET_VERSION")event.ports[0]?.postMessage({version:self.__ASTRO_FLASH_VERSION__})});\n`;
     await writeFile(serviceWorker, workerSource);
   }
-  const referencedRuntimeNames = new Set(
-    [...workerSource.matchAll(/workbox-[a-f0-9]+(?:\.js)?/g)].map((match) =>
-      match[0].endsWith(".js") ? match[0] : `${match[0]}.js`,
-    ),
-  );
-  if (referencedRuntimeNames.size === 0) {
-    throw new Error("Generated service worker references no Workbox runtime");
-  }
-  if (
-    !(
-      await Promise.all(
-        [...referencedRuntimeNames].map((name) =>
-          isFile(join(outputDir, name)),
-        ),
-      )
-    ).every(Boolean)
-  ) {
-    throw new Error(
-      "Generated service worker references a missing Workbox runtime",
-    );
-  }
   for (const path of await getWorkboxFiles(outputDir)) {
     const name = path.split(sep).at(-1) ?? "";
-    if (name.startsWith("workbox-") && !referencedRuntimeNames.has(name)) {
-      await rm(path);
-    }
+    if (name.startsWith("workbox-")) await rm(path);
   }
   console.log("  - Service worker generated successfully");
 }
@@ -925,7 +940,6 @@ export async function validateOutput(outputDir: string): Promise<void> {
   const paths = new BuildPaths(outputDir);
   const required = [
     paths.html,
-    paths.offlineGamesJson,
     paths.versionJson,
     join(outputDir, "sw.js"),
     paths.fflateJs,
@@ -1104,7 +1118,7 @@ export async function validateOutput(outputDir: string): Promise<void> {
   let offlineManifest: OfflineManifest;
   try {
     offlineManifest = JSON.parse(
-      await readFile(paths.offlineGamesJson, "utf8"),
+      await readFile(versionedOfflineManifest, "utf8"),
     ) as OfflineManifest;
   } catch {
     throw new Error("Build output has invalid offline game manifest");
@@ -1115,12 +1129,6 @@ export async function validateOutput(outputDir: string): Promise<void> {
     !offlineManifest.runtime?.files?.length
   ) {
     throw new Error("Build output has invalid offline game manifest");
-  }
-  if (
-    (await readFile(versionedOfflineManifest, "utf8")) !==
-    (await readFile(paths.offlineGamesJson, "utf8"))
-  ) {
-    throw new Error("Build output has inconsistent offline game manifests");
   }
   const gameRoots = Object.fromEntries(
     Object.entries(offlineManifest.games).map(([id, game]) => [id, game.root]),
@@ -1210,6 +1218,114 @@ export async function replaceOutput(
   }
 }
 
+export async function assembleReleaseOutput(
+  stagingDir: string,
+  version: string,
+): Promise<void> {
+  const releasePath = releaseRelativePath(version);
+  const releaseDir = join(stagingDir, ...releasePath.split("/"));
+  const rootHtml = join(stagingDir, "index.html");
+  const html = await replaceExactlyOnce(
+    await readFile(rootHtml, "utf8"),
+    /<head>/g,
+    `<head>\n    <base href="/${releasePath}/" />`,
+    "Could not set the immutable release base URL",
+  ).then((content) =>
+    content.replaceAll(
+      "https://flash.4st.li/assets/",
+      `https://flash.4st.li/${releasePath}/assets/`,
+    ),
+  );
+
+  await mkdir(releaseDir, { recursive: true });
+  for (const entry of await readdir(stagingDir, { withFileTypes: true })) {
+    if (
+      entry.name === RELEASES_PATH ||
+      entry.name === "index.html" ||
+      entry.name === "sw.js" ||
+      entry.name === "version.json" ||
+      entry.name === "CNAME"
+    ) {
+      continue;
+    }
+    await rename(join(stagingDir, entry.name), join(releaseDir, entry.name));
+  }
+  await writeFile(rootHtml, html);
+}
+
+export async function validateReleaseOutput(
+  outputDir: string,
+  version: string,
+): Promise<void> {
+  const releasePath = releaseRelativePath(version);
+  const releaseDir = join(outputDir, ...releasePath.split("/"));
+  const allowedRootEntries = new Set([
+    "CNAME",
+    "index.html",
+    "releases",
+    "sw.js",
+    "version.json",
+  ]);
+  const unexpectedRootEntries = (await readdir(outputDir)).filter(
+    (name) => !allowedRootEntries.has(name),
+  );
+  if (unexpectedRootEntries.length > 0) {
+    throw new Error(
+      `Build output has files outside the release directory: ${unexpectedRootEntries.join(", ")}`,
+    );
+  }
+  const releases = await readdir(join(outputDir, RELEASES_PATH));
+  if (releases.length !== 1 || releases[0] !== version) {
+    throw new Error("Build output has an invalid release directory");
+  }
+  const html = await readFile(join(outputDir, "index.html"), "utf8");
+  if (!html.includes(`<base href="/${releasePath}/" />`)) {
+    throw new Error("Build output has no matching immutable release base URL");
+  }
+  if (await isFile(join(releaseDir, "offline-games.json"))) {
+    throw new Error("Build output contains an unversioned offline manifest");
+  }
+  const manifestReference = html.match(
+    /window\.ASTRO_OFFLINE_MANIFEST_URL="(offline-games\.[a-f0-9]{8}\.json)"/,
+  )?.[1];
+  if (
+    !manifestReference ||
+    !(await isFile(join(releaseDir, manifestReference)))
+  ) {
+    throw new Error("Build output has no release-scoped offline manifest");
+  }
+  for (const requiredPath of [
+    "apps",
+    "assets",
+    "capture.html",
+    "css",
+    "iframe",
+    "js",
+    "vendor",
+  ]) {
+    const path = join(releaseDir, requiredPath);
+    if (!(await isFile(path)) && !(await isDirectory(path))) {
+      throw new Error(`Build output is missing release path: ${requiredPath}`);
+    }
+  }
+  for (const path of await walkFiles(releaseDir)) {
+    if (
+      ![".css", ".html", ".js", ".mjs"].includes(extname(path)) ||
+      /offline-worker\.[a-f0-9]{8}\.js$/.test(path)
+    ) {
+      continue;
+    }
+    const reference = (await readFile(path, "utf8")).match(
+      /["'`(=]\s*\/(apps|assets|css|dos|iframe|js|swf|vendor)\//,
+    )?.[0];
+    if (reference) {
+      throw new Error(
+        `Build output has an unscoped release reference in ${relative(releaseDir, path)}: ${reference}`,
+      );
+    }
+  }
+}
+
 export interface BuildOptions {
   outputDir?: string;
   revision?: string;
@@ -1251,6 +1367,7 @@ export async function build({
       recursive: true,
       preserveTimestamps: true,
     });
+    await scopeReleaseReferences(stagingDir, deploymentVersion);
     const paths = new BuildPaths(stagingDir);
     await installFflate(stagingDir);
     await installJsDos(stagingDir);
@@ -1258,10 +1375,12 @@ export async function build({
     await installRuffleRuntime(paths.js);
     await updateHtml(paths, deploymentVersion);
     await writeOfflineGameManifest(paths, deploymentVersion);
-    await versionOfflineGameManifest(paths);
     await writeVersionMetadata(paths, deploymentVersion);
+    await versionOfflineGameManifest(paths);
     await generate(stagingDir, deploymentVersion);
     await validateOutput(stagingDir);
+    await assembleReleaseOutput(stagingDir, deploymentVersion);
+    await validateReleaseOutput(stagingDir, deploymentVersion);
     await replaceOutput(stagingDir, resolvedOutput);
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- deploy the complete application tree under `/releases/<version>/`
- keep only `index.html`, `sw.js`, `version.json`, `CNAME`, and `releases/` at the root
- preserve nested ES module and vendor relative paths under one immutable release URL
- rewrite root-absolute application asset references into the current release
- remove the unversioned offline manifest with no compatibility copy
- make the root service worker self-contained and scope its precache URLs to the release
- validate that no application files or unscoped asset references escape the release directory

## Validation

- production build completed successfully
- 629 files verified under one release directory
- focused deployment, offline update, worker, and startup recovery tests pass
- type checks, JavaScript validation, icon validation, formatting, lint, and diff checks pass

Cloudflare rules are intentionally not changed in this PR.