### PR TITLE
Fix final precache integrity validation

### DIFF
--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -22,6 +22,7 @@ import {
   installRuffle,
   installWebtorrent,
   updateHtml,
+  validatePrecacheIntegrity,
   validateOutput,
   versionOfflineGameManifest,
   writeOfflineGameManifest,
@@ -452,9 +453,12 @@ describe("Workbox and artifact validation", () => {
   test("precaches bitmap artwork and Pinball data", async () => {
     const root = await makeTemporaryDirectory();
     await writeFiles(root, {
-      "js/offline-worker.12345678.js": "offline worker",
-      "assets/xp/Chess.12345678.bmp": "bitmap",
-      "apps/pinball/runtime/SpaceCadetPinball.data": "pinball data",
+      "index.html": "final index",
+      "releases/26.07.28-abcdef1/js/offline-worker.12345678.js":
+        "offline worker",
+      "releases/26.07.28-abcdef1/assets/xp/Chess.12345678.bmp": "bitmap",
+      "releases/26.07.28-abcdef1/apps/pinball/runtime/SpaceCadetPinball.data":
+        "pinball data",
     });
 
     await generateServiceWorker(root, undefined, "26.07.28-abcdef1");
@@ -474,21 +478,38 @@ describe("Workbox and artifact validation", () => {
         .update("bitmap")
         .digest("base64")}"`,
     );
+    expect(worker).toContain(
+      `integrity:"sha384-${createHash("sha384")
+        .update("final index")
+        .digest("base64")}"`,
+    );
+    await validatePrecacheIntegrity(root);
+    await writeFile(join(root, "index.html"), "changed after generation");
+    await expect(validatePrecacheIntegrity(root)).rejects.toThrow(
+      "invalid integrity: index.html",
+    );
   });
 
   test("generates a self-contained worker for the release directory", async () => {
     const root = await makeTemporaryDirectory();
+    const release = join(root, "releases", "26.07.28-abcdef1");
     await writeFiles(root, {
-      "js/offline-worker.12345678.js": "offline worker",
+      "index.html": "final index",
+      "releases/26.07.28-abcdef1/js/offline-worker.12345678.js":
+        "offline worker",
     });
     let configuration: any;
     const generator = async (options: any) => {
       configuration = options;
-      await addGeneratedRuntime(root);
+      await writeFiles(root, {
+        "sw.js": 's("workbox-f9030226", import.meta.url)',
+        "workbox-f9030226.js": "workbox",
+      });
       return { count: 1, size: 1, warnings: [], filePaths: [] };
     };
     await generateServiceWorker(root, generator as any, "26.07.28-abcdef1");
     expect(configuration.inlineWorkboxRuntime).toBeTrue();
+    expect(configuration.globDirectory).toBe(`${release}/`);
     expect(configuration.importScripts).toEqual([
       "releases/26.07.28-abcdef1/js/offline-worker.12345678.js",
     ]);
@@ -565,8 +586,12 @@ describe("atomic build", () => {
       sourceDir: source,
       outputDir: output,
       version: "26.07.28-abcdef1",
-      installRuffle: async (jsDir) => addGeneratedRuntime(join(jsDir, "..")),
-      generate: addGeneratedRuntime,
+      installRuffle: async (jsDir) =>
+        writeFiles(jsDir, {
+          "ruffle.js": "ruffle",
+          "core.ruffle.abc123.js": "core",
+          "abc123.wasm": "wasm",
+        }),
     });
 
     const currentFiles = await fileSnapshot(source);

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -899,7 +899,8 @@ export async function generateServiceWorker(
 ): Promise<void> {
   console.log("Generating service worker...");
   const releasePrefix = version ? `${releaseRelativePath(version)}/` : "";
-  const offlineWorkerNames = (await readdir(join(outputDir, "js"))).filter(
+  const contentDir = version ? join(outputDir, releasePrefix) : outputDir;
+  const offlineWorkerNames = (await readdir(join(contentDir, "js"))).filter(
     (name) => /^offline-worker\.[a-f0-9]{8}\.js$/.test(name),
   );
   if (offlineWorkerNames.length !== 1) {
@@ -909,12 +910,25 @@ export async function generateServiceWorker(
   }
   await generator({
     ...workboxConfig,
-    globDirectory: `${resolve(outputDir)}/`,
+    globDirectory: `${resolve(contentDir)}/`,
     importScripts: [`${releasePrefix}js/${offlineWorkerNames[0]}`],
     inlineWorkboxRuntime: true,
     manifestTransforms: [
-      createIntegrityManifestTransform(outputDir, releasePrefix),
+      createIntegrityManifestTransform(contentDir, releasePrefix),
     ],
+    ...(version
+      ? {
+          additionalManifestEntries: [
+            {
+              integrity: `sha384-${createHash("sha384")
+                .update(await readFile(join(outputDir, "index.html")))
+                .digest("base64")}`,
+              revision: await getShortHash(join(outputDir, "index.html")),
+              url: "index.html",
+            },
+          ],
+        }
+      : {}),
     swDest: join(resolve(outputDir), "sw.js"),
   });
 
@@ -941,7 +955,6 @@ export async function validateOutput(outputDir: string): Promise<void> {
   const required = [
     paths.html,
     paths.versionJson,
-    join(outputDir, "sw.js"),
     paths.fflateJs,
     join(paths.jsDosRoot, "js-dos.js"),
     join(paths.jsDosRoot, "emulators", "wdosbox.wasm"),
@@ -1282,6 +1295,7 @@ export async function validateReleaseOutput(
   if (!html.includes(`<base href="/${releasePath}/" />`)) {
     throw new Error("Build output has no matching immutable release base URL");
   }
+  await validatePrecacheIntegrity(outputDir);
   if (await isFile(join(releaseDir, "offline-games.json"))) {
     throw new Error("Build output contains an unversioned offline manifest");
   }
@@ -1323,6 +1337,49 @@ export async function validateReleaseOutput(
         `Build output has an unscoped release reference in ${relative(releaseDir, path)}: ${reference}`,
       );
     }
+  }
+}
+
+export async function validatePrecacheIntegrity(
+  outputDir: string,
+): Promise<void> {
+  const serviceWorker = join(outputDir, "sw.js");
+  if (!(await isFile(serviceWorker))) {
+    throw new Error("Build output is missing required file: sw.js");
+  }
+  const source = await readFile(serviceWorker, "utf8");
+  const entries = [
+    ...source.matchAll(
+      /\{(?=[^{}]*\bintegrity:"([^"]+)")(?=[^{}]*\burl:"([^"]+)")[^{}]*\}/g,
+    ),
+  ];
+  if (entries.length === 0) {
+    throw new Error("Build output has no integrity-protected precache entries");
+  }
+  let indexEntries = 0;
+  const root = resolve(outputDir);
+  for (const [, integrity, url] of entries) {
+    const relativeUrl = decodeURIComponent(url.split(/[?#]/, 1)[0])
+      .replace(/^\/+/, "")
+      .split("/")
+      .join(sep);
+    const path = resolve(root, relativeUrl);
+    if (path !== root && !path.startsWith(`${root}${sep}`)) {
+      throw new Error(`Precache entry escapes the build output: ${url}`);
+    }
+    if (!(await isFile(path))) {
+      throw new Error(`Precache entry references a missing file: ${url}`);
+    }
+    const actualIntegrity = `sha384-${createHash("sha384")
+      .update(await readFile(path))
+      .digest("base64")}`;
+    if (integrity !== actualIntegrity) {
+      throw new Error(`Precache entry has invalid integrity: ${url}`);
+    }
+    if (url === "index.html") indexEntries += 1;
+  }
+  if (indexEntries !== 1) {
+    throw new Error("Build output must precache index.html exactly once");
   }
 }
 
@@ -1377,9 +1434,9 @@ export async function build({
     await writeOfflineGameManifest(paths, deploymentVersion);
     await writeVersionMetadata(paths, deploymentVersion);
     await versionOfflineGameManifest(paths);
-    await generate(stagingDir, deploymentVersion);
     await validateOutput(stagingDir);
     await assembleReleaseOutput(stagingDir, deploymentVersion);
+    await generate(stagingDir, deploymentVersion);
     await validateReleaseOutput(stagingDir, deploymentVersion);
     await replaceOutput(stagingDir, resolvedOutput);
   } finally {


### PR DESCRIPTION
## Summary

- generate the service worker only after the immutable release layout and final `index.html` exist
- hash release files from their final physical directory and add the root document explicitly
- validate every emitted precache SRI value against the final deployment bytes
- fail the build if `index.html` is missing, duplicated, changed, or has invalid integrity

## Root cause

The build generated `sw.js` before `assembleReleaseOutput()` added the release `<base>` element to `index.html`. The worker contained the hash of the earlier document, so browsers blocked the final document during precaching.

## Validation

- `bun test` — 108 tests pass
- `bun run typecheck`
- `bun run quality`
- complete production build with final precache validation
- production preview smoke test that fetched `index.html` and `sw.js` over HTTP and compared the served document with its emitted SHA-384 value
