### PR TITLE
Resolve game assets from release URLs

### DIFF
--- a/site/js/flash-url-router.js
+++ b/site/js/flash-url-router.js
@@ -27,6 +27,7 @@
     games,
     pageUrl = root.location?.href,
     gameRoots = root.ASTRO_GAME_ROOTS || {},
+    assetBaseUrl = root.document?.baseURI || pageUrl,
   ) => {
     if (!pageUrl) throw new Error("Flash URL routing requires a page URL.");
     const routes = new Map();
@@ -68,7 +69,7 @@
           : new URL(request.url);
       const route = routes.get(routeKey(originalUrl, pageUrl));
       if (!route) return null;
-      const localUrl = new URL(route.localPath, pageUrl);
+      const localUrl = new URL(route.localPath, assetBaseUrl);
       localUrl.search = originalUrl.search;
       return { ...route, localUrl, originalUrl };
     };

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -492,7 +492,8 @@
     const absoluteUrl = (url) =>
       new URL(
         url,
-        environment.location?.href ||
+        environment.document?.baseURI ||
+          environment.location?.href ||
           environment.location?.origin ||
           "https://astro.local/",
       ).href;

--- a/site/js/shell/bootstrap.js
+++ b/site/js/shell/bootstrap.js
@@ -7,6 +7,8 @@
 const flashUrlRouter = window.AstroFlashUrlRouter.create(
   window.FLASH_GAMES,
   window.location.href,
+  window.ASTRO_GAME_ROOTS,
+  document.baseURI,
 );
 
 const { fetch: originalFetch } = window;

--- a/site/js/shell/window-manager.js
+++ b/site/js/shell/window-manager.js
@@ -534,7 +534,10 @@ const updateMaximizeButton = (win) => {
 };
 
 const bundledGameRoot = (gameId, type) =>
-  window.ASTRO_GAME_ROOTS?.[gameId] || `${type}/${gameId}/`;
+  new URL(
+    window.ASTRO_GAME_ROOTS?.[gameId] || `${type}/${gameId}/`,
+    document.baseURI,
+  ).href;
 
 const loadRuffleSWF = (gameId, win) => {
   const ruffle = window.RufflePlayer.newest();

--- a/tests/flash-url-router.test.ts
+++ b/tests/flash-url-router.test.ts
@@ -80,10 +80,11 @@ test("Flash URL router maps archived assets into a versioned game package", () =
     },
     pageUrl,
     { example: "swf/example.0123456789abcdef/" },
+    "https://astro.example/releases/26.08.12-abcdef1/",
   );
 
   expect(router.resolve("https://media.example/main.swf")?.localUrl.href).toBe(
-    "https://astro.example/app/swf/example.0123456789abcdef/main.swf",
+    "https://astro.example/releases/26.08.12-abcdef1/swf/example.0123456789abcdef/main.swf",
   );
 });
 

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -173,6 +173,7 @@ test("offline updates", async () => {
   }
 
   const makeEnvironment = ({
+    assetBaseUrl = "https://flash.example/",
     registration = new Registration({
       active: new Worker("activated", manifest.version),
     }),
@@ -225,7 +226,10 @@ test("offline updates", async () => {
         timers.push({ callback, delay });
         return timers.length;
       },
-      document: Object.assign(new Events(), { visibilityState: "visible" }),
+      document: Object.assign(new Events(), {
+        baseURI: assetBaseUrl,
+        visibilityState: "visible",
+      }),
       caches: {
         keys: async () => ["astro-flash-precache", BUNDLED_GAME_CACHE],
         open: async (name) =>
@@ -311,6 +315,22 @@ test("offline updates", async () => {
   ]);
   assert.strictEqual(manager.getSnapshot().downloadedGameBytes, 14);
   assert.strictEqual(initial.bundledCache.values.size, 2);
+
+  const versioned = makeEnvironment({
+    assetBaseUrl: `https://flash.example/releases/${manifest.version}/`,
+  });
+  const versionedManager = createManager({
+    currentVersion: manifest.version,
+    environment: versioned.environment,
+  });
+  await versionedManager.initialize();
+  await versionedManager.downloadGame("bike-mania");
+  assert.strictEqual(
+    versioned.bundledCache.values.has(
+      `https://flash.example/releases/${manifest.version}/swf/bike-mania.bike-1/main.swf`,
+    ),
+    true,
+  );
 
   const bikeUrl = "https://flash.example/swf/bike-mania.bike-1/main.swf";
   await initial.bundledCache.delete(bikeUrl);

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -637,6 +637,26 @@ test("native games open from their public deep links", async () => {
   }
 });
 
+test("bundled iframe deep links use the production release base URL", async () => {
+  const shell = await loadShell();
+  const version = "26.08.12-abcdef1";
+  const gameRoot = "iframe/inside-the-firewall.0123456789abcdef/";
+  const base = shell.document.createElement("base");
+  base.href = `/releases/${version}/`;
+  shell.document.head.prepend(base);
+  shell.window.ASTRO_GAME_ROOTS = {
+    "inside-the-firewall": gameRoot,
+  };
+  shell.window.location.hash = "#inside-the-firewall";
+
+  await login(shell);
+
+  const frame = shell.document.querySelector<HTMLIFrameElement>(
+    '.xp-window[data-game="inside-the-firewall"] iframe',
+  );
+  expect(frame?.src).toBe(`http://127.0.0.1/releases/${version}/${gameRoot}`);
+});
+
 test("placeholder-only applications are not installed or exposed by the shell", async () => {
   const shell = await login(await loadShell());
   const removedApplicationIds = [


### PR DESCRIPTION
## Summary

- resolve archived Flash routes from the immutable release base instead of the visible root URL
- give Ruffle and iframe games absolute versioned package roots
- store optional offline files under the same versioned cache keys used by runtime requests
- add production-base regression coverage for archived routes, iframe deep links, and offline downloads

## Root cause

After the root deep-link fix, `window.location.href` correctly stayed at `/`. The Flash router still used that URL as the base for local archived files, so it requested `/swf/...` while the file existed at `/releases/<version>/swf/...`. Offline downloads also derived cache keys from the visible root URL instead of `document.baseURI`.

## Validation

- 110 tests pass
- type check, formatting, and lint pass
- 79 browser JavaScript files validate
- 42 sourced icons validate
- complete production build passes artifact and precache validation
- production browser verification:
  - Simpsons main SWF, language XML, sound SWF, and score SWF all load from the versioned release
  - Bike Mania loads through the direct bundled-SWF path
  - Inside the Firewall loads from its versioned iframe package
  - affected game launches complete their offline downloads
  - no console errors in the affected game flows
