### PR TITLE
Fix Minesweeper board overflow

### DIFF
--- a/site/apps/minesweeper/index.js
+++ b/site/apps/minesweeper/index.js
@@ -157,7 +157,10 @@ const mountMinesweeper = (context, instance) => {
   const resizeWindow = () => {
     const owner = instance.window.el;
     const width = level.columns * 16 + 26;
-    const height = level.rows * 16 + 115;
+    // Board rows plus the menu, score panel, frame, content padding, title bar,
+    // and the shell's bottom frame. The old calculation counted only one side
+    // of the content padding, so the board extended six pixels below the shell.
+    const height = level.rows * 16 + 121;
     owner.style.width = `${width}px`;
     owner.style.height = `${height}px`;
     owner.style.minWidth = `${width}px`;

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -652,6 +652,19 @@ test("All Programs exposes system applications and games in the XP hierarchy", a
   expect(intermediateCells).toHaveLength(256);
   intermediateCells[128]!.click();
   expect(intermediateCells[128]!.dataset.open).toBe("true");
+  minesweeperWindow
+    .querySelector<HTMLButtonElement>(".minesweeper-menu-trigger")!
+    .click();
+  minesweeperWindow
+    .querySelector<HTMLButtonElement>('[data-command="expert"]')!
+    .click();
+  expect(
+    minesweeperWindow.querySelectorAll<HTMLButtonElement>(
+      ".xp-minesweeper-board [role='gridcell']",
+    ),
+  ).toHaveLength(480);
+  expect((minesweeperWindow as HTMLElement).style.width).toBe("506px");
+  expect((minesweeperWindow as HTMLElement).style.height).toBe("377px");
 
   shell.document.getElementById("start-button")!.click();
   shell.document.getElementById("all-programs-button")!.click();


### PR DESCRIPTION
## Summary
- include both sides of Minesweeper content padding in difficulty-driven shell sizing
- keep Expert mode board and content inside the XP window frame
- cover Expert mode dimensions and its 480-cell board through shell behavior

## Verification
- browser: Expert window 506x377; root client and scroll size 500x346; content contained inside bottom frame
- bun test: 154 passed
- bun run typecheck
- bun run validate:javascript
- bun run validate:icons
- bun run quality
- bun run build