### PR TITLE
Keep game volume scaled by system volume

### DIFF
--- a/site/js/shell/window-manager.js
+++ b/site/js/shell/window-manager.js
@@ -365,7 +365,7 @@ const setWindowVolume = (win, value) => {
   setGameVolume(win.gameId, numericValue, isMuted);
 
   if (win.gameId === focusedGameId) {
-    setPlayerVolume(win.player, win.type, isMuted ? 0 : numericValue / 100);
+    setPlayerVolume(win.player, win.type, normalizeGameVolume(win.gameId));
   }
   syncWindowVolumeUI(win);
 };
@@ -378,7 +378,7 @@ const toggleWindowMute = (win) => {
     const volume = gameSettings.volume || 100;
     setGameVolume(win.gameId, volume, false);
     if (win.gameId === focusedGameId) {
-      setPlayerVolume(win.player, win.type, volume / 100);
+      setPlayerVolume(win.player, win.type, normalizeGameVolume(win.gameId));
     }
   } else {
     // Muting - store current volume before setting to 0

--- a/tests/shell-behavior.test.ts
+++ b/tests/shell-behavior.test.ts
@@ -639,6 +639,58 @@ test("system tray volume controls persist volume and mute state", async () => {
   );
 });
 
+test("game volume changes remain scaled by the system volume", async () => {
+  const shell = await login(
+    await loadShell({ initialStorage: { volume: "40" } }),
+  );
+  shell.document.getElementById("start-button")!.click();
+  shell.document.getElementById("all-programs-button")!.click();
+  const flyouts = shell.document.getElementById("start-menu-flyouts")!;
+  flyouts
+    .querySelector<HTMLButtonElement>('[data-program-id="games"]')!
+    .click();
+  const adventure = [
+    ...flyouts.querySelectorAll<HTMLButtonElement>(".start-program-folder"),
+  ].find((button) => button.textContent?.trim().startsWith("Adventure"))!;
+  adventure.click();
+  const game = [
+    ...flyouts.querySelectorAll<HTMLButtonElement>(".sm-game"),
+  ].find((button) => button.textContent?.includes("Inside the Firewall"))!;
+  game.click();
+  await flushShell();
+
+  const gameWindow = shell.document.querySelector<HTMLElement>(
+    '.xp-window[data-game="inside-the-firewall"]',
+  )!;
+  const iframe = gameWindow.querySelector<HTMLIFrameElement>("iframe")!;
+  const appliedVolumes: number[] = [];
+  iframe.contentWindow!.postMessage = ((message: unknown) => {
+    if (
+      message &&
+      typeof message === "object" &&
+      "type" in message &&
+      message.type === "setVolume" &&
+      "volume" in message &&
+      typeof message.volume === "number"
+    ) {
+      appliedVolumes.push(message.volume);
+    }
+  }) as typeof iframe.contentWindow.postMessage;
+
+  const gameVolume = gameWindow.querySelector<HTMLInputElement>(
+    ".game-volume-slider",
+  )!;
+  gameVolume.value = "50";
+  gameVolume.dispatchEvent(new shell.window.Event("input", { bubbles: true }));
+  expect(appliedVolumes.at(-1)).toBe(0.2);
+
+  const mute = gameWindow.querySelector<HTMLButtonElement>(".volume-btn")!;
+  mute.click();
+  expect(appliedVolumes.at(-1)).toBe(0);
+  mute.click();
+  expect(appliedVolumes.at(-1)).toBe(0.2);
+});
+
 test("clock and network tray buttons open their corresponding dialogs", async () => {
   const shell = await login(await loadShell());
   shell.document.getElementById("taskbar-clock")!.click();


### PR DESCRIPTION
## Summary
- apply the system master-volume calculation after game slider changes
- preserve system-volume scaling when a game is unmuted
- add behavior coverage for both paths

## Testing
- bun test tests/shell-behavior.test.ts (28 passed)
- bun run typecheck
- bun run quality
- bun run validate:javascript