### PR TITLE
Fix ScummVM release data routing

### DIFF
--- a/site/iframe/scummvm/launcher.js
+++ b/site/iframe/scummvm/launcher.js
@@ -8,6 +8,13 @@
 
   const SCUMMVM_ROOT = "../../vendor/scummvm/2026.3.0/";
   const SCUMMVM_GAME_ROUTE = `/iframe/scummvm/local-games/${game.id}/`;
+  // This is the virtual filesystem root compiled into the ScummVM runtime.
+  // Build it from segments so release URL scoping does not change it.
+  const SCUMMVM_DATA_PATH = ["", "vendor", "scummvm", "2026.3.0", "data"].join(
+    "/",
+  );
+  const SCUMMVM_DATA_ROUTE = `${SCUMMVM_DATA_PATH}/`;
+  const SCUMMVM_DATA_URL = new URL(`${SCUMMVM_ROOT}data/`, location.href);
   const STORAGE_DIRECTORY = "astro-flash-scummvm";
   const MAX_CD_IMAGE_SIZE = 800 * 1024 * 1024;
   const metadataKey = `astro-flash.scummvm.${game.id}.iso.v1`;
@@ -154,6 +161,17 @@
       typeof input === "string" || input instanceof URL ? input : input.url,
       location.href,
     );
+    if (
+      requestUrl.origin === location.origin &&
+      requestUrl.pathname.startsWith(SCUMMVM_DATA_ROUTE)
+    ) {
+      const releaseUrl = new URL(
+        requestUrl.pathname.slice(SCUMMVM_DATA_ROUTE.length),
+        SCUMMVM_DATA_URL,
+      );
+      releaseUrl.search = requestUrl.search;
+      return nativeFetch(releaseUrl, init);
+    }
     if (
       !temporaryIso ||
       !temporaryGameFiles ||
@@ -318,7 +336,7 @@
     setControlsDisabled(true);
     setMessage("Starting ScummVM…");
 
-    const gamePath = `/vendor/scummvm/2026.3.0/data/${game.id}`;
+    const gamePath = `${SCUMMVM_DATA_PATH}/${game.id}`;
     const argumentsHash = encodeURI(`--path=${gamePath} ${game.scummvmId}`);
     history.replaceState(null, "", `${location.pathname}#${argumentsHash}`);
     panel.hidden = true;

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -23,6 +23,7 @@ import {
   installWebtorrent,
   updateHtml,
   validatePrecacheIntegrity,
+  validateReleaseOutput,
   validateOutput,
   versionOfflineGameManifest,
   writeOfflineGameManifest,
@@ -144,6 +145,15 @@ async function makeSource(root: string): Promise<void> {
       '<script src="../../js/storage-policy.js?v=old"></script>',
     "iframe/revcdos/index.html":
       '<script src="../../js/storage-policy.js?v=old"></script>',
+    "iframe/scummvm/launcher.js": [
+      'const route = "/iframe/scummvm/local-games/peril";',
+      'const dataPath = ["", "vendor", "scummvm", "2026.3.0", "data"].join("/");',
+    ].join("\n"),
+    "vendor/scummvm/2026.3.0/data/index.json": JSON.stringify({
+      peril: { baseUrl: "/iframe/scummvm/local-games/peril" },
+      pokus: { baseUrl: "/iframe/scummvm/local-games/pokus" },
+    }),
+    "vendor/scummvm/2026.3.0/scummvm.wasm": "scummvm",
     "dos/doom/doom.jsdos": "jsdos",
   });
 }
@@ -613,6 +623,18 @@ describe("atomic build", () => {
     ).toBeFalse();
     const rootHtml = await readFile(join(output, "index.html"), "utf8");
     expect(rootHtml).toContain('<base href="/releases/26.07.28-abcdef1/" />');
+    const scummvmIndexPath = join(
+      release,
+      "vendor",
+      "scummvm",
+      "2026.3.0",
+      "data",
+      "index.json",
+    );
+    const scummvmIndex = JSON.parse(await readFile(scummvmIndexPath, "utf8"));
+    expect(scummvmIndex.peril.baseUrl).toBe(
+      "/releases/26.07.28-abcdef1/iframe/scummvm/local-games/peril",
+    );
     const metadata = JSON.parse(
       await readFile(join(output, "version.json"), "utf8"),
     );
@@ -620,6 +642,14 @@ describe("atomic build", () => {
     expect(metadata.bundledGameBytes).toBeGreaterThan(0);
     expect(metadata.revision).toBe("abcdef1");
     expect(metadata.version).toBe("26.07.28-abcdef1");
+
+    await writeFile(
+      scummvmIndexPath,
+      '{"peril":{"baseUrl":"/iframe/scummvm/local-games/peril"}}',
+    );
+    await expect(
+      validateReleaseOutput(output, "26.07.28-abcdef1"),
+    ).rejects.toThrow("unscoped release reference");
   });
 
   test("preserves previous output after a failed build", async () => {

--- a/tests/scummvm.test.ts
+++ b/tests/scummvm.test.ts
@@ -145,6 +145,53 @@ test("Pink Panther wrappers execute their game configuration", async () => {
   expect(pokus.releases[508716126]).toBe("Spanish");
 });
 
+test("maps ScummVM's fixed data path to the active release", async () => {
+  const requests: string[] = [];
+  const window = new Window({
+    url: "http://127.0.0.1/releases/test/iframe/passport.hash/",
+    settings: {
+      disableCSSFileLoading: true,
+      disableJavaScriptFileLoading: true,
+      enableJavaScriptEvaluation: true,
+      handleDisabledFileLoadingAsSuccess: true,
+      suppressInsecureJavaScriptEnvironmentWarning: true,
+    },
+  });
+  Object.assign(window, {
+    Array,
+    Object,
+    PINK_GAME: {
+      id: "peril",
+      shellId: "pink-panther-passport-to-peril",
+      title: "The Pink Panther: Passport to Peril",
+    },
+    AstroStoragePolicy: {
+      errorMessage: (error: Error) => error.message,
+      requestPersistence: () => Promise.resolve(),
+    },
+    AstroIso9660: {},
+    fetch: (input: string | URL | Request) => {
+      requests.push(String(input));
+      return Promise.resolve(new Response("{}"));
+    },
+  });
+  const launcher = await Bun.file(
+    new URL("../site/iframe/scummvm/launcher.js", import.meta.url),
+  ).text();
+  const script = window.document.createElement("script");
+  script.textContent = launcher;
+  window.document.body.appendChild(script);
+
+  await window.fetch(
+    "/vendor/scummvm/2026.3.0/data/index.json?runtime=scummvm",
+  );
+
+  expect(requests).toEqual([
+    "http://127.0.0.1/releases/test/vendor/scummvm/2026.3.0/data/index.json?runtime=scummvm",
+  ]);
+  window.close();
+});
+
 test("mounts supported English and Spanish CD images", async () => {
   if (!authorizedCopiesAvailable) return;
   for (const game of games) {

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -212,7 +212,7 @@ export async function scopeReleaseReferences(
     /(["'`(=]\s*)\/(apps|assets|css|dos|iframe|js|swf|vendor)\//g;
   for (const path of await walkFiles(root)) {
     if (
-      ![".css", ".html", ".js", ".mjs"].includes(extname(path)) ||
+      ![".css", ".html", ".js", ".json", ".mjs"].includes(extname(path)) ||
       path.endsWith(`${sep}js${sep}offline-worker.js`)
     ) {
       continue;
@@ -1324,7 +1324,7 @@ export async function validateReleaseOutput(
   }
   for (const path of await walkFiles(releaseDir)) {
     if (
-      ![".css", ".html", ".js", ".mjs"].includes(extname(path)) ||
+      ![".css", ".html", ".js", ".json", ".mjs"].includes(extname(path)) ||
       /offline-worker\.[a-f0-9]{8}\.js$/.test(path)
     ) {
       continue;


### PR DESCRIPTION
## Summary
- keep ScummVM's compiled virtual filesystem path stable while release URLs remain versioned
- route the fixed ScummVM data-index request to the active release
- scope and validate root references inside JSON build artifacts
- add regressions for the runtime route and release JSON

## Verification
- `bun test` (111 passed)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- production build and artifact validation
- browser: Passport to Peril with real English ISO
- browser: Hokus Pokus Pink with real English ISO
- browser: Simpsons archived SWF, Bike Mania direct SWF, Inside the Firewall iframe, and DOOM