### PR TITLE
Keep deep links on the root URL

### DIFF
--- a/site/js/shell/window-manager.js
+++ b/site/js/shell/window-manager.js
@@ -751,7 +751,10 @@ const focusWindow = (gameId) => {
     ? gameId
     : window.XPApplicationRegistry?.get(gameId)?.deepLinkId;
   if (deepLinkId && window.location.hash !== `#${deepLinkId}`) {
-    history.replaceState(null, "", `#${deepLinkId}`);
+    const deepLinkUrl = new URL("/", window.location.origin);
+    deepLinkUrl.search = window.location.search;
+    deepLinkUrl.hash = deepLinkId;
+    history.replaceState(null, "", deepLinkUrl);
   }
 };
 

--- a/tests/solitaire.test.ts
+++ b/tests/solitaire.test.ts
@@ -115,6 +115,19 @@ describe("Windows XP Solitaire through BoxedWine", () => {
     ).not.toBeNull();
   });
 
+  test("keeps the application URL at the origin root with a release base URL", async () => {
+    const shell = await login(await loadShell());
+    const base = shell.document.createElement("base");
+    base.href = "/releases/26.08.12-abcdef1/";
+    shell.document.head.prepend(base);
+    shell.window.history.replaceState(null, "", "/releases/26.08.12-abcdef1/");
+
+    launchSolitaire(shell);
+
+    expect(shell.window.location.pathname).toBe("/");
+    expect(shell.window.location.hash).toBe("#solitaire");
+  });
+
   test("stops the emulator when its window closes", async () => {
     const shell = await login(await loadShell());
     const solitaireWindow = launchSolitaire(shell);


### PR DESCRIPTION
## Summary

- resolve application deep links from the origin root instead of the production release `<base>` URL
- preserve the current query string while setting the application hash
- add a regression test that starts from a versioned release URL and verifies that Solitaire returns to `/#solitaire`

## Root cause

The production document has a versioned `<base>` element. `history.replaceState(..., "#solitaire")` resolved that relative fragment against the base and changed the visible path to `/releases/<version>/#solitaire`.

## Validation

- 109 automated tests pass
- type check, formatting, and lint pass
- all 79 browser JavaScript files validate
- all 42 sourced icons validate
- complete production build passes final artifact validation
- browser test against the production preview:
  - Start → All Programs → Games → Solitaire opens at `/#solitaire`
  - reload keeps `/#solitaire` and reopens Solitaire
  - closing Solitaire returns to `/`
  - no browser console errors
