### PR TITLE
Simplify settings and update controls

### DIFF
--- a/site/css/apps/programs.css
+++ b/site/css/apps/programs.css
@@ -4439,6 +4439,17 @@
   font-weight: 700;
 }
 
+.project-update-delay {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 8px 20px;
+}
+
+.project-update-delay select {
+  min-width: 150px;
+}
+
 .project-offline-game-list {
   max-height: 156px;
   margin: 0 0 10px;

--- a/site/css/apps/programs.css
+++ b/site/css/apps/programs.css
@@ -4440,14 +4440,25 @@
 }
 
 .project-update-delay {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  display: block;
   margin: 0 0 8px 20px;
 }
 
-.project-update-delay select {
-  min-width: 150px;
+.project-update-delay output {
+  font-weight: 700;
+}
+
+.project-update-delay input[type="range"] {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 8px 0 2px;
+}
+
+.project-update-delay > span {
+  display: flex;
+  justify-content: space-between;
+  color: #555;
 }
 
 .project-offline-game-list {

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -369,6 +369,23 @@
 
     const markWaitingUpdate = async (worker, knownMetadata = null) => {
       if (!worker) return;
+      if (
+        applyTargetVersion === currentVersion &&
+        !state.automaticUpdatesEnabled
+      ) {
+        if ((await requestWorkerVersion(worker)) !== currentVersion) {
+          throw new Error("The downloaded system version is inconsistent.");
+        }
+        applyTargetVersion = null;
+        setState({
+          phase: "ready",
+          workerState: "waiting",
+          updateReady: false,
+          error: null,
+        });
+        worker.postMessage({ type: "SKIP_WAITING" });
+        return true;
+      }
       let metadata = knownMetadata;
       try {
         metadata ||= await fetchVersion();
@@ -489,7 +506,7 @@
       });
     };
 
-    const trackRegistration = (nextRegistration) => {
+    const trackRegistration = (nextRegistration, inspectWaiting = true) => {
       registration = nextRegistration;
       if (trackedRegistrations.has(nextRegistration)) return;
       trackedRegistrations.add(nextRegistration);
@@ -503,6 +520,7 @@
         );
       });
       if (
+        inspectWaiting &&
         nextRegistration.waiting &&
         nextRegistration.active &&
         (state.automaticUpdatesEnabled || applyTargetVersion !== null)
@@ -518,7 +536,7 @@
       }
     };
 
-    const registerAndWait = async (targetVersion) => {
+    const registerAndWait = async (targetVersion, inspectWaiting = true) => {
       if (!navigatorObject.serviceWorker) {
         throw new Error(
           "Offline system files are not supported by this browser.",
@@ -528,7 +546,7 @@
         versionedServiceWorkerUrl(targetVersion),
         { scope: "/", updateViaCache: "none" },
       );
-      trackRegistration(nextRegistration);
+      trackRegistration(nextRegistration, inspectWaiting);
       if (nextRegistration.active) {
         setState({
           phase: nextRegistration.waiting ? "updating" : "ready",
@@ -634,6 +652,9 @@
 
     const cacheEntry = async (id, entry, progress) => {
       const cache = await environment.caches.open(bundledCacheName);
+      if (!state.enabled) {
+        throw new Error("Offline access was disabled.");
+      }
       if (
         records[id]?.revision === entry.revision &&
         Array.isArray(records[id].files) &&
@@ -658,16 +679,22 @@
           if (!response.ok) {
             throw new Error(`Offline download failed (${response.status}).`);
           }
+          if (!state.enabled) {
+            throw new Error("Offline access was disabled.");
+          }
           const url = absoluteUrl(file.url);
           await cache.put(url, response);
           written.push(url);
           loaded += file.bytes;
           progress(file.bytes);
         }
+        if (!state.enabled) {
+          throw new Error("Offline access was disabled.");
+        }
       } catch (error) {
         await Promise.all(
           written
-            .filter((url) => !previousUrls.has(url))
+            .filter((url) => !state.enabled || !previousUrls.has(url))
             .map((url) => cache.delete(url).catch(() => {})),
         );
         throw error;
@@ -680,6 +707,12 @@
           .filter((url) => !nextUrls.has(url))
           .map((url) => cache.delete(url).catch(() => {})),
       );
+      if (!state.enabled) {
+        await Promise.all(
+          written.map((url) => cache.delete(url).catch(() => {})),
+        );
+        throw new Error("Offline access was disabled.");
+      }
       records[id] = {
         bytes: entry.bytes,
         files: entry.files.map((file) => file.url),
@@ -738,11 +771,21 @@
         return snapshot();
       } catch (error) {
         const normalized = storagePolicy.normalizeError(error);
-        setState({
-          gamePhase: "error",
-          activeGameId: null,
-          gameError: normalized.message,
-        });
+        setState(
+          state.enabled
+            ? {
+                gamePhase: "error",
+                activeGameId: null,
+                gameError: normalized.message,
+              }
+            : {
+                gamePhase: "idle",
+                activeGameId: null,
+                gameError: null,
+                gameProgressLoaded: 0,
+                gameProgressTotal: 0,
+              },
+        );
         throw normalized;
       }
     };
@@ -1052,7 +1095,7 @@
       await deleteShellCaches();
       registration = null;
       setState({ phase: "starting", updateReady: false });
-      await checkForUpdates();
+      await checkForUpdates({ applyAutomatically: true, bypassDelay: true });
       return snapshot();
     };
 
@@ -1208,17 +1251,31 @@
       try {
         const existingRegistration =
           await navigatorObject.serviceWorker?.getRegistration?.("/");
-        if (existingRegistration) trackRegistration(existingRegistration);
         if (state.automaticUpdatesEnabled) {
+          if (existingRegistration) trackRegistration(existingRegistration);
           try {
             await checkForUpdates({ applyAutomatically: true });
           } catch (error) {
             if (!existingRegistration) throw error;
             setState({ phase: "ready", workerState: "active", error: null });
           }
+        } else if (
+          existingRegistration?.active &&
+          (await requestWorkerVersion(existingRegistration.active)) ===
+            currentVersion &&
+          workerNeedsVersionedUrl(existingRegistration.active, currentVersion)
+        ) {
+          applyTargetVersion = currentVersion;
+          await registerAndWait(currentVersion, false);
+          if (registration.waiting) {
+            await markWaitingUpdate(registration.waiting);
+          } else if (registration.installing) {
+            trackInstallingWorker(registration.installing, true);
+          }
         } else if (!existingRegistration) {
           await registerAndWait(currentVersion);
         } else {
+          trackRegistration(existingRegistration, false);
           setState({ phase: "ready", workerState: "active", error: null });
         }
         await loadGameManifest();

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -18,6 +18,9 @@
   const GAME_RECORDS_KEY = "astroFlashOfflineGameRecords";
   const ACTIVE_VERSION_RELOAD_KEY = "astroFlashActiveVersionReload";
   const AUTOMATIC_UPDATE_DELAY_KEY = "astroFlashAutomaticUpdateDelay";
+  const OFFLINE_ENABLED_KEY = "astroFlashOfflineEnabled";
+  const SAVE_PLAYED_GAMES_KEY = "astroFlashSavePlayedGamesOffline";
+  const AUTOMATIC_UPDATES_KEY = "astroFlashAutomaticUpdatesEnabled";
   const BUNDLED_GAME_CACHE = "astro-bundled-games-v1";
   const DEFAULT_CHECK_INTERVAL = 60 * 60 * 1000;
   const UPDATE_RETRY_DELAY = 30 * 1000;
@@ -175,6 +178,12 @@
     };
 
     const scheduleUpdateRetry = () => {
+      if (
+        !state.enabled ||
+        (!state.automaticUpdatesEnabled && applyTargetVersion === null)
+      ) {
+        return;
+      }
       if (updateRetryTimer !== null) return;
       updateRetryTimer = (environment.setTimeout || setTimeout)(() => {
         updateRetryTimer = null;
@@ -187,6 +196,10 @@
     };
 
     const scheduleAutomaticUpdate = (eligibleAt) => {
+      if (!state.enabled || !state.automaticUpdatesEnabled) {
+        cancelAutomaticUpdate();
+        return;
+      }
       if (automaticUpdateTimer !== null) {
         (environment.clearTimeout || clearTimeout)(automaticUpdateTimer);
       }
@@ -214,6 +227,12 @@
       if (automaticUpdateTimer === null) return;
       (environment.clearTimeout || clearTimeout)(automaticUpdateTimer);
       automaticUpdateTimer = null;
+    };
+
+    const cancelUpdateRetry = () => {
+      if (updateRetryTimer === null) return;
+      (environment.clearTimeout || clearTimeout)(updateRetryTimer);
+      updateRetryTimer = null;
     };
 
     const requestWorkerVersion = (worker) =>
@@ -251,10 +270,13 @@
       AUTOMATIC_UPDATE_DELAY_KEY,
     );
     const savedAutomaticUpdateDelay = Number(savedAutomaticUpdateDelayValue);
+    const settingEnabled = (key) => storage.getItem(key) !== "false";
     let state = {
-      enabled: true,
+      enabled: settingEnabled(OFFLINE_ENABLED_KEY),
+      savePlayedGamesOffline: settingEnabled(SAVE_PLAYED_GAMES_KEY),
+      automaticUpdatesEnabled: settingEnabled(AUTOMATIC_UPDATES_KEY),
       online: navigatorObject.onLine !== false,
-      phase: "starting",
+      phase: settingEnabled(OFFLINE_ENABLED_KEY) ? "starting" : "disabled",
       currentVersion,
       availableVersion: null,
       availableRevision: null,
@@ -444,6 +466,7 @@
         error: null,
       });
       worker.addEventListener("statechange", () => {
+        if (!state.enabled) return;
         setState({ workerState: worker.state });
         if (worker.state === "installed" && isUpdate) {
           (environment.setTimeout || setTimeout)(() => {
@@ -471,6 +494,7 @@
       if (trackedRegistrations.has(nextRegistration)) return;
       trackedRegistrations.add(nextRegistration);
       nextRegistration.addEventListener("updatefound", () => {
+        if (!state.enabled) return;
         trackInstallingWorker(
           nextRegistration.installing,
           Boolean(
@@ -478,7 +502,11 @@
           ),
         );
       });
-      if (nextRegistration.waiting && nextRegistration.active) {
+      if (
+        nextRegistration.waiting &&
+        nextRegistration.active &&
+        (state.automaticUpdatesEnabled || applyTargetVersion !== null)
+      ) {
         void markWaitingUpdate(nextRegistration.waiting);
       } else if (nextRegistration.installing) {
         trackInstallingWorker(
@@ -664,6 +692,9 @@
     };
 
     const downloadGame = async (id) => {
+      if (!state.enabled) {
+        throw new Error("Enable offline access to download built-in games.");
+      }
       const currentManifest = await ensureManifest();
       const entry = currentManifest.games[id];
       if (!entry) throw new Error("This bundled game is unavailable.");
@@ -764,6 +795,9 @@
     };
 
     const downloadAllGames = async () => {
+      if (!state.enabled) {
+        throw new Error("Enable offline access to download built-in games.");
+      }
       const currentManifest = await ensureManifest();
       for (const id of Object.keys(currentManifest.games)) {
         if (records[id]?.revision !== currentManifest.games[id].revision) {
@@ -820,12 +854,21 @@
       applyAutomatically = false,
       bypassDelay = false,
     } = {}) => {
+      if (!state.enabled) {
+        throw new Error("Enable offline access to use offline updates.");
+      }
       if (checkPromise) return checkPromise;
       checkPromise = (async () => {
         const previousPhase = state.phase;
         setState({ phase: "checking", error: null });
         try {
           const metadata = await fetchVersion();
+          if (!state.enabled) {
+            throw new Error("Offline access was disabled.");
+          }
+          const automaticApplicationAllowed =
+            applyAutomatically &&
+            (state.automaticUpdatesEnabled || bypassDelay);
           rememberVersionMetadata(metadata);
           if (applyTargetVersion && applyTargetVersion !== metadata.version) {
             applyTargetVersion = null;
@@ -846,9 +889,13 @@
             workerNeedsVersionedUrl(registration?.active, metadata.version);
           if (updateAvailable && !bypassDelay && checkedAt < eligibleAt) {
             applyTargetVersion = null;
-            scheduleAutomaticUpdate(eligibleAt);
+            if (state.automaticUpdatesEnabled) {
+              scheduleAutomaticUpdate(eligibleAt);
+            }
             setState({
-              phase: "update-pending",
+              phase: state.automaticUpdatesEnabled
+                ? "update-pending"
+                : "update-available",
               availableVersion: metadata.version,
               availableRevision: metadata.revision,
               lastChecked: checkedAt,
@@ -858,7 +905,11 @@
             });
             return snapshot();
           }
-          if (!updateAvailable || applyAutomatically || migrateActiveWorker) {
+          if (
+            !updateAvailable ||
+            automaticApplicationAllowed ||
+            migrateActiveWorker
+          ) {
             cancelAutomaticUpdate();
           }
           if (
@@ -869,7 +920,7 @@
             setState({ lastChecked: checkedAt });
             return snapshot();
           }
-          if (updateAvailable && !applyAutomatically) {
+          if (updateAvailable && !automaticApplicationAllowed) {
             setState({
               phase: "update-available",
               availableVersion: metadata.version,
@@ -881,7 +932,10 @@
             });
             return snapshot();
           }
-          if ((applyAutomatically && updateAvailable) || migrateActiveWorker) {
+          if (
+            (automaticApplicationAllowed && updateAvailable) ||
+            migrateActiveWorker
+          ) {
             applyTargetVersion = metadata.version;
           }
           await registerAndWait(metadata.version);
@@ -983,6 +1037,9 @@
     };
 
     const repair = async () => {
+      if (!state.enabled) {
+        throw new Error("Enable offline access before repairing system files.");
+      }
       if (navigatorObject.onLine === false) {
         throw new Error("Connect to the internet to repair system files.");
       }
@@ -996,6 +1053,78 @@
       registration = null;
       setState({ phase: "starting", updateReady: false });
       await checkForUpdates();
+      return snapshot();
+    };
+
+    const setOfflineEnabled = async (enabled) => {
+      if (typeof enabled !== "boolean") {
+        throw new Error("The offline access setting is invalid.");
+      }
+      storage.setItem(OFFLINE_ENABLED_KEY, String(enabled));
+      if (enabled === state.enabled) return snapshot();
+      if (enabled) {
+        setState({ enabled: true, phase: "starting", error: null });
+        return initialize();
+      }
+
+      setState({ enabled: false, phase: "disabling", error: null });
+      applyTargetVersion = null;
+      reloadWhenControlled = false;
+      cancelAutomaticUpdate();
+      cancelUpdateRetry();
+      try {
+        if (checkPromise) await checkPromise.catch(() => {});
+        const currentRegistration =
+          registration ||
+          (await navigatorObject.serviceWorker?.getRegistration?.("/"));
+        if (currentRegistration) await currentRegistration.unregister();
+        await deleteShellCaches();
+        await environment.caches?.delete(bundledCacheName);
+        for (const id of Object.keys(records)) delete records[id];
+        persistRecords();
+        registration = null;
+        manifest = null;
+        setState({
+          phase: "disabled",
+          workerState: "unregistered",
+          bundledGames: [],
+          updateReady: false,
+          availableVersion: null,
+          availableRevision: null,
+          updateEligibleAt: null,
+          gamePhase: "idle",
+          error: null,
+        });
+        await refreshStorageEstimate();
+        return snapshot();
+      } catch (error) {
+        setState({ phase: "disabled", error: error.message });
+        throw error;
+      }
+    };
+
+    const setSavePlayedGamesOffline = (enabled) => {
+      if (typeof enabled !== "boolean") {
+        throw new Error("The automatic game download setting is invalid.");
+      }
+      storage.setItem(SAVE_PLAYED_GAMES_KEY, String(enabled));
+      setState({ savePlayedGamesOffline: enabled });
+      return snapshot();
+    };
+
+    const setAutomaticUpdatesEnabled = (enabled) => {
+      if (typeof enabled !== "boolean") {
+        throw new Error("The automatic update setting is invalid.");
+      }
+      storage.setItem(AUTOMATIC_UPDATES_KEY, String(enabled));
+      setState({ automaticUpdatesEnabled: enabled });
+      if (!enabled) {
+        applyTargetVersion = null;
+        cancelAutomaticUpdate();
+        cancelUpdateRetry();
+      } else if (state.enabled) {
+        void checkForUpdates({ applyAutomatically: true }).catch(() => {});
+      }
       return snapshot();
     };
 
@@ -1021,6 +1150,8 @@
         state.updateEligibleAt !== null &&
         environment.Date.now() >= state.updateEligibleAt;
       if (
+        !state.enabled ||
+        !state.automaticUpdatesEnabled ||
         navigatorObject.onLine === false ||
         (!automaticUpdateIsDue &&
           state.lastChecked &&
@@ -1056,14 +1187,38 @@
     const initialize = async () => {
       attachLifecycleListeners();
       await refreshStorageEstimate();
+      if (!state.enabled) {
+        const existingRegistration =
+          await navigatorObject.serviceWorker?.getRegistration?.("/");
+        if (existingRegistration) await existingRegistration.unregister();
+        await deleteShellCaches();
+        await environment.caches?.delete(bundledCacheName);
+        for (const id of Object.keys(records)) delete records[id];
+        persistRecords();
+        registration = null;
+        manifest = null;
+        setState({
+          phase: "disabled",
+          workerState: "unregistered",
+          bundledGames: [],
+          error: null,
+        });
+        return snapshot();
+      }
       try {
         const existingRegistration =
           await navigatorObject.serviceWorker?.getRegistration?.("/");
         if (existingRegistration) trackRegistration(existingRegistration);
-        try {
-          await checkForUpdates({ applyAutomatically: true });
-        } catch (error) {
-          if (!existingRegistration) throw error;
+        if (state.automaticUpdatesEnabled) {
+          try {
+            await checkForUpdates({ applyAutomatically: true });
+          } catch (error) {
+            if (!existingRegistration) throw error;
+            setState({ phase: "ready", workerState: "active", error: null });
+          }
+        } else if (!existingRegistration) {
+          await registerAndWait(currentVersion);
+        } else {
           setState({ phase: "ready", workerState: "active", error: null });
         }
         await loadGameManifest();
@@ -1095,7 +1250,10 @@
       removeAllGames,
       removeGame,
       repair,
+      setAutomaticUpdatesEnabled,
       setAutomaticUpdateDelay,
+      setOfflineEnabled,
+      setSavePlayedGamesOffline,
       subscribe,
       updateNow,
     };

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -139,6 +139,7 @@
     let reloadWhenControlled = false;
     let lifecycleListenersAttached = false;
     let updateRetryTimer = null;
+    let automaticUpdateTimer = null;
     let bypassWorkerCdn = false;
     let applyTargetVersion = null;
 
@@ -183,6 +184,36 @@
           bypassDelay: shouldApply,
         }).catch(() => {});
       }, UPDATE_RETRY_DELAY);
+    };
+
+    const scheduleAutomaticUpdate = (eligibleAt) => {
+      if (automaticUpdateTimer !== null) {
+        (environment.clearTimeout || clearTimeout)(automaticUpdateTimer);
+      }
+      const delay = Math.max(0, eligibleAt - environment.Date.now());
+      automaticUpdateTimer = (environment.setTimeout || setTimeout)(
+        () => {
+          automaticUpdateTimer = null;
+          if (environment.Date.now() < eligibleAt) {
+            scheduleAutomaticUpdate(eligibleAt);
+            return;
+          }
+          void checkForUpdates({ applyAutomatically: true }).catch(() => {
+            if (navigatorObject.onLine !== false) {
+              scheduleAutomaticUpdate(
+                environment.Date.now() + UPDATE_RETRY_DELAY,
+              );
+            }
+          });
+        },
+        Math.min(delay, 2_147_483_647),
+      );
+    };
+
+    const cancelAutomaticUpdate = () => {
+      if (automaticUpdateTimer === null) return;
+      (environment.clearTimeout || clearTimeout)(automaticUpdateTimer);
+      automaticUpdateTimer = null;
     };
 
     const requestWorkerVersion = (worker) =>
@@ -813,6 +844,7 @@
             workerNeedsVersionedUrl(registration?.active, metadata.version);
           if (updateAvailable && !bypassDelay && checkedAt < eligibleAt) {
             applyTargetVersion = null;
+            scheduleAutomaticUpdate(eligibleAt);
             setState({
               phase: "update-pending",
               availableVersion: metadata.version,
@@ -823,6 +855,9 @@
               error: null,
             });
             return snapshot();
+          }
+          if (!updateAvailable || applyAutomatically || migrateActiveWorker) {
+            cancelAutomaticUpdate();
           }
           if (
             updateAvailable &&
@@ -980,9 +1015,13 @@
       checkForUpdates({ applyAutomatically: true, bypassDelay: true });
 
     const automaticCheck = () => {
+      const automaticUpdateIsDue =
+        state.updateEligibleAt !== null &&
+        environment.Date.now() >= state.updateEligibleAt;
       if (
         navigatorObject.onLine === false ||
-        (state.lastChecked &&
+        (!automaticUpdateIsDue &&
+          state.lastChecked &&
           environment.Date.now() - state.lastChecked < checkInterval)
       ) {
         return;

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -265,6 +265,7 @@
         savedAutomaticUpdateDelay >= 0
           ? savedAutomaticUpdateDelay
           : null,
+      releaseUpdateDelayMs: null,
       downloadBytes: cachedDownloadBytes,
       bundledGameBytes: null,
       downloadMetadataError: false,
@@ -333,6 +334,7 @@
       setState({
         downloadBytes: metadata.offlineBytes,
         bundledGameBytes: metadata.bundledGameBytes,
+        releaseUpdateDelayMs: metadata.stabilityDelayMs,
         downloadMetadataError: false,
       });
     };

--- a/site/js/offline.js
+++ b/site/js/offline.js
@@ -17,6 +17,7 @@
   const DOWNLOAD_BYTES_KEY = "astroFlashDownloadBytes";
   const GAME_RECORDS_KEY = "astroFlashOfflineGameRecords";
   const ACTIVE_VERSION_RELOAD_KEY = "astroFlashActiveVersionReload";
+  const AUTOMATIC_UPDATE_DELAY_KEY = "astroFlashAutomaticUpdateDelay";
   const BUNDLED_GAME_CACHE = "astro-bundled-games-v1";
   const DEFAULT_CHECK_INTERVAL = 60 * 60 * 1000;
   const UPDATE_RETRY_DELAY = 30 * 1000;
@@ -118,7 +119,7 @@
   const createManager = ({
     currentVersion,
     environment = globalThis,
-    serviceWorkerUrl = "/sw.js",
+    serviceWorkerUrl = "/sw.{version}.js",
     versionUrl = "/version.json",
     gameManifestUrl = "offline-games.json",
     cachePrefix = "astro-flash",
@@ -139,9 +140,18 @@
     let lifecycleListenersAttached = false;
     let updateRetryTimer = null;
     let bypassWorkerCdn = false;
-    let automaticTargetVersion = null;
+    let applyTargetVersion = null;
 
     const versionedServiceWorkerUrl = (version) => {
+      if (serviceWorkerUrl.includes("{version}")) {
+        const versionedUrl = serviceWorkerUrl.replace(
+          "{version}",
+          encodeURIComponent(version),
+        );
+        return bypassWorkerCdn
+          ? `${versionedUrl}?retry=${environment.Date.now()}`
+          : versionedUrl;
+      }
       const separator = serviceWorkerUrl.includes("?") ? "&" : "?";
       const versionedUrl = `${serviceWorkerUrl}${separator}v=${encodeURIComponent(version)}`;
       return bypassWorkerCdn
@@ -149,11 +159,29 @@
         : versionedUrl;
     };
 
+    const workerNeedsVersionedUrl = (worker, version) => {
+      if (!worker?.scriptURL || !serviceWorkerUrl.includes("{version}")) {
+        return false;
+      }
+      const expected = new URL(
+        serviceWorkerUrl.replace("{version}", encodeURIComponent(version)),
+        environment.location.href,
+      );
+      return (
+        new URL(worker.scriptURL, environment.location.href).pathname !==
+        expected.pathname
+      );
+    };
+
     const scheduleUpdateRetry = () => {
       if (updateRetryTimer !== null) return;
       updateRetryTimer = (environment.setTimeout || setTimeout)(() => {
         updateRetryTimer = null;
-        void checkForUpdates().catch(() => {});
+        const shouldApply = applyTargetVersion !== null;
+        void checkForUpdates({
+          applyAutomatically: shouldApply,
+          bypassDelay: shouldApply,
+        }).catch(() => {});
       }, UPDATE_RETRY_DELAY);
     };
 
@@ -188,6 +216,10 @@
       storage.getItem(DOWNLOAD_VERSION_KEY) === currentVersion
         ? Number(storage.getItem(DOWNLOAD_BYTES_KEY)) || null
         : null;
+    const savedAutomaticUpdateDelayValue = storage.getItem(
+      AUTOMATIC_UPDATE_DELAY_KEY,
+    );
+    const savedAutomaticUpdateDelay = Number(savedAutomaticUpdateDelayValue);
     let state = {
       enabled: true,
       online: navigatorObject.onLine !== false,
@@ -196,6 +228,12 @@
       availableVersion: null,
       availableRevision: null,
       updateEligibleAt: null,
+      automaticUpdateDelayMs:
+        savedAutomaticUpdateDelayValue !== null &&
+        Number.isInteger(savedAutomaticUpdateDelay) &&
+        savedAutomaticUpdateDelay >= 0
+          ? savedAutomaticUpdateDelay
+          : null,
       downloadBytes: cachedDownloadBytes,
       bundledGameBytes: null,
       downloadMetadataError: false,
@@ -268,8 +306,11 @@
       });
     };
 
+    const automaticUpdateDelay = (metadata) =>
+      state.automaticUpdateDelayMs ?? metadata.stabilityDelayMs;
+
     const updateEligibleAt = (metadata) =>
-      Date.parse(metadata.releasedAt) + metadata.stabilityDelayMs;
+      Date.parse(metadata.releasedAt) + automaticUpdateDelay(metadata);
 
     const markWaitingUpdate = async (worker, knownMetadata = null) => {
       if (!worker) return;
@@ -282,10 +323,10 @@
         return false;
       }
       const eligibleAt = updateEligibleAt(metadata);
-      if (environment.Date.now() < eligibleAt) {
-        if (automaticTargetVersion === metadata.version) {
-          automaticTargetVersion = null;
-        }
+      if (
+        environment.Date.now() < eligibleAt &&
+        applyTargetVersion !== metadata.version
+      ) {
         setState({
           phase: "update-pending",
           updateReady: false,
@@ -325,8 +366,8 @@
         downloadBytes: metadata?.offlineBytes || state.downloadBytes,
         error: null,
       });
-      if (automaticTargetVersion === metadata.version) {
-        automaticTargetVersion = null;
+      if (applyTargetVersion === metadata.version) {
+        applyTargetVersion = null;
         await applyUpdate();
       }
       return true;
@@ -742,7 +783,10 @@
       }
     };
 
-    const checkForUpdates = async ({ applyAutomatically = false } = {}) => {
+    const checkForUpdates = async ({
+      applyAutomatically = false,
+      bypassDelay = false,
+    } = {}) => {
       if (checkPromise) return checkPromise;
       checkPromise = (async () => {
         const previousPhase = state.phase;
@@ -750,11 +794,8 @@
         try {
           const metadata = await fetchVersion();
           rememberVersionMetadata(metadata);
-          if (
-            automaticTargetVersion &&
-            automaticTargetVersion !== metadata.version
-          ) {
-            automaticTargetVersion = null;
+          if (applyTargetVersion && applyTargetVersion !== metadata.version) {
+            applyTargetVersion = null;
           }
           const checkedAt = environment.Date.now();
           storage.setItem(LAST_CHECKED_KEY, String(checkedAt));
@@ -766,8 +807,12 @@
             (activeWorkerVersion !== null &&
               activeWorkerVersion !== metadata.version);
           const eligibleAt = updateEligibleAt(metadata);
-          if (updateAvailable && checkedAt < eligibleAt) {
-            automaticTargetVersion = null;
+          const migrateActiveWorker =
+            !updateAvailable &&
+            activeWorkerVersion === metadata.version &&
+            workerNeedsVersionedUrl(registration?.active, metadata.version);
+          if (updateAvailable && !bypassDelay && checkedAt < eligibleAt) {
+            applyTargetVersion = null;
             setState({
               phase: "update-pending",
               availableVersion: metadata.version,
@@ -779,8 +824,28 @@
             });
             return snapshot();
           }
-          if (applyAutomatically && updateAvailable) {
-            automaticTargetVersion = metadata.version;
+          if (
+            updateAvailable &&
+            activeWorkerVersion === metadata.version &&
+            (await reconcileActiveVersion(metadata.version))
+          ) {
+            setState({ lastChecked: checkedAt });
+            return snapshot();
+          }
+          if (updateAvailable && !applyAutomatically) {
+            setState({
+              phase: "update-available",
+              availableVersion: metadata.version,
+              availableRevision: metadata.revision,
+              lastChecked: checkedAt,
+              updateEligibleAt: eligibleAt,
+              updateReady: false,
+              error: null,
+            });
+            return snapshot();
+          }
+          if ((applyAutomatically && updateAvailable) || migrateActiveWorker) {
+            applyTargetVersion = metadata.version;
           }
           await registerAndWait(metadata.version);
           let waitingUpdateReady = false;
@@ -830,6 +895,9 @@
                 : "unregistered",
             error: null,
           });
+          if (!registration?.waiting && !registration?.installing) {
+            applyTargetVersion = null;
+          }
         } catch (error) {
           setState({
             phase: previousPhase === "ready" ? "ready" : "error",
@@ -894,6 +962,23 @@
       return snapshot();
     };
 
+    const setAutomaticUpdateDelay = (delay) => {
+      if (delay === null) {
+        storage.removeItem(AUTOMATIC_UPDATE_DELAY_KEY);
+        setState({ automaticUpdateDelayMs: null });
+        return snapshot();
+      }
+      if (!Number.isInteger(delay) || delay < 0) {
+        throw new Error("The automatic update delay is invalid.");
+      }
+      storage.setItem(AUTOMATIC_UPDATE_DELAY_KEY, String(delay));
+      setState({ automaticUpdateDelayMs: delay });
+      return snapshot();
+    };
+
+    const updateNow = () =>
+      checkForUpdates({ applyAutomatically: true, bypassDelay: true });
+
     const automaticCheck = () => {
       if (
         navigatorObject.onLine === false ||
@@ -902,7 +987,7 @@
       ) {
         return;
       }
-      void checkForUpdates().catch(() => {});
+      void checkForUpdates({ applyAutomatically: true }).catch(() => {});
     };
 
     const attachLifecycleListeners = () => {
@@ -969,7 +1054,9 @@
       removeAllGames,
       removeGame,
       repair,
+      setAutomaticUpdateDelay,
       subscribe,
+      updateNow,
     };
   };
 

--- a/site/js/shell/system-tray.js
+++ b/site/js/shell/system-tray.js
@@ -642,10 +642,12 @@ const wireProjectSettings = (win) => {
     } else {
       gameDownloadProgress.removeAttribute("value");
     }
+    const gameBusy = ["downloading", "removing"].includes(state.gamePhase);
     offlineEnabledCheckbox.checked = state.enabled;
     savePlayedGamesCheckbox.checked = state.savePlayedGamesOffline;
     automaticUpdatesCheckbox.checked = state.automaticUpdatesEnabled;
-    offlineEnabledCheckbox.disabled = transientPhases.has(state.phase);
+    offlineEnabledCheckbox.disabled =
+      gameBusy || transientPhases.has(state.phase);
     savePlayedGamesCheckbox.disabled =
       !state.enabled || transientPhases.has(state.phase);
     automaticUpdatesCheckbox.disabled =
@@ -671,7 +673,6 @@ const wireProjectSettings = (win) => {
     updateDelayOutput.value = formatAutomaticUpdateDelay(automaticUpdateDelay);
     repairButton.disabled =
       !state.enabled || !state.online || transientPhases.has(state.phase);
-    const gameBusy = ["downloading", "removing"].includes(state.gamePhase);
     downloadAllGamesButton.disabled =
       !state.online ||
       !state.enabled ||

--- a/site/js/shell/system-tray.js
+++ b/site/js/shell/system-tray.js
@@ -158,6 +158,22 @@ const offlineStatusText = (state) => {
 const formatUpdateCheckTime = (timestamp) =>
   timestamp ? new Date(timestamp).toLocaleString() : "Never";
 
+const UPDATE_DELAY_HOUR = 60 * 60 * 1000;
+const formatAutomaticUpdateDelay = (delayMs) => {
+  const hours = Math.round(delayMs / UPDATE_DELAY_HOUR);
+  if (hours === 0) return "No delay";
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return [
+    days ? `${days} ${days === 1 ? "day" : "days"}` : "",
+    remainingHours
+      ? `${remainingHours} ${remainingHours === 1 ? "hour" : "hours"}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+};
+
 const formatProjectBytes = (bytes) =>
   XPDialogs.formatBytes(bytes).replace(/\s+\([^)]*\)$/, "");
 
@@ -264,16 +280,9 @@ const wireProjectSettings = (win) => {
       <fieldset>
         <legend>Automatic updates</legend>
         <p class="project-settings-description">Astro Flash checks for updates automatically. It waits for the selected time before it downloads and applies a new release.</p>
-        <label class="project-update-delay">Wait before automatic update:
-          <select data-project-setting="update-delay">
-            <option value="">Use release default</option>
-            <option value="0">Do not wait</option>
-            <option value="3600000">1 hour</option>
-            <option value="21600000">6 hours</option>
-            <option value="43200000">12 hours</option>
-            <option value="86400000">1 day</option>
-            <option value="259200000">3 days</option>
-          </select>
+        <label class="project-update-delay">Wait before automatic update: <output data-project-value="update-delay">6 hours</output>
+          <input type="range" min="0" max="72" step="1" value="6" data-project-setting="update-delay">
+          <span><span>No delay</span><span>3 days</span></span>
         </label>
       </fieldset>
       <fieldset>
@@ -339,9 +348,10 @@ const wireProjectSettings = (win) => {
   const updateNowButton = content.querySelector(
     '[data-project-action="update-now"]',
   );
-  const updateDelaySelect = content.querySelector(
+  const updateDelayInput = content.querySelector(
     '[data-project-setting="update-delay"]',
   );
+  const updateDelayOutput = value("update-delay");
   const repairButton = content.querySelector('[data-project-action="repair"]');
   const downloadAllGamesButton = content.querySelector(
     '[data-project-action="download-all-games"]',
@@ -610,11 +620,18 @@ const wireProjectSettings = (win) => {
     checkButton.disabled = !state.online || transientPhases.has(state.phase);
     updateNowButton.disabled =
       !state.online || transientPhases.has(state.phase);
-    updateDelaySelect.disabled = transientPhases.has(state.phase);
-    updateDelaySelect.value =
-      state.automaticUpdateDelayMs === null
-        ? ""
-        : String(state.automaticUpdateDelayMs);
+    updateDelayInput.disabled = transientPhases.has(state.phase);
+    const automaticUpdateDelay =
+      state.automaticUpdateDelayMs ??
+      state.releaseUpdateDelayMs ??
+      6 * UPDATE_DELAY_HOUR;
+    updateDelayInput.value = String(
+      Math.min(
+        72,
+        Math.max(0, Math.round(automaticUpdateDelay / UPDATE_DELAY_HOUR)),
+      ),
+    );
+    updateDelayOutput.value = formatAutomaticUpdateDelay(automaticUpdateDelay);
     repairButton.disabled = !state.online || transientPhases.has(state.phase);
     const gameBusy = ["downloading", "removing"].includes(state.gamePhase);
     downloadAllGamesButton.disabled =
@@ -657,10 +674,13 @@ const wireProjectSettings = (win) => {
   updateNowButton.addEventListener("click", () => {
     offlineManager.updateNow().catch(() => {});
   });
-  updateDelaySelect.addEventListener("change", () => {
-    const delay = updateDelaySelect.value
-      ? Number(updateDelaySelect.value)
-      : null;
+  updateDelayInput.addEventListener("input", () => {
+    updateDelayOutput.value = formatAutomaticUpdateDelay(
+      Number(updateDelayInput.value) * UPDATE_DELAY_HOUR,
+    );
+  });
+  updateDelayInput.addEventListener("change", () => {
+    const delay = Number(updateDelayInput.value) * UPDATE_DELAY_HOUR;
     offlineManager.setAutomaticUpdateDelay(delay);
     offlineManager
       .checkForUpdates({ applyAutomatically: true })

--- a/site/js/shell/system-tray.js
+++ b/site/js/shell/system-tray.js
@@ -207,6 +207,7 @@ const saveBundledGameForOffline = (gameId) => {
     .then(async () => {
       await offlineManagerInitialization;
       const snapshot = offlineManager.getSnapshot();
+      if (!snapshot.enabled || !snapshot.savePlayedGamesOffline) return;
       if (!snapshot.bundledGames.some((game) => game.id === gameId)) {
         return;
       }
@@ -244,6 +245,7 @@ const wireProjectSettings = (win) => {
       </div>
       <fieldset>
         <legend>Offline access</legend>
+        <label class="project-offline-setting"><input type="checkbox" data-project-setting="offline-enabled" checked> Keep Astro Flash available offline</label>
         <p class="project-settings-description">Astro Flash saves its system files automatically so the desktop can start without an internet connection.</p>
         <dl class="dlg-props-table project-settings-details">
           <dt>Status:</dt><dd data-project-value="offlineFiles"></dd>
@@ -259,6 +261,7 @@ const wireProjectSettings = (win) => {
     <section class="project-settings-panel" id="project-panel-games" role="tabpanel" aria-labelledby="project-tab-games" hidden>
       <fieldset>
         <legend>Built-in games for offline play</legend>
+        <label class="project-offline-setting"><input type="checkbox" data-project-setting="save-played-games" checked> Automatically save built-in games after I play them</label>
         <p class="project-settings-description">Built-in games come with Astro Flash. Select the games that you want to use without an internet connection.</p>
         <p><strong data-project-value="offlineGames"></strong> built-in games are available offline and use <strong data-project-value="offlineGameStorage"></strong>.</p>
         <div class="project-offline-game-list" data-project-offline-games role="group" aria-label="Built-in games available offline"></div>
@@ -279,6 +282,7 @@ const wireProjectSettings = (win) => {
     <section class="project-settings-panel" id="project-panel-updates" role="tabpanel" aria-labelledby="project-tab-updates" hidden>
       <fieldset>
         <legend>Automatic updates</legend>
+        <label class="project-offline-setting"><input type="checkbox" data-project-setting="automatic-updates" checked> Download and apply updates automatically</label>
         <p class="project-settings-description">Astro Flash checks for updates automatically. It waits for the selected time before it downloads and applies a new release.</p>
         <label class="project-update-delay">Wait before automatic update: <output data-project-value="update-delay">6 hours</output>
           <input type="range" min="0" max="72" step="1" value="6" data-project-setting="update-delay">
@@ -352,6 +356,15 @@ const wireProjectSettings = (win) => {
     '[data-project-setting="update-delay"]',
   );
   const updateDelayOutput = value("update-delay");
+  const offlineEnabledCheckbox = content.querySelector(
+    '[data-project-setting="offline-enabled"]',
+  );
+  const savePlayedGamesCheckbox = content.querySelector(
+    '[data-project-setting="save-played-games"]',
+  );
+  const automaticUpdatesCheckbox = content.querySelector(
+    '[data-project-setting="automatic-updates"]',
+  );
   const repairButton = content.querySelector('[data-project-action="repair"]');
   const downloadAllGamesButton = content.querySelector(
     '[data-project-action="download-all-games"]',
@@ -406,6 +419,7 @@ const wireProjectSettings = (win) => {
     "updating",
     "applying",
     "repairing",
+    "disabling",
   ]);
   let offlineListSignature = "";
   let gameDataRefresh = 0;
@@ -501,6 +515,7 @@ const wireProjectSettings = (win) => {
         downloaded.has(game.id),
       ]),
       busy,
+      state.enabled,
       state.activeGameId,
     ]);
     if (signature === offlineListSignature) return;
@@ -509,7 +524,9 @@ const wireProjectSettings = (win) => {
     if (!state.bundledGames.length) {
       const empty = document.createElement("p");
       empty.className = "project-settings-description";
-      empty.textContent = "Loading the built-in game list...";
+      empty.textContent = state.enabled
+        ? "Loading the built-in game list..."
+        : "Enable offline access to select built-in games.";
       offlineGamesList.appendChild(empty);
       return;
     }
@@ -525,7 +542,7 @@ const wireProjectSettings = (win) => {
       const checkbox = document.createElement("input");
       checkbox.type = "checkbox";
       checkbox.checked = downloaded.has(game.id);
-      checkbox.disabled = busy;
+      checkbox.disabled = busy || !state.enabled;
       checkbox.dataset.offlineGame = game.id;
       const title = document.createElement("span");
       title.textContent = gamesList[game.id]?.title || formatGameTitle(game.id);
@@ -564,8 +581,9 @@ const wireProjectSettings = (win) => {
     value("connection").textContent = state.online
       ? "Connected to the internet"
       : "Working offline";
-    value("offlineFiles").textContent =
-      state.workerState === "active"
+    value("offlineFiles").textContent = !state.enabled
+      ? "Disabled"
+      : state.workerState === "active"
         ? "Ready for offline use"
         : formatProjectState(state.workerState);
     value("offlineGames").textContent =
@@ -575,7 +593,9 @@ const wireProjectSettings = (win) => {
     );
     value("storage").textContent = projectStorageText(state);
     value("lastChecked").textContent = formatUpdateCheckTime(state.lastChecked);
-    offlineStatus.textContent = offlineStatusText(state);
+    offlineStatus.textContent = state.enabled
+      ? offlineStatusText(state)
+      : "Offline access is disabled.";
     const activeGameTitle = state.activeGameId
       ? gamesList[state.activeGameId]?.title ||
         formatGameTitle(state.activeGameId)
@@ -589,18 +609,23 @@ const wireProjectSettings = (win) => {
           : state.downloadedGameIds.length
             ? "Selected built-in games are available offline."
             : "No built-in games are available offline.";
-    updateStatus.textContent =
-      state.phase === "checking"
-        ? "Checking for updates..."
-        : state.phase === "update-pending"
-          ? `Automatic update is scheduled for ${formatUpdateCheckTime(state.updateEligibleAt)}. The system files will download at that time. Select Update Now to install it immediately.`
-          : state.updateReady
-            ? `Astro Flash ${state.availableVersion || "update"} is ready to apply.`
-            : state.availableVersion
-              ? `Astro Flash ${state.availableVersion} is available.`
-              : state.lastChecked
-                ? "Astro Flash is up to date."
-                : "Updates have not been checked yet.";
+    updateStatus.textContent = !state.enabled
+      ? "Enable offline access to use offline updates."
+      : !state.automaticUpdatesEnabled
+        ? state.availableVersion
+          ? `Astro Flash ${state.availableVersion} is available.`
+          : "Automatic updates are disabled. Use Check for Updates or Update Now when you want to update the offline copy."
+        : state.phase === "checking"
+          ? "Checking for updates..."
+          : state.phase === "update-pending"
+            ? `Automatic update is scheduled for ${formatUpdateCheckTime(state.updateEligibleAt)}. The system files will download at that time. Select Update Now to install it immediately.`
+            : state.updateReady
+              ? `Astro Flash ${state.availableVersion || "update"} is ready to apply.`
+              : state.availableVersion
+                ? `Astro Flash ${state.availableVersion} is available.`
+                : state.lastChecked
+                  ? "Astro Flash is up to date."
+                  : "Updates have not been checked yet.";
     if (state.error) {
       updateStatus.textContent = state.error;
     }
@@ -617,10 +642,22 @@ const wireProjectSettings = (win) => {
     } else {
       gameDownloadProgress.removeAttribute("value");
     }
-    checkButton.disabled = !state.online || transientPhases.has(state.phase);
+    offlineEnabledCheckbox.checked = state.enabled;
+    savePlayedGamesCheckbox.checked = state.savePlayedGamesOffline;
+    automaticUpdatesCheckbox.checked = state.automaticUpdatesEnabled;
+    offlineEnabledCheckbox.disabled = transientPhases.has(state.phase);
+    savePlayedGamesCheckbox.disabled =
+      !state.enabled || transientPhases.has(state.phase);
+    automaticUpdatesCheckbox.disabled =
+      !state.enabled || transientPhases.has(state.phase);
+    checkButton.disabled =
+      !state.enabled || !state.online || transientPhases.has(state.phase);
     updateNowButton.disabled =
-      !state.online || transientPhases.has(state.phase);
-    updateDelayInput.disabled = transientPhases.has(state.phase);
+      !state.enabled || !state.online || transientPhases.has(state.phase);
+    updateDelayInput.disabled =
+      !state.enabled ||
+      !state.automaticUpdatesEnabled ||
+      transientPhases.has(state.phase);
     const automaticUpdateDelay =
       state.automaticUpdateDelayMs ??
       state.releaseUpdateDelayMs ??
@@ -632,15 +669,17 @@ const wireProjectSettings = (win) => {
       ),
     );
     updateDelayOutput.value = formatAutomaticUpdateDelay(automaticUpdateDelay);
-    repairButton.disabled = !state.online || transientPhases.has(state.phase);
+    repairButton.disabled =
+      !state.enabled || !state.online || transientPhases.has(state.phase);
     const gameBusy = ["downloading", "removing"].includes(state.gamePhase);
     downloadAllGamesButton.disabled =
       !state.online ||
+      !state.enabled ||
       gameBusy ||
       !state.bundledGames.length ||
       state.downloadedGameIds.length === state.bundledGames.length;
     removeAllGamesButton.disabled =
-      gameBusy || state.downloadedGameIds.length === 0;
+      !state.enabled || gameBusy || state.downloadedGameIds.length === 0;
     renderOfflineGameList(state);
   };
   const unsubscribe = offlineManager.subscribe(render);
@@ -674,6 +713,30 @@ const wireProjectSettings = (win) => {
   updateNowButton.addEventListener("click", () => {
     offlineManager.updateNow().catch(() => {});
   });
+  offlineEnabledCheckbox.addEventListener("change", async () => {
+    if (!offlineEnabledCheckbox.checked) {
+      const accepted = await XPDialogs.confirm(
+        "Turn off offline access and remove downloaded system files and built-in game copies?\n\nPersonal files, saved games, preferences, and installed games will be preserved.",
+        "Turn Off Offline Access",
+        "question",
+      );
+      if (!accepted) {
+        offlineEnabledCheckbox.checked = true;
+        return;
+      }
+    }
+    offlineManager
+      .setOfflineEnabled(offlineEnabledCheckbox.checked)
+      .catch((error) => {
+        offlineStatus.textContent = error.message;
+      });
+  });
+  savePlayedGamesCheckbox.addEventListener("change", () => {
+    offlineManager.setSavePlayedGamesOffline(savePlayedGamesCheckbox.checked);
+  });
+  automaticUpdatesCheckbox.addEventListener("change", () => {
+    offlineManager.setAutomaticUpdatesEnabled(automaticUpdatesCheckbox.checked);
+  });
   updateDelayInput.addEventListener("input", () => {
     updateDelayOutput.value = formatAutomaticUpdateDelay(
       Number(updateDelayInput.value) * UPDATE_DELAY_HOUR,
@@ -682,9 +745,11 @@ const wireProjectSettings = (win) => {
   updateDelayInput.addEventListener("change", () => {
     const delay = Number(updateDelayInput.value) * UPDATE_DELAY_HOUR;
     offlineManager.setAutomaticUpdateDelay(delay);
-    offlineManager
-      .checkForUpdates({ applyAutomatically: true })
-      .catch(() => {});
+    if (offlineManager.getSnapshot().automaticUpdatesEnabled) {
+      offlineManager
+        .checkForUpdates({ applyAutomatically: true })
+        .catch(() => {});
+    }
   });
   repairButton.addEventListener("click", async () => {
     const accepted = await XPDialogs.confirm(

--- a/site/js/shell/system-tray.js
+++ b/site/js/shell/system-tray.js
@@ -137,17 +137,14 @@ let offlineManagerInitialized = false;
 
 const offlineStatusText = (state) => {
   const messages = {
-    starting: "Preparing Windows XP system files...",
-    downloading: "Downloading Windows XP system files...",
-    ready: "Windows XP system files are available offline.",
+    starting: "Preparing Astro Flash system files...",
+    downloading: "Downloading Astro Flash system files...",
+    ready: "Astro Flash system files are available offline.",
     checking: "Checking for updates...",
     updating: "Downloading the latest update...",
-    "update-available": state.enabled
-      ? "An update is downloading..."
-      : "An update is available.",
-    "update-pending": "A newer update is waiting for its stability delay.",
-    "update-ready":
-      "An update is ready and will install automatically on the next load.",
+    "update-available": "An update is available.",
+    "update-pending": "An automatic update is scheduled.",
+    "update-ready": "An update is ready to apply.",
     "repair-required":
       "The installed update is incomplete. Repair the system files.",
     applying: "Applying the update...",
@@ -217,8 +214,7 @@ const wireProjectSettings = (win) => {
   content.innerHTML = `
     <div class="project-settings-tabs" role="tablist" aria-label="Astro Flash Settings">
       <button type="button" role="tab" class="active" id="project-tab-general" aria-controls="project-panel-general" aria-selected="true">General</button>
-      <button type="button" role="tab" id="project-tab-offline" aria-controls="project-panel-offline" aria-selected="false" tabindex="-1">Offline</button>
-      <button type="button" role="tab" id="project-tab-game-data" aria-controls="project-panel-game-data" aria-selected="false" tabindex="-1">Game Data</button>
+      <button type="button" role="tab" id="project-tab-games" aria-controls="project-panel-games" aria-selected="false" tabindex="-1">Games</button>
       <button type="button" role="tab" id="project-tab-updates" aria-controls="project-panel-updates" aria-selected="false" tabindex="-1">Updates</button>
       <button type="button" role="tab" id="project-tab-recovery" aria-controls="project-panel-recovery" aria-selected="false" tabindex="-1">Recovery</button>
     </div>
@@ -231,81 +227,85 @@ const wireProjectSettings = (win) => {
         </div>
       </div>
       <fieldset>
-        <legend>Game library</legend>
+        <legend>Offline access</legend>
+        <p class="project-settings-description">Astro Flash saves its system files automatically so the desktop can start without an internet connection.</p>
         <dl class="dlg-props-table project-settings-details">
-          <dt>Included games:</dt><dd data-project-value="includedGames"></dd>
-          <dt>Downloaded games:</dt><dd data-project-value="downloadedGames"></dd>
+          <dt>Status:</dt><dd data-project-value="offlineFiles"></dd>
+          <dt>System files:</dt><dd data-project-value="downloadSize"></dd>
         </dl>
-        <button type="button" class="xp-btn" data-project-action="manage-games">Manage Games...</button>
       </fieldset>
       <fieldset>
         <legend>Storage</legend>
-        <p>Astro Flash Collection is using <strong data-project-value="storage"></strong> of browser storage.</p>
+        <p>Astro Flash uses <strong data-project-value="storage"></strong> of browser storage. This includes system files, games, and personal data.</p>
       </fieldset>
       <a class="project-suggestions-link" href="https://github.com/astrovm/flash/issues" target="_blank" rel="noopener noreferrer">Send suggestions or report a problem</a>
     </section>
-    <section class="project-settings-panel" id="project-panel-offline" role="tabpanel" aria-labelledby="project-tab-offline" hidden>
+    <section class="project-settings-panel" id="project-panel-games" role="tabpanel" aria-labelledby="project-tab-games" hidden>
       <fieldset>
-        <legend>Windows XP system files</legend>
-        <p class="project-settings-description">The desktop, settings, artwork, fonts, and sounds are saved automatically for offline use.</p>
-        <dl class="dlg-props-table project-settings-details">
-          <dt>System download:</dt><dd data-project-value="downloadSize"></dd>
-          <dt>Offline status:</dt><dd data-project-value="offlineFiles"></dd>
-        </dl>
-        <p class="project-settings-status" data-project-status="offline" aria-live="polite"></p>
-        <progress class="project-settings-progress" aria-label="Offline download progress" hidden></progress>
-        <div class="project-settings-actions">
-          <button type="button" class="xp-btn" data-project-action="repair">Repair System Files</button>
-        </div>
-      </fieldset>
-      <fieldset>
-        <legend>Included games</legend>
-        <p class="project-settings-description">Choose which of the ${bundledGameCount} included games should work offline. The shared Flash runtime is downloaded once when needed.</p>
-        <dl class="dlg-props-table project-settings-details">
-          <dt>Downloaded:</dt><dd data-project-value="offlineGames"></dd>
-          <dt>Game storage:</dt><dd data-project-value="offlineGameStorage"></dd>
-        </dl>
-        <div class="project-offline-game-list" data-project-offline-games role="group" aria-label="Included games available offline"></div>
-        <progress class="project-settings-progress" data-project-game-progress aria-label="Included game download progress" hidden></progress>
+        <legend>Built-in games for offline play</legend>
+        <p class="project-settings-description">Built-in games come with Astro Flash. Select the games that you want to use without an internet connection.</p>
+        <p><strong data-project-value="offlineGames"></strong> built-in games are available offline and use <strong data-project-value="offlineGameStorage"></strong>.</p>
+        <div class="project-offline-game-list" data-project-offline-games role="group" aria-label="Built-in games available offline"></div>
+        <progress class="project-settings-progress" data-project-game-progress aria-label="Built-in game download progress" hidden></progress>
         <p class="project-settings-status" data-project-status="offline-games" aria-live="polite"></p>
         <div class="project-settings-actions">
-          <button type="button" class="xp-btn" data-project-action="download-all-games">Download All Games</button>
-          <button type="button" class="xp-btn" data-project-action="remove-all-games">Remove Offline Games</button>
+          <button type="button" class="xp-btn" data-project-action="download-all-games">Make All Available Offline</button>
+          <button type="button" class="xp-btn" data-project-action="remove-all-games">Remove Offline Copies</button>
         </div>
       </fieldset>
-      <p class="project-settings-description">Games installed from Internet Games use separate storage and remain available after installation. Legacy games may fetch additional files the first time they are used.</p>
-    </section>
-    <section class="project-settings-panel" id="project-panel-game-data" role="tabpanel" aria-labelledby="project-tab-game-data" hidden>
       <fieldset>
-        <legend>Installed game data</legend>
-        <p class="project-settings-description">Remove games installed from Internet Games, reVCDOS game data, or saved Pink Panther CD images. Saved games are preserved.</p>
+        <legend>Installed games and game files</legend>
+        <p class="project-settings-description">These games and files were downloaded separately. Removing an item preserves its saved games.</p>
         <div class="project-game-data-list" data-project-game-data aria-live="polite"></div>
         <p class="project-settings-status" data-project-status="game-data" aria-live="polite"></p>
       </fieldset>
     </section>
     <section class="project-settings-panel" id="project-panel-updates" role="tabpanel" aria-labelledby="project-tab-updates" hidden>
       <fieldset>
-        <legend>Astro Flash updates</legend>
+        <legend>Automatic updates</legend>
+        <p class="project-settings-description">Astro Flash checks for updates automatically. It waits for the selected time before it downloads and applies a new release.</p>
+        <label class="project-update-delay">Wait before automatic update:
+          <select data-project-setting="update-delay">
+            <option value="">Use release default</option>
+            <option value="0">Do not wait</option>
+            <option value="3600000">1 hour</option>
+            <option value="21600000">6 hours</option>
+            <option value="43200000">12 hours</option>
+            <option value="86400000">1 day</option>
+            <option value="259200000">3 days</option>
+          </select>
+        </label>
+      </fieldset>
+      <fieldset>
+        <legend>Update status</legend>
         <dl class="dlg-props-table project-settings-details">
-          <dt>Installed version:</dt><dd data-project-value="version"></dd>
-          <dt>Available version:</dt><dd data-project-value="availableVersion"></dd>
+          <dt>Installed:</dt><dd data-project-value="version"></dd>
+          <dt>Available:</dt><dd data-project-value="availableVersion"></dd>
           <dt>Last checked:</dt><dd data-project-value="lastChecked"></dd>
         </dl>
         <p class="project-settings-status" data-project-status="updates" aria-live="polite"></p>
+        <progress class="project-settings-progress" data-project-update-progress aria-label="System file download progress" hidden></progress>
         <div class="project-settings-actions">
+          <button type="button" class="xp-btn" data-project-action="update-now">Update Now</button>
           <button type="button" class="xp-btn" data-project-action="check">Check for Updates</button>
         </div>
       </fieldset>
     </section>
     <section class="project-settings-panel" id="project-panel-recovery" role="tabpanel" aria-labelledby="project-tab-recovery" hidden>
       <fieldset class="project-recovery-group">
+        <legend>Repair system files</legend>
+        <p>Download a clean copy of the Astro Flash system files. Built-in games and personal data are preserved.</p>
+        <p class="project-settings-status" data-project-status="offline" aria-live="polite"></p>
+        <button type="button" class="xp-btn" data-project-action="repair">Repair System Files</button>
+      </fieldset>
+      <fieldset class="project-recovery-group">
         <legend>Restore the desktop</legend>
-        <p>Restore all game shortcuts and their default positions. Personal files, downloaded games, and preferences are preserved.</p>
+        <p>Restore all game shortcuts and their default positions. Personal files, installed games, offline copies, and preferences are preserved.</p>
         <button type="button" class="xp-btn" data-project-action="restore-desktop">Restore Default Desktop</button>
       </fieldset>
       <fieldset class="project-recovery-group project-recovery-danger">
         <legend>Reset Astro Flash</legend>
-        <p>Permanently delete personal files and reset all preferences. Downloaded games and offline files are preserved.</p>
+        <p>Permanently delete personal files and reset all preferences. Installed games and offline copies are preserved.</p>
         <button type="button" class="xp-btn" data-project-action="reset">Reset Astro Flash</button>
       </fieldset>
     </section>
@@ -329,11 +329,19 @@ const wireProjectSettings = (win) => {
   const gameDataStatus = content.querySelector(
     '[data-project-status="game-data"]',
   );
-  const downloadProgress = content.querySelector(".project-settings-progress");
+  const downloadProgress = content.querySelector(
+    "[data-project-update-progress]",
+  );
   const gameDownloadProgress = content.querySelector(
     "[data-project-game-progress]",
   );
   const checkButton = content.querySelector('[data-project-action="check"]');
+  const updateNowButton = content.querySelector(
+    '[data-project-action="update-now"]',
+  );
+  const updateDelaySelect = content.querySelector(
+    '[data-project-setting="update-delay"]',
+  );
   const repairButton = content.querySelector('[data-project-action="repair"]');
   const downloadAllGamesButton = content.querySelector(
     '[data-project-action="download-all-games"]',
@@ -359,7 +367,7 @@ const wireProjectSettings = (win) => {
       panel.hidden = !active;
       panel.classList.toggle("active", active);
     });
-    if (panelId === "project-panel-game-data") void renderGameData();
+    if (panelId === "project-panel-games") void renderGameData();
   };
   tabs.forEach((tab, index) => {
     tab.addEventListener("click", () => showTab(tab));
@@ -403,7 +411,7 @@ const wireProjectSettings = (win) => {
       const items = [
         ...internetGames.map((item) => ({
           ...item,
-          detail: "Internet Game",
+          detail: "Installed game",
           removeId: item.id,
           owner: "internet",
         })),
@@ -417,7 +425,7 @@ const wireProjectSettings = (win) => {
       if (!items.length) {
         const empty = document.createElement("p");
         empty.className = "project-settings-description";
-        empty.textContent = "No downloaded or stored game data was found.";
+        empty.textContent = "No installed games or separate game files found.";
         gameDataList.appendChild(empty);
       }
       items.forEach((item) => {
@@ -491,7 +499,7 @@ const wireProjectSettings = (win) => {
     if (!state.bundledGames.length) {
       const empty = document.createElement("p");
       empty.className = "project-settings-description";
-      empty.textContent = "Loading the included-game catalog...";
+      empty.textContent = "Loading the built-in game list...";
       offlineGamesList.appendChild(empty);
       return;
     }
@@ -537,8 +545,6 @@ const wireProjectSettings = (win) => {
       : state.lastChecked
         ? "Up to date"
         : "Not checked";
-    value("includedGames").textContent = String(bundledGameCount);
-    value("downloadedGames").textContent = String(installedGameIds.size);
     value("downloadSize").textContent =
       state.downloadBytes === null
         ? state.downloadMetadataError
@@ -563,7 +569,7 @@ const wireProjectSettings = (win) => {
     const activeGameTitle = state.activeGameId
       ? gamesList[state.activeGameId]?.title ||
         formatGameTitle(state.activeGameId)
-      : "included games";
+      : "built-in games";
     offlineGamesStatus.textContent = state.gameError
       ? state.gameError
       : state.gamePhase === "downloading"
@@ -571,19 +577,19 @@ const wireProjectSettings = (win) => {
         : state.gamePhase === "removing"
           ? "Removing offline game files..."
           : state.downloadedGameIds.length
-            ? "Selected games are ready for offline use."
-            : "No included games are downloaded for offline use.";
+            ? "Selected built-in games are available offline."
+            : "No built-in games are available offline.";
     updateStatus.textContent =
       state.phase === "checking"
         ? "Checking for updates..."
         : state.phase === "update-pending"
-          ? `Astro Flash Collection ${state.availableVersion} will become eligible after ${formatUpdateCheckTime(state.updateEligibleAt)} if no newer update is released.`
+          ? `Automatic update is scheduled for ${formatUpdateCheckTime(state.updateEligibleAt)}. The system files will download at that time. Select Update Now to install it immediately.`
           : state.updateReady
-            ? `Astro Flash Collection ${state.availableVersion || "update"} will install automatically the next time you load it.`
+            ? `Astro Flash ${state.availableVersion || "update"} is ready to apply.`
             : state.availableVersion
-              ? `Astro Flash Collection ${state.availableVersion} is available.`
+              ? `Astro Flash ${state.availableVersion} is available.`
               : state.lastChecked
-                ? "Astro Flash Collection is up to date."
+                ? "Astro Flash is up to date."
                 : "Updates have not been checked yet.";
     if (state.error) {
       updateStatus.textContent = state.error;
@@ -602,6 +608,13 @@ const wireProjectSettings = (win) => {
       gameDownloadProgress.removeAttribute("value");
     }
     checkButton.disabled = !state.online || transientPhases.has(state.phase);
+    updateNowButton.disabled =
+      !state.online || transientPhases.has(state.phase);
+    updateDelaySelect.disabled = transientPhases.has(state.phase);
+    updateDelaySelect.value =
+      state.automaticUpdateDelayMs === null
+        ? ""
+        : String(state.automaticUpdateDelayMs);
     repairButton.disabled = !state.online || transientPhases.has(state.phase);
     const gameBusy = ["downloading", "removing"].includes(state.gamePhase);
     downloadAllGamesButton.disabled =
@@ -641,6 +654,18 @@ const wireProjectSettings = (win) => {
   checkButton.addEventListener("click", () => {
     offlineManager.checkForUpdates().catch(() => {});
   });
+  updateNowButton.addEventListener("click", () => {
+    offlineManager.updateNow().catch(() => {});
+  });
+  updateDelaySelect.addEventListener("change", () => {
+    const delay = updateDelaySelect.value
+      ? Number(updateDelaySelect.value)
+      : null;
+    offlineManager.setAutomaticUpdateDelay(delay);
+    offlineManager
+      .checkForUpdates({ applyAutomatically: true })
+      .catch(() => {});
+  });
   repairButton.addEventListener("click", async () => {
     const accepted = await XPDialogs.confirm(
       "Clear and download the Windows XP system files again?",
@@ -659,7 +684,7 @@ const wireProjectSettings = (win) => {
   });
   removeAllGamesButton.addEventListener("click", async () => {
     const accepted = await XPDialogs.confirm(
-      "Remove the offline copies of all included games? Internet Games installations will be preserved.",
+      "Remove the offline copies of all built-in games? Installed games will be preserved.",
       "Remove Offline Games",
       "question",
     );
@@ -668,15 +693,6 @@ const wireProjectSettings = (win) => {
       offlineGamesStatus.textContent = error.message;
     });
   });
-  content
-    .querySelector('[data-project-action="manage-games"]')
-    .addEventListener("click", () => {
-      openSystemWindow("__internet-games");
-      openWindows
-        .get("__internet-games")
-        ?.el.querySelector('[data-internet-tab="installed"]')
-        ?.click();
-    });
   restoreDesktopButton.addEventListener("click", async () => {
     const accepted = await XPDialogs.confirm(
       "Restore all game shortcuts and the default desktop layout?\n\nYour personal files and other settings will be preserved.",

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -608,7 +608,7 @@ describe("Workbox and artifact validation", () => {
       'self.__ASTRO_FLASH_VERSION__="26.07.28-abcdef1"',
     );
     expect(await readFile(join(root, "sw.26.07.28-abcdef1.js"), "utf8")).toBe(
-      await readFile(join(root, "sw.js"), "utf8"),
+      `${await readFile(join(root, "sw.js"), "utf8")}\nself.__ASTRO_FLASH_IMMUTABLE_WORKER__=true;\n`,
     );
   });
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -607,6 +607,9 @@ describe("Workbox and artifact validation", () => {
     expect(await readFile(join(root, "sw.js"), "utf8")).toContain(
       'self.__ASTRO_FLASH_VERSION__="26.07.28-abcdef1"',
     );
+    expect(await readFile(join(root, "sw.26.07.28-abcdef1.js"), "utf8")).toBe(
+      await readFile(join(root, "sw.js"), "utf8"),
+    );
   });
 
   test("removes an unused external Workbox runtime", async () => {
@@ -691,6 +694,9 @@ describe("atomic build", () => {
     }
     expect(await Bun.file(join(output, "stale.txt")).exists()).toBeFalse();
     expect(await Bun.file(join(output, "sw.js")).exists()).toBeTrue();
+    expect(
+      await Bun.file(join(output, "sw.26.07.28-abcdef1.js")).exists(),
+    ).toBeTrue();
     const release = join(output, "releases", "26.07.28-abcdef1");
     expect(
       await Bun.file(join(output, "apps", "core", "boxedwine.js")).exists(),

--- a/tests/helpers/shell-harness.ts
+++ b/tests/helpers/shell-harness.ts
@@ -34,7 +34,10 @@ const activeWindows = new Set<Window>();
 export const flushShell = () =>
   new Promise((resolve) => setTimeout(resolve, 0));
 
-export async function loadShell({ gameLibraryManager } = {}) {
+export async function loadShell({
+  gameLibraryManager,
+  offlineSettings = {},
+} = {}) {
   const window = new Window({
     url: "http://127.0.0.1/",
     width: 1024,
@@ -198,19 +201,45 @@ export async function loadShell({ gameLibraryManager } = {}) {
     gameLibraryManager || emptyLibrary;
 
   const offlineSnapshot = {
+    activeGameId: null,
+    automaticUpdateDelayMs: null,
+    availableVersion: null,
     bundledGames: [
       { id: "freecell" },
       { id: "solitaire" },
       { id: "spider-solitaire" },
     ],
     downloadedGameIds: [],
-    phase: "idle",
+    downloadedGameBytes: 0,
+    downloadBytes: 8_000_000,
+    downloadMetadataError: false,
+    enabled: true,
+    gameError: null,
+    gamePhase: "idle",
+    gameProgressLoaded: 0,
+    gameProgressTotal: 0,
+    lastChecked: null,
+    online: true,
+    releaseUpdateDelayMs: 6 * 60 * 60 * 1000,
+    savePlayedGamesOffline: true,
+    automaticUpdatesEnabled: true,
+    phase: "ready",
+    updateEligibleAt: null,
     updateAvailable: false,
+    updateReady: false,
+    usage: 0,
+    workerState: "active",
+    ...offlineSettings,
   };
   const offlineDownloads: string[] = [];
+  const offlineListeners = new Set();
+  const notifyOfflineListeners = () =>
+    offlineListeners.forEach((listener) => listener({ ...offlineSnapshot }));
   window.AstroOffline.createManager = () => ({
-    subscribe() {
-      return () => {};
+    subscribe(listener) {
+      offlineListeners.add(listener);
+      listener({ ...offlineSnapshot });
+      return () => offlineListeners.delete(listener);
     },
     async initialize() {},
     getSnapshot() {
@@ -219,7 +248,23 @@ export async function loadShell({ gameLibraryManager } = {}) {
     async downloadGame(gameId) {
       offlineDownloads.push(gameId);
       offlineSnapshot.downloadedGameIds.push(gameId);
+      notifyOfflineListeners();
     },
+    async setOfflineEnabled(enabled) {
+      offlineSnapshot.enabled = enabled;
+      notifyOfflineListeners();
+    },
+    setSavePlayedGamesOffline(enabled) {
+      offlineSnapshot.savePlayedGamesOffline = enabled;
+      notifyOfflineListeners();
+    },
+    setAutomaticUpdatesEnabled(enabled) {
+      offlineSnapshot.automaticUpdatesEnabled = enabled;
+      notifyOfflineListeners();
+    },
+    setAutomaticUpdateDelay() {},
+    async checkForUpdates() {},
+    async updateNow() {},
   });
 
   // Happy DOM evaluates separately injected classic scripts in isolated lexical

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -315,12 +315,111 @@ test("offline updates", async () => {
     environment: initial.environment,
   });
   await manager.initialize();
+  assert.strictEqual(manager.getSnapshot().enabled, true);
+  assert.strictEqual(manager.getSnapshot().savePlayedGamesOffline, true);
+  assert.strictEqual(manager.getSnapshot().automaticUpdatesEnabled, true);
   assert.deepStrictEqual(initial.serviceWorker.registerCalls[0], [
     `/sw.${manifest.version}.js`,
     { scope: "/", updateViaCache: "none" },
   ]);
   assert.strictEqual(manager.getSnapshot().phase, "ready");
   assert.strictEqual(manager.getSnapshot().bundledGames.length, 4);
+
+  const disabled = makeEnvironment({
+    storageValues: {
+      astroFlashOfflineEnabled: "false",
+      astroFlashOfflineGameRecords: JSON.stringify({
+        "synthetic-game": {
+          bytes: 4,
+          files: ["swf/synthetic-game/main.swf"],
+          revision: "synthetic-1",
+          type: "swf",
+        },
+      }),
+      syntheticPersonalPreference: "preserve-me",
+    },
+  });
+  const disabledManager = createManager({
+    currentVersion: manifest.version,
+    environment: disabled.environment,
+  });
+  await disabledManager.initialize();
+  assert.strictEqual(disabledManager.getSnapshot().enabled, false);
+  assert.strictEqual(disabledManager.getSnapshot().phase, "disabled");
+  assert.strictEqual(disabled.registration.unregisterCalls, 1);
+  assert.strictEqual(disabled.serviceWorker.registerCalls.length, 0);
+  await assert.rejects(
+    disabledManager.downloadGame("bike-mania"),
+    /Enable offline access/,
+  );
+  assert.strictEqual(
+    disabled.fetches.some(({ url }) => String(url).startsWith("/version.json")),
+    false,
+  );
+  assert(disabled.deletedCaches.includes("astro-flash-precache"));
+  assert(disabled.deletedCaches.includes(BUNDLED_GAME_CACHE));
+  assert.deepStrictEqual(
+    JSON.parse(disabled.storage.getItem("astroFlashOfflineGameRecords")),
+    {},
+  );
+  assert.strictEqual(
+    disabled.storage.getItem("syntheticPersonalPreference"),
+    "preserve-me",
+  );
+
+  await disabledManager.setOfflineEnabled(true);
+  assert.strictEqual(disabledManager.getSnapshot().enabled, true);
+  assert.strictEqual(disabledManager.getSnapshot().phase, "ready");
+  assert.strictEqual(disabled.serviceWorker.registerCalls.length, 1);
+  disabledManager.setSavePlayedGamesOffline(false);
+  assert.strictEqual(
+    disabled.storage.getItem("astroFlashSavePlayedGamesOffline"),
+    "false",
+  );
+  disabledManager.setAutomaticUpdatesEnabled(false);
+  const versionFetchesBeforeVisibility = disabled.fetches.filter(({ url }) =>
+    String(url).startsWith("/version.json"),
+  ).length;
+  disabled.setNow(now + 2 * 60 * 60 * 1000);
+  disabled.environment.document.dispatch("visibilitychange");
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.strictEqual(
+    disabled.fetches.filter(({ url }) =>
+      String(url).startsWith("/version.json"),
+    ).length,
+    versionFetchesBeforeVisibility,
+  );
+  await disabledManager.checkForUpdates();
+  assert.strictEqual(
+    disabled.fetches.filter(({ url }) =>
+      String(url).startsWith("/version.json"),
+    ).length,
+    versionFetchesBeforeVisibility + 1,
+  );
+
+  const manualUpdates = makeEnvironment({
+    storageValues: { astroFlashAutomaticUpdatesEnabled: "false" },
+  });
+  const manualUpdatesManager = createManager({
+    currentVersion: manifest.version,
+    environment: manualUpdates.environment,
+  });
+  await manualUpdatesManager.initialize();
+  assert.strictEqual(
+    manualUpdates.fetches.some(({ url }) =>
+      String(url).startsWith("/version.json"),
+    ),
+    false,
+  );
+  manualUpdates.setRemote({ version: "26.07.30-manual11" });
+  manualUpdates.registration.waiting = new Worker(
+    "installed",
+    "26.07.30-manual11",
+  );
+  await manualUpdatesManager.updateNow();
+  assert.deepStrictEqual(manualUpdates.registration.waiting.messages, [
+    { type: "SKIP_WAITING" },
+  ]);
 
   const legacyActiveWorker = new Worker(
     "activated",

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -32,10 +32,11 @@ test("offline updates", async () => {
   }
 
   class Worker extends Events {
-    constructor(state = "activated", version = null) {
+    constructor(state = "activated", version = null, scriptURL = null) {
       super();
       this.state = state;
       this.version = version;
+      this.scriptURL = scriptURL;
       this.messages = [];
     }
     transition(state) {
@@ -315,11 +316,42 @@ test("offline updates", async () => {
   });
   await manager.initialize();
   assert.deepStrictEqual(initial.serviceWorker.registerCalls[0], [
-    `/sw.js?v=${manifest.version}`,
+    `/sw.${manifest.version}.js`,
     { scope: "/", updateViaCache: "none" },
   ]);
   assert.strictEqual(manager.getSnapshot().phase, "ready");
   assert.strictEqual(manager.getSnapshot().bundledGames.length, 4);
+
+  const legacyActiveWorker = new Worker(
+    "activated",
+    manifest.version,
+    `/sw.js?v=${manifest.version}`,
+  );
+  const migrationRegistration = new Registration({
+    active: legacyActiveWorker,
+  });
+  const migration = makeEnvironment({
+    registration: migrationRegistration,
+    remoteVersion: manifest.version,
+  });
+  const migrationWaitingWorker = new Worker("installed", manifest.version);
+  migration.serviceWorker.register = async (...args) => {
+    migration.serviceWorker.registerCalls.push(args);
+    migrationRegistration.waiting = migrationWaitingWorker;
+    return migrationRegistration;
+  };
+  const migrationManager = createManager({
+    currentVersion: manifest.version,
+    environment: migration.environment,
+  });
+  await migrationManager.initialize();
+  assert.strictEqual(
+    migration.serviceWorker.registerCalls[0][0],
+    `/sw.${manifest.version}.js`,
+  );
+  assert.deepStrictEqual(migrationWaitingWorker.messages, [
+    { type: "SKIP_WAITING" },
+  ]);
 
   await manager.downloadGame("bike-mania");
   assert.strictEqual(
@@ -578,7 +610,7 @@ test("offline updates", async () => {
   await new Promise((resolve) => setImmediate(resolve));
   assert.match(
     staleWaiting.serviceWorker.registerCalls.at(-1)[0],
-    /^\/sw\.js\?v=26\.07\.30-bbbbbbb&retry=1800000000000$/,
+    /^\/sw\.26\.07\.30-bbbbbbb\.js\?retry=1800000000000$/,
   );
   assert.strictEqual(staleWaitingManager.getSnapshot().updateReady, true);
   assert.deepStrictEqual(staleWaitingRegistration.waiting.messages, [
@@ -620,6 +652,57 @@ test("offline updates", async () => {
   ]);
   delayed.serviceWorker.dispatch("controllerchange");
   assert.strictEqual(delayed.getReloads(), 1);
+
+  const configurableReleaseTime = now - 7 * 60 * 60 * 1000;
+  const configurableRegistration = new Registration({
+    active: new Worker("activated", manifest.version),
+  });
+  const configurable = makeEnvironment({
+    registration: configurableRegistration,
+    remoteVersion: "26.07.30-config123",
+    remoteReleasedAt: new Date(configurableReleaseTime).toISOString(),
+    storageValues: {
+      astroFlashAutomaticUpdateDelay: String(12 * 60 * 60 * 1000),
+    },
+  });
+  const configurableManager = createManager({
+    currentVersion: manifest.version,
+    environment: configurable.environment,
+  });
+  await configurableManager.initialize();
+  assert.strictEqual(
+    configurableManager.getSnapshot().automaticUpdateDelayMs,
+    12 * 60 * 60 * 1000,
+  );
+  assert.strictEqual(configurableManager.getSnapshot().phase, "update-pending");
+  assert.strictEqual(configurable.serviceWorker.registerCalls.length, 0);
+  await configurableManager.checkForUpdates();
+  assert.strictEqual(configurable.serviceWorker.registerCalls.length, 0);
+
+  const configurableWaitingWorker = new Worker(
+    "installed",
+    "26.07.30-config123",
+  );
+  configurableRegistration.waiting = configurableWaitingWorker;
+  await configurableManager.updateNow();
+  assert.strictEqual(
+    configurable.serviceWorker.registerCalls.at(-1)[0],
+    "/sw.26.07.30-config123.js",
+  );
+  assert.deepStrictEqual(configurableWaitingWorker.messages, [
+    { type: "SKIP_WAITING" },
+  ]);
+
+  configurableManager.setAutomaticUpdateDelay(0);
+  assert.strictEqual(
+    configurable.storage.getItem("astroFlashAutomaticUpdateDelay"),
+    "0",
+  );
+  configurableManager.setAutomaticUpdateDelay(null);
+  assert.strictEqual(
+    configurable.storage.getItem("astroFlashAutomaticUpdateDelay"),
+    null,
+  );
 
   const activatedUpdate = makeEnvironment({
     registration: new Registration({

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -452,6 +452,42 @@ test("offline updates", async () => {
     { type: "SKIP_WAITING" },
   ]);
 
+  const manualMigrationRegistration = new Registration({
+    active: new Worker(
+      "activated",
+      manifest.version,
+      `/sw.js?v=${manifest.version}`,
+    ),
+  });
+  const manualMigration = makeEnvironment({
+    registration: manualMigrationRegistration,
+    storageValues: { astroFlashAutomaticUpdatesEnabled: "false" },
+  });
+  const manualMigrationWorker = new Worker("installed", manifest.version);
+  manualMigration.serviceWorker.register = async (...args) => {
+    manualMigration.serviceWorker.registerCalls.push(args);
+    manualMigrationRegistration.waiting = manualMigrationWorker;
+    return manualMigrationRegistration;
+  };
+  const manualMigrationManager = createManager({
+    currentVersion: manifest.version,
+    environment: manualMigration.environment,
+  });
+  await manualMigrationManager.initialize();
+  assert.strictEqual(
+    manualMigration.serviceWorker.registerCalls[0][0],
+    `/sw.${manifest.version}.js`,
+  );
+  assert.deepStrictEqual(manualMigrationWorker.messages, [
+    { type: "SKIP_WAITING" },
+  ]);
+  assert.strictEqual(
+    manualMigration.fetches.some(({ url }) =>
+      String(url).startsWith("/version.json"),
+    ),
+    false,
+  );
+
   await manager.downloadGame("bike-mania");
   assert.strictEqual(
     initial.fetches.find(({ url }) =>
@@ -504,6 +540,60 @@ test("offline updates", async () => {
   await manager.removeAllGames();
   assert.deepStrictEqual(manager.getSnapshot().downloadedGameIds, []);
   assert(initial.deletedCaches.includes(BUNDLED_GAME_CACHE));
+
+  const interrupted = makeEnvironment();
+  const interruptedManager = createManager({
+    currentVersion: manifest.version,
+    environment: interrupted.environment,
+  });
+  await interruptedManager.initialize();
+  const originalInterruptedPut = interrupted.bundledCache.put.bind(
+    interrupted.bundledCache,
+  );
+  let releaseInterruptedPut;
+  let markInterruptedPutStarted;
+  const interruptedPutStarted = new Promise((resolve) => {
+    markInterruptedPutStarted = resolve;
+  });
+  const interruptedPutRelease = new Promise((resolve) => {
+    releaseInterruptedPut = resolve;
+  });
+  interrupted.bundledCache.put = async (...arguments_) => {
+    markInterruptedPutStarted();
+    await interruptedPutRelease;
+    return originalInterruptedPut(...arguments_);
+  };
+  const interruptedDownload = interruptedManager.downloadGame("doom");
+  await interruptedPutStarted;
+  await interruptedManager.setOfflineEnabled(false);
+  releaseInterruptedPut();
+  await assert.rejects(interruptedDownload, /Offline access was disabled/);
+  assert.strictEqual(interruptedManager.getSnapshot().phase, "disabled");
+  assert.strictEqual(interruptedManager.getSnapshot().gamePhase, "idle");
+  assert.strictEqual(interrupted.bundledCache.values.size, 0);
+  assert.deepStrictEqual(
+    JSON.parse(
+      interrupted.storage.getItem("astroFlashOfflineGameRecords") || "{}",
+    ),
+    {},
+  );
+
+  const repaired = makeEnvironment({
+    storageValues: { astroFlashAutomaticUpdatesEnabled: "false" },
+  });
+  const repairedManager = createManager({
+    currentVersion: manifest.version,
+    environment: repaired.environment,
+  });
+  await repairedManager.initialize();
+  repaired.setRemote({ version: "26.07.30-repair111" });
+  repaired.registration.waiting = new Worker("installed", "26.07.30-repair111");
+  await repairedManager.repair();
+  assert.strictEqual(repaired.registration.unregisterCalls, 1);
+  assert(repaired.deletedCaches.includes("astro-flash-precache"));
+  assert.deepStrictEqual(repaired.registration.waiting.messages, [
+    { type: "SKIP_WAITING" },
+  ]);
 
   const lowEstimate = makeEnvironment();
   lowEstimate.environment.navigator.storage = {

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -679,6 +679,25 @@ test("offline updates", async () => {
   await configurableManager.checkForUpdates();
   assert.strictEqual(configurable.serviceWorker.registerCalls.length, 0);
 
+  const scheduledUpdate = configurable.timers.find(
+    ({ delay }) => delay === 5 * 60 * 60 * 1000,
+  );
+  assert.ok(scheduledUpdate);
+  configurable.setNow(now + 5 * 60 * 60 * 1000);
+  configurableRegistration.waiting = new Worker(
+    "installed",
+    "26.07.30-config123",
+  );
+  scheduledUpdate.callback();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.strictEqual(
+    configurable.serviceWorker.registerCalls.at(-1)[0],
+    "/sw.26.07.30-config123.js",
+  );
+  assert.deepStrictEqual(configurableRegistration.waiting.messages, [
+    { type: "SKIP_WAITING" },
+  ]);
+
   const configurableWaitingWorker = new Worker(
     "installed",
     "26.07.30-config123",

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -133,9 +133,13 @@ test("desktop icons select and launch their actual destinations", async () => {
   ).toEqual(["General", "Games", "Updates", "Recovery"]);
   expect(settings.textContent).toContain("Built-in games for offline play");
   expect(settings.textContent).toContain("Installed games and game files");
-  expect(
-    settings.querySelector('[data-project-setting="update-delay"]'),
-  ).not.toBeNull();
+  const updateDelay = settings.querySelector<HTMLInputElement>(
+    '[data-project-setting="update-delay"]',
+  )!;
+  expect(updateDelay.type).toBe("range");
+  expect(updateDelay.min).toBe("0");
+  expect(updateDelay.max).toBe("72");
+  expect(settings.textContent).not.toContain("Use release default");
   expect(
     settings.querySelector('[data-project-action="update-now"]')?.textContent,
   ).toBe("Update Now");

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -243,6 +243,23 @@ test("offline-dependent settings are disabled when offline access is off", async
   }
 });
 
+test("offline access cannot be disabled during a game download", async () => {
+  const shell = await login(
+    await loadShell({
+      offlineSettings: { gamePhase: "downloading", activeGameId: "freecell" },
+    }),
+  );
+  const settingsIcon = shell.document.querySelector<HTMLButtonElement>(
+    '[data-desktop-id="__astro-settings"]',
+  )!;
+  settingsIcon.dispatchEvent(new shell.window.MouseEvent("dblclick"));
+  expect(
+    shell.document.querySelector<HTMLInputElement>(
+      '.xp-window[data-game="__astro-settings"] [data-project-setting="offline-enabled"]',
+    )?.disabled,
+  ).toBeTrue();
+});
+
 test("My Computer exposes the native desktop shell menu and opens Properties", async () => {
   const shell = await login(await loadShell());
   const icon = shell.document.querySelector<HTMLButtonElement>(

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -122,11 +122,23 @@ test("desktop icons select and launch their actual destinations", async () => {
   settingsIcon.click();
   expect(settingsIcon.classList.contains("selected")).toBeTrue();
   settingsIcon.dispatchEvent(new shell.window.MouseEvent("dblclick"));
+  const settings = shell.document.querySelector(
+    '.xp-window[data-game="__astro-settings"] .project-settings-content',
+  )!;
+  expect(settings).not.toBeNull();
   expect(
-    shell.document.querySelector(
-      '.xp-window[data-game="__astro-settings"] .project-settings-content',
+    [...settings.querySelectorAll<HTMLButtonElement>('[role="tab"]')].map(
+      (tab) => tab.textContent,
     ),
+  ).toEqual(["General", "Games", "Updates", "Recovery"]);
+  expect(settings.textContent).toContain("Built-in games for offline play");
+  expect(settings.textContent).toContain("Installed games and game files");
+  expect(
+    settings.querySelector('[data-project-setting="update-delay"]'),
   ).not.toBeNull();
+  expect(
+    settings.querySelector('[data-project-action="update-now"]')?.textContent,
+  ).toBe("Update Now");
 });
 
 test("desktop arrow keys move between icons by screen direction", async () => {

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -141,6 +141,21 @@ test("desktop icons select and launch their actual destinations", async () => {
   expect(updateDelay.max).toBe("72");
   expect(settings.textContent).not.toContain("Use release default");
   expect(
+    settings.querySelector<HTMLInputElement>(
+      '[data-project-setting="offline-enabled"]',
+    )?.checked,
+  ).toBeTrue();
+  expect(
+    settings.querySelector<HTMLInputElement>(
+      '[data-project-setting="save-played-games"]',
+    )?.checked,
+  ).toBeTrue();
+  expect(
+    settings.querySelector<HTMLInputElement>(
+      '[data-project-setting="automatic-updates"]',
+    )?.checked,
+  ).toBeTrue();
+  expect(
     settings.querySelector('[data-project-action="update-now"]')?.textContent,
   ).toBe("Update Now");
 });
@@ -196,6 +211,36 @@ test("desktop arrow keys move between icons by screen direction", async () => {
   press("ArrowUp");
   expect(shell.document.activeElement).toBe(icons[0]);
   expect(icons[0]!.classList.contains("selected")).toBeTrue();
+});
+
+test("offline-dependent settings are disabled when offline access is off", async () => {
+  const shell = await login(
+    await loadShell({ offlineSettings: { enabled: false, phase: "disabled" } }),
+  );
+  const settingsIcon = shell.document.querySelector<HTMLButtonElement>(
+    '[data-desktop-id="__astro-settings"]',
+  )!;
+  settingsIcon.dispatchEvent(new shell.window.MouseEvent("dblclick"));
+  const settings = shell.document.querySelector(
+    '.xp-window[data-game="__astro-settings"] .project-settings-content',
+  )!;
+  expect(
+    settings.querySelector<HTMLInputElement>(
+      '[data-project-setting="offline-enabled"]',
+    )?.checked,
+  ).toBeFalse();
+  for (const selector of [
+    '[data-project-setting="save-played-games"]',
+    '[data-project-setting="automatic-updates"]',
+    '[data-project-setting="update-delay"]',
+    '[data-project-action="check"]',
+    '[data-project-action="update-now"]',
+  ]) {
+    expect(
+      settings.querySelector<HTMLInputElement | HTMLButtonElement>(selector)
+        ?.disabled,
+    ).toBeTrue();
+  }
 });
 
 test("My Computer exposes the native desktop shell menu and opens Properties", async () => {
@@ -745,6 +790,16 @@ test("native games open from their public deep links", async () => {
       shell.document.querySelector(`.xp-window[data-game="${applicationId}"]`),
     ).not.toBeNull();
   }
+});
+
+test("played built-in games are not saved when automatic offline copies are disabled", async () => {
+  const shell = await loadShell({
+    offlineSettings: { savePlayedGamesOffline: false },
+  });
+  shell.window.location.hash = "#freecell";
+  await login(shell);
+  await flushShell();
+  expect(shell.offlineDownloads).toEqual([]);
 });
 
 test("bundled iframe deep links use the production release base URL", async () => {

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -204,6 +204,13 @@ function releaseRelativePath(version: string): string {
   return `${RELEASES_PATH}/${version}`;
 }
 
+function versionedServiceWorkerName(version: string): string {
+  if (!/^[a-zA-Z0-9._-]+$/.test(version)) {
+    throw new Error(`Invalid service worker version: ${version}`);
+  }
+  return `sw.${version}.js`;
+}
+
 export async function scopeReleaseReferences(
   root: string,
   version: string,
@@ -1044,6 +1051,12 @@ export async function generateServiceWorker(
     const name = path.split(sep).at(-1) ?? "";
     if (name.startsWith("workbox-")) await rm(path);
   }
+  if (version) {
+    await cp(
+      serviceWorker,
+      join(outputDir, versionedServiceWorkerName(version)),
+    );
+  }
   console.log("  - Service worker generated successfully");
 }
 
@@ -1385,6 +1398,7 @@ export async function validateReleaseOutput(
     "index.html",
     "releases",
     "sw.js",
+    versionedServiceWorkerName(version),
     "version.json",
   ]);
   const unexpectedRootEntries = (await readdir(outputDir)).filter(
@@ -1404,6 +1418,15 @@ export async function validateReleaseOutput(
     throw new Error("Build output has no matching immutable release base URL");
   }
   await validatePrecacheIntegrity(outputDir);
+  if (
+    (
+      await readFile(join(outputDir, versionedServiceWorkerName(version)))
+    ).toString() !== (await readFile(join(outputDir, "sw.js"))).toString()
+  ) {
+    throw new Error(
+      "Build output has an inconsistent versioned service worker",
+    );
+  }
   if (await isFile(join(releaseDir, "offline-games.json"))) {
     throw new Error("Build output contains an unversioned offline manifest");
   }

--- a/tools/deploy.ts
+++ b/tools/deploy.ts
@@ -53,6 +53,8 @@ export const PRECACHE_FILE_SUFFIXES = new Set(
   PRECACHE_EXTENSIONS.map((extension) => `.${extension}`),
 );
 const APP_VERSION_PATTERN = /const APP_VERSION = "[^"]+";/g;
+const VERSIONED_SERVICE_WORKER_MARKER =
+  "\nself.__ASTRO_FLASH_IMMUTABLE_WORKER__=true;\n";
 
 type WorkboxGenerator = typeof generateSW;
 
@@ -1052,9 +1054,9 @@ export async function generateServiceWorker(
     if (name.startsWith("workbox-")) await rm(path);
   }
   if (version) {
-    await cp(
-      serviceWorker,
+    await writeFile(
       join(outputDir, versionedServiceWorkerName(version)),
+      workerSource + VERSIONED_SERVICE_WORKER_MARKER,
     );
   }
   console.log("  - Service worker generated successfully");
@@ -1418,11 +1420,12 @@ export async function validateReleaseOutput(
     throw new Error("Build output has no matching immutable release base URL");
   }
   await validatePrecacheIntegrity(outputDir);
-  if (
-    (
-      await readFile(join(outputDir, versionedServiceWorkerName(version)))
-    ).toString() !== (await readFile(join(outputDir, "sw.js"))).toString()
-  ) {
+  const rootWorker = await readFile(join(outputDir, "sw.js"), "utf8");
+  const versionedWorker = await readFile(
+    join(outputDir, versionedServiceWorkerName(version)),
+    "utf8",
+  );
+  if (versionedWorker !== rootWorker + VERSIONED_SERVICE_WORKER_MARKER) {
     throw new Error(
       "Build output has an inconsistent versioned service worker",
     );


### PR DESCRIPTION
## Summary

- reorganize Astro Flash Settings into General, Games, Updates, and Recovery
- use consistent terms for built-in games, installed games, and offline copies
- add a persisted automatic-update delay setting
- add an Update Now action that bypasses the automatic delay
- keep update checks metadata-only until an update will be applied
- publish immutable versioned service-worker files to prevent early background downloads

## Why

The settings mixed different game counts and storage concepts. The update stability delay also controlled user-requested updates, while browser service-worker checks could download an automatic update before the delay expired.

## Impact

Automatic updates now download and apply together after the configured delay. Users can still install an update immediately with Update Now. Existing service workers migrate to immutable versioned worker URLs.

## Validation

- `bun test` — 137 tests passed
- `bun run typecheck`
- `bun run quality`
- `bun run build --revision HEAD`
- verified the root and versioned production workers are byte-identical